### PR TITLE
Fix shadermaterials demo

### DIFF
--- a/demos/shadermaterials/src/App.jsx
+++ b/demos/shadermaterials/src/App.jsx
@@ -37,7 +37,7 @@ export const ImageFadeMaterial = shaderMaterial(
       vec4 finalTexture = mix(_texture, _texture2, dispFactor);
       gl_FragColor = finalTexture;
       #include <tonemapping_fragment>
-      #include <encodings_fragment>
+      #include <colorspace_fragment>
     }`
 )
 


### PR DESCRIPTION
`<encodings_fragment>` is deprecated, switch to `<colorspace_fragment>` as referenced here : https://github.com/mrdoob/three.js/pull/26206

- [x] Ready to merge