### PR TITLE
Fix CSG house demo

### DIFF
--- a/demos/csg-house/src/App.jsx
+++ b/demos/csg-house/src/App.jsx
@@ -41,7 +41,7 @@ function House(props) {
           <Door rotation={[0, Math.PI / 2, 0]} position={[-1.425, -0.45, 0]} scale={[1, 0.9, 1]} />
         </PivotControls>
       </Geometry>
-      <meshStandardMaterial envMapIntensity={0.25} />
+      <meshStandardMaterial />
     </mesh>
   )
 }

--- a/demos/csg-house/src/Environment.jsx
+++ b/demos/csg-house/src/Environment.jsx
@@ -7,9 +7,9 @@ export const Environment = memo(({ direction = [5, 5, 5] }) => (
     <directionalLight position={[-5, 5, 5]} intensity={0.1} shadow-mapSize={128} castShadow />
     <directionalLight position={[-5, 5, -5]} intensity={0.1} shadow-mapSize={128} castShadow />
     <directionalLight position={[0, 5, 0]} intensity={0.1} shadow-mapSize={128} castShadow />
-    <AccumulativeShadows frames={100} alphaTest={0.85} opacity={0.75} scale={30} position={[0, -1.5, 0]}>
-      <RandomizedLight amount={8} radius={2.5} ambient={0.5} intensity={1} position={direction} bias={0.001} />
+    <AccumulativeShadows frames={100} alphaTest={0.75} opacity={0.75} scale={30} position={[0, -1.5, 0]}>
+      <RandomizedLight amount={8} radius={2.5} ambient={0.5} intensity={Math.PI} position={direction} bias={0.001} />
     </AccumulativeShadows>
-    <EnvironmentImpl preset="city" />
+    <EnvironmentImpl preset="city" environmentIntensity={0.25} />
   </>
 ))


### PR DESCRIPTION
1. By default RandomizedLight has intensity of Math.PI for threejs r155 onwards as referenced by this commit.

https://github.com/pmndrs/drei/commit/8583b8e1791194c6a353bb6d5780c571956553af

2. Environment Intensity has been introduced in r163 as separate from material.envMapIntensity

https://github.com/mrdoob/three.js/pull/27903


- [x] ready for merge ?





