### PR TITLE
Fix basic ballpit demo

### DIFF
--- a/demos/basic-ballpit/src/App.jsx
+++ b/demos/basic-ballpit/src/App.jsx
@@ -32,7 +32,7 @@ function InstancedSpheres({ count = 200 }) {
     for (let i = 0; i < count; i++) api.at(i).scaleOverride([data[i].scale, data[i].scale, data[i].scale])
   }, [])
   return (
-    <instancedMesh ref={ref} args={[null, null, count]}>
+    <instancedMesh ref={ref} args={[null, null, count]} frustumCulled={false}>
       <sphereGeometry args={[1, 64, 64]}>
         <instancedBufferAttribute attach="attributes-color" args={[colorArray, 3]} />
       </sphereGeometry>


### PR DESCRIPTION
BoundingBox of instancedMesh is not updated by cannon so the mesh was always frustum culled since it always started outside the camera frustum. The choice was either to set 

`frustumCulling={false}` on the mesh

or do
```
useFrame(()=> {
  ref.current.computeBoundingSphere()
  ref.current.instanceMatrix.needsUpdate = true
})
```

I chose the simpler option

- [x] ready to merge