### PR TITLE
Fix zustand-site demo

### DIFF
--- a/demos/zustand-site/src/materials/layerMaterial.js
+++ b/demos/zustand-site/src/materials/layerMaterial.js
@@ -38,7 +38,7 @@ const LayerMaterial = shaderMaterial(
       if (color.a < 0.1) discard;
       gl_FragColor = vec4(color.rgb, .1);
       #include <tonemapping_fragment>
-      #include <encodings_fragment>
+      #include <colorspace_fragment>
     }`,
 )
 


### PR DESCRIPTION
`<encodings_fragment>` is deprecated, switch to `<colorspace_fragment>` as referenced here : https://github.com/mrdoob/three.js/pull/26206

- [x] Ready to merge