### PR TITLE
Add pmndrs metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       #
       # Lint
       #
+      - run: pnpm lint:metadata
       - run: pnpm lint:versions
 
       #

--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@ $ npx degit pmndrs/examples/demos/basic-demo myproject
 $ code myproject
 ```
 
+## Demo metadata
+
+Every demo has a `pmndrs.json` file containing the catalog metadata used by the
+website:
+
+```json
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Basic Demo",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": ["interaction", "pointer-events"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/rrppl0y8l4",
+  "libraries": ["@react-three/fiber", "@react-three/drei"],
+  "assets": []
+}
+```
+
+Use package names for `libraries`; each entry must also be a dependency of the
+demo. `publishedAt` is optional and uses `YYYY-MM-DD` when the original
+publication date is known. Add externally sourced models, textures, fonts,
+audio, and other assets to `assets` with their creator, source, and license when
+available.
+
+Run `pnpm lint:metadata` to validate every metadata file.
+
 # INSTALL
 
 Prerequisites:

--- a/apps/website/app/demos/[demoname]/page.tsx
+++ b/apps/website/app/demos/[demoname]/page.tsx
@@ -17,8 +17,8 @@ export async function generateMetadata({ params }: Props) {
   const demo = demos.find(({ name }) => name === params.demoname);
   if (!demo) return;
 
-  const title = `${demo.name} - pmndrs`;
-  const description = `Play with "${demo.name}" pmndrs demo.`;
+  const title = `${demo.title} - pmndrs`;
+  const description = demo.description;
 
   return {
     title,
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: Props) {
           url: demo.thumb,
           // width: 800,
           // height: 600,
-          alt: `${demo.name} capture of the demo`,
+          alt: `${demo.title} capture of the demo`,
         },
       ],
       type: "website",
@@ -104,7 +104,7 @@ export default async function Page(props: Props) {
       ) : (
         <>
           <div className="Frame">
-            <ScaledDemoFrame src={embed_url} title={demoname} />
+            <ScaledDemoFrame src={embed_url} title={demo.title} />
           </div>
 
           <Social demoname={demoname} embed_url={embed_url} />

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -4,17 +4,18 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   ComponentProps,
-  createRef,
   ElementRef,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import { useParams } from "next/navigation";
 import clsx from "clsx";
 
-import { getDemos } from "@/lib/helper";
+import { getLibraryLabel } from "@/const/libraries";
+import type { Demo } from "@/lib/helper";
 import { Style } from "./Style";
 
 const STORAGE_KEY = "nav-collapsed";
@@ -34,14 +35,28 @@ function syncCollapsedAttr(collapsed: boolean) {
 export default function Nav({
   demos,
   ...props
-}: { demos: ReturnType<typeof getDemos> } & ComponentProps<"nav">) {
+}: { demos: Demo[] } & ComponentProps<"nav">) {
   const ulRef = useRef<ElementRef<"ul">>(null);
-  const lisRef = useRef(
-    Array.from({ length: demos.length }).map(() => createRef<HTMLLIElement>()),
-  );
 
   const [collapsed, setCollapsed] = useState(false);
   const [ready, setReady] = useState(false);
+  const [library, setLibrary] = useState("");
+
+  const libraryOptions = useMemo(
+    () =>
+      Array.from(new Set(demos.flatMap((demo) => demo.libraries))).sort(
+        (a, b) => getLibraryLabel(a).localeCompare(getLibraryLabel(b)),
+      ),
+    [demos],
+  );
+
+  const filteredDemos = useMemo(
+    () =>
+      library
+        ? demos.filter((demo) => demo.libraries.includes(library))
+        : demos,
+    [demos, library],
+  );
 
   const toggle = useCallback(() => {
     setCollapsed((prev) => {
@@ -68,8 +83,9 @@ export default function Nav({
   useEffect(() => {
     const hasDemoSelected = typeof demoname === "string" && demoname.length > 0;
     if (!hasDemoSelected) return;
-    const i = demos.findIndex(({ name }) => name === demoname);
-    const li = lisRef.current[i]?.current;
+    const li = ulRef.current?.querySelector(
+      `[data-demo="${CSS.escape(demoname)}"]`,
+    );
     if (li)
       li.scrollIntoView({
         inline: "center",
@@ -77,7 +93,7 @@ export default function Nav({
         behavior: firstRef.current ? "instant" : "smooth",
       });
     firstRef.current = false;
-  }, [demoname, demos]);
+  }, [demoname, filteredDemos]);
 
   const navRef = useRef<HTMLDivElement>(null);
 
@@ -103,11 +119,7 @@ export default function Nav({
   }, [toggle]);
 
   return (
-    <div
-      ref={navRef}
-      className="Nav"
-      data-collapsed={collapsed || undefined}
-    >
+    <div ref={navRef} className="Nav" data-collapsed={collapsed || undefined}>
       <Style
         css={`
           @scope {
@@ -236,6 +248,45 @@ export default function Nav({
               margin: 0;
             }
 
+            .filters {
+              position: sticky;
+              top: 0;
+              z-index: 2;
+              padding: 1rem 0.75rem 0.25rem 1rem;
+              background: linear-gradient(#eee 75%, transparent);
+            }
+
+            .filters label {
+              display: grid;
+              gap: 0.35rem;
+              color: #555;
+              font-size: 0.65rem;
+              font-weight: 700;
+              letter-spacing: 0.06em;
+              text-transform: uppercase;
+            }
+
+            .filters select {
+              width: 100%;
+              min-height: 2.25rem;
+              padding: 0.45rem 2rem 0.45rem 0.65rem;
+              border: 1px solid #d4d4d4;
+              border-radius: 6px;
+              background: white;
+              color: #222;
+              font: inherit;
+              font-size: 0.75rem;
+              letter-spacing: normal;
+              text-transform: none;
+            }
+
+            .empty {
+              padding: 1rem;
+              color: #666;
+              font-size: 0.75rem;
+              text-align: center;
+            }
+
             li {
               padding-inline-start: unset;
               transform: scale(1);
@@ -253,7 +304,9 @@ export default function Nav({
               overflow: hidden;
               outline: 2px solid transparent;
               outline-offset: 2px;
-              transition: outline-color 0.2s ease, box-shadow 0.2s ease;
+              transition:
+                outline-color 0.2s ease,
+                box-shadow 0.2s ease;
             }
 
             a:hover {
@@ -296,7 +349,6 @@ export default function Nav({
               font-size: 0.7rem;
               background: none;
             }
-
           }
         `}
       />
@@ -308,7 +360,11 @@ export default function Nav({
         aria-pressed={!collapsed}
       >
         <span className="toggleInner">
-          <svg viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            viewBox="0 0 6 10"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
               d="M5 1L1 5L5 9"
               stroke="currentColor"
@@ -317,26 +373,47 @@ export default function Nav({
               strokeLinejoin="round"
             />
           </svg>
-          <span className="toggleLabel">{ready ? (collapsed ? "show" : "hide") : ""}</span>
+          <span className="toggleLabel">
+            {ready ? (collapsed ? "show" : "hide") : ""}
+          </span>
         </span>
       </button>
 
       <nav {...props}>
+        <div className="filters">
+          <label>
+            Library
+            <select
+              value={library}
+              onChange={(event) => setLibrary(event.target.value)}
+            >
+              <option value="">All libraries</option>
+              {libraryOptions.map((option) => (
+                <option key={option} value={option}>
+                  {getLibraryLabel(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
         <ul ref={ulRef}>
-          {demos.map(({ name, thumb, isNew }, i) => (
-            <li key={thumb} ref={lisRef.current[i]}>
+          {filteredDemos.map(({ name, title, thumb, isNew }) => (
+            <li key={thumb} data-demo={name}>
               <Link
                 href={`/demos/${name}`}
                 className={clsx({ active: demoname === name })}
               >
                 <div className="thumb">
                   {isNew && <span className="pill">New</span>}
-                  <Image src={thumb} fill sizes="227px" alt={name} />
+                  <Image src={thumb} fill sizes="227px" alt={title} />
                 </div>
               </Link>
             </li>
           ))}
         </ul>
+        {filteredDemos.length === 0 && (
+          <p className="empty">No demos use this library.</p>
+        )}
       </nav>
     </div>
   );

--- a/apps/website/const/libraries.ts
+++ b/apps/website/const/libraries.ts
@@ -1,0 +1,31 @@
+export const LIBRARY_LABELS: Record<string, string> = {
+  "@pmndrs/assets": "Assets",
+  "@pmndrs/branding": "Branding",
+  "@react-spring/core": "React Spring Core",
+  "@react-spring/three": "React Spring Three",
+  "@react-spring/web": "React Spring Web",
+  "@react-three/cannon": "Cannon",
+  "@react-three/csg": "CSG",
+  "@react-three/drei": "Drei",
+  "@react-three/fiber": "R3F",
+  "@react-three/flex": "Flex",
+  "@react-three/postprocessing": "Postprocessing",
+  "@react-three/rapier": "Rapier",
+  "@use-gesture/react": "Use Gesture",
+  ecctrl: "Ecctrl",
+  jotai: "Jotai",
+  lamina: "Lamina",
+  leva: "Leva",
+  maath: "Maath",
+  meshline: "Meshline",
+  "suspend-react": "Suspend React",
+  "three-stdlib": "Three Stdlib",
+  "tunnel-rat": "Tunnel Rat",
+  "use-asset": "Use Asset",
+  valtio: "Valtio",
+  zustand: "Zustand",
+};
+
+export function getLibraryLabel(library: string) {
+  return LIBRARY_LABELS[library] ?? library;
+}

--- a/apps/website/const/new.ts
+++ b/apps/website/const/new.ts
@@ -1,2 +1,1 @@
-
 export const NEW_DEMOS = new Set(["flow-shield"]);

--- a/apps/website/lib/helper.ts
+++ b/apps/website/lib/helper.ts
@@ -1,4 +1,6 @@
-// Importing JSON directly
+import fs from "node:fs";
+import path from "node:path";
+
 import { NEW_DEMOS } from "@/const/new";
 import pkg from "@/package.json";
 
@@ -6,18 +8,58 @@ import { generatePort } from "@examples/e2e";
 
 const BASE_PATH = process.env.BASE_PATH || "";
 const BASE_URL = process.env.BASE_URL;
+const DEMOS_DIRECTORY = path.resolve(process.cwd(), "../../demos");
 
 const host =
   process.env.NODE_ENV === "development"
     ? (port: number) => `http://localhost:${port}`
     : () => (BASE_URL ? new URL(BASE_URL).origin : "");
 
+export type AssetAttribution = {
+  name: string;
+  files?: string[];
+  creator?: string;
+  source?: string;
+  license?: string;
+  licenseUrl?: string;
+  modified?: boolean;
+  notes?: string;
+};
 
-export function getDemos() {
+export type DemoMetadata = {
+  title: string;
+  description: string;
+  tags: string[];
+  authors: string[];
+  publishedAt?: string;
+  source: string;
+  libraries: string[];
+  assets: AssetAttribution[];
+};
+
+export type Demo = DemoMetadata & {
+  name: string;
+  thumb: string;
+  embed_url: string;
+  website_url: string;
+  isNew: boolean;
+};
+
+function getMetadata(demoname: string): DemoMetadata {
+  const metadataPath = path.join(DEMOS_DIRECTORY, demoname, "pmndrs.json");
+  const metadata = JSON.parse(
+    fs.readFileSync(metadataPath, "utf8"),
+  ) as DemoMetadata & { $schema: string };
+  const { $schema: _, ...demo } = metadata;
+  return demo;
+}
+
+export function getDemos(): Demo[] {
   return Object.keys(pkg.dependencies)
     .filter((dep) => dep.startsWith("@demo/"))
     .map((pkgname) => {
       const demoname = pkgname.split("@demo/")[1];
+      const metadata = getMetadata(demoname);
       const port = generatePort(demoname);
       const h = host(port);
 
@@ -25,6 +67,7 @@ export function getDemos() {
       const website_url = `${h}${BASE_PATH}/demos/${demoname}`;
 
       return {
+        ...metadata,
         name: demoname,
         thumb: `${embed_url}/thumbnail.webp`,
         embed_url,

--- a/bin/validate-pmndrs-metadata.mjs
+++ b/bin/validate-pmndrs-metadata.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const demosDirectory = path.join(root, "demos");
+const schemaPath = path.join(root, "schemas", "pmndrs.schema.json");
+const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+const allowedLibraries = new Set(schema.properties.libraries.items.enum);
+const requiredFields = new Set(schema.required);
+const allowedFields = new Set(Object.keys(schema.properties));
+const allowedAssetFields = new Set(Object.keys(schema.$defs.asset.properties));
+const legacyPackageFields = ["description", "homepage", "keywords"];
+const errors = [];
+
+function addError(demoName, message) {
+  errors.push(`${demoName}: ${message}`);
+}
+
+function isStringArray(value) {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === "string" && item.length > 0)
+  );
+}
+
+function hasDuplicates(value) {
+  return new Set(value).size !== value.length;
+}
+
+function isUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isDate(value) {
+  return (
+    /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+    !Number.isNaN(Date.parse(`${value}T00:00:00Z`))
+  );
+}
+
+const demoNames = fs
+  .readdirSync(demosDirectory)
+  .filter((name) =>
+    fs.existsSync(path.join(demosDirectory, name, "package.json")),
+  )
+  .sort();
+
+for (const demoName of demoNames) {
+  const demoDirectory = path.join(demosDirectory, demoName);
+  const packagePath = path.join(demoDirectory, "package.json");
+  const metadataPath = path.join(demoDirectory, "pmndrs.json");
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+
+  if (!fs.existsSync(metadataPath)) {
+    addError(demoName, "missing pmndrs.json");
+    continue;
+  }
+
+  let metadata;
+  try {
+    metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  } catch (error) {
+    addError(demoName, `invalid JSON (${error.message})`);
+    continue;
+  }
+
+  for (const field of requiredFields) {
+    if (!(field in metadata)) addError(demoName, `missing "${field}"`);
+  }
+  for (const field of Object.keys(metadata)) {
+    if (!allowedFields.has(field)) {
+      addError(demoName, `unknown field "${field}"`);
+    }
+  }
+
+  if (metadata.$schema !== "../../schemas/pmndrs.schema.json") {
+    addError(demoName, 'invalid "$schema" path');
+  }
+  if (typeof metadata.title !== "string" || metadata.title.length === 0) {
+    addError(demoName, '"title" must be a non-empty string');
+  }
+  if (typeof metadata.description !== "string") {
+    addError(demoName, '"description" must be a string');
+  }
+
+  for (const field of ["tags", "authors", "libraries"]) {
+    if (!isStringArray(metadata[field])) {
+      addError(demoName, `"${field}" must contain non-empty strings`);
+    } else if (hasDuplicates(metadata[field])) {
+      addError(demoName, `"${field}" contains duplicates`);
+    }
+  }
+
+  if (!isUrl(metadata.source)) {
+    addError(demoName, '"source" must be an HTTP(S) URL');
+  }
+  if (metadata.publishedAt !== undefined && !isDate(metadata.publishedAt)) {
+    addError(demoName, '"publishedAt" must use YYYY-MM-DD');
+  }
+
+  const dependencies = packageJson.dependencies ?? {};
+  for (const library of metadata.libraries ?? []) {
+    if (!allowedLibraries.has(library)) {
+      addError(demoName, `unknown library "${library}"`);
+    }
+    if (!(library in dependencies)) {
+      addError(demoName, `library "${library}" is not listed in dependencies`);
+    }
+  }
+
+  if (!Array.isArray(metadata.assets)) {
+    addError(demoName, '"assets" must be an array');
+  } else {
+    metadata.assets.forEach((asset, index) => {
+      if (!asset || typeof asset !== "object" || Array.isArray(asset)) {
+        addError(demoName, `asset ${index} must be an object`);
+        return;
+      }
+      if (typeof asset.name !== "string" || asset.name.length === 0) {
+        addError(demoName, `asset ${index} requires a name`);
+      }
+      for (const field of Object.keys(asset)) {
+        if (!allowedAssetFields.has(field)) {
+          addError(demoName, `asset ${index} has unknown field "${field}"`);
+        }
+      }
+      if (
+        asset.files !== undefined &&
+        (!isStringArray(asset.files) || hasDuplicates(asset.files))
+      ) {
+        addError(demoName, `asset ${index} "files" must contain unique paths`);
+      }
+      for (const field of ["source", "licenseUrl"]) {
+        if (asset[field] !== undefined && !isUrl(asset[field])) {
+          addError(demoName, `asset ${index} "${field}" must be a URL`);
+        }
+      }
+    });
+  }
+
+  for (const field of legacyPackageFields) {
+    if (field in packageJson) {
+      addError(
+        demoName,
+        `package.json still contains migrated field "${field}"`,
+      );
+    }
+  }
+  for (const dependency of Object.keys(dependencies)) {
+    if (
+      allowedLibraries.has(dependency) &&
+      !metadata.libraries?.includes(dependency)
+    ) {
+      addError(
+        demoName,
+        `dependency "${dependency}" is missing from libraries`,
+      );
+    }
+  }
+}
+
+const metadataWithoutPackage = fs
+  .readdirSync(demosDirectory)
+  .filter(
+    (name) =>
+      fs.existsSync(path.join(demosDirectory, name, "pmndrs.json")) &&
+      !fs.existsSync(path.join(demosDirectory, name, "package.json")),
+  );
+
+for (const demoName of metadataWithoutPackage) {
+  addError(demoName, "pmndrs.json has no matching package.json");
+}
+
+if (errors.length > 0) {
+  console.error(`Metadata validation failed with ${errors.length} error(s):`);
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`Validated metadata for ${demoNames.length} demos.`);

--- a/demos/aquarium/package.json
+++ b/demos/aquarium/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@demo/aquarium",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/n7jf0f",
   "repository": {
     "type": "git",
     "url": "https://github.com/pmndrs/examples/tree/main/demos/aquarium"
   },
-  "keywords": [],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/aquarium/pmndrs.json
+++ b/demos/aquarium/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Aquarium",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/n7jf0f",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/aquarium/pmndrs.json
+++ b/demos/aquarium/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Aquarium",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-29",
   "source": "https://codesandbox.io/s/n7jf0f",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/arkanoid-under-60-loc/package.json
+++ b/demos/arkanoid-under-60-loc/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/arkanoid-under-60-loc",
   "version": "1.0.0",
-  "description": "Super small Arkanoid barebones implementation.",
-  "homepage": "https://codesandbox.io/s/66cd7",
-  "keywords": [
-    "collisions",
-    "cannon",
-    "arkanoid",
-    "physics"
-  ],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "@react-three/rapier": "^1.4.0",

--- a/demos/arkanoid-under-60-loc/pmndrs.json
+++ b/demos/arkanoid-under-60-loc/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Arkanoid Under 60 LOC",
   "description": "Super small Arkanoid barebones implementation.",
   "tags": ["collisions", "cannon", "arkanoid", "physics"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-06-19",
   "source": "https://codesandbox.io/s/66cd7",
   "libraries": ["@react-three/fiber", "@react-three/rapier"],
   "assets": []

--- a/demos/arkanoid-under-60-loc/pmndrs.json
+++ b/demos/arkanoid-under-60-loc/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Arkanoid Under 60 LOC",
+  "description": "Super small Arkanoid barebones implementation.",
+  "tags": ["collisions", "cannon", "arkanoid", "physics"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/66cd7",
+  "libraries": ["@react-three/fiber", "@react-three/rapier"],
+  "assets": []
+}

--- a/demos/arkanoid/package.json
+++ b/demos/arkanoid/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/arkanoid",
   "version": "1.0.0",
-  "description": "Simple arkanoid implementation using cannon physics.",
-  "homepage": "https://codesandbox.io/s/2yqpv",
-  "keywords": [
-    "physics",
-    "cannon",
-    "game",
-    "audio"
-  ],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-three/cannon": "^6.6.0",

--- a/demos/arkanoid/pmndrs.json
+++ b/demos/arkanoid/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Arkanoid",
+  "description": "Simple arkanoid implementation using cannon physics.",
+  "tags": ["physics", "cannon", "game", "audio"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2yqpv",
+  "libraries": ["@react-spring/three", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "zustand"],
+  "assets": []
+}

--- a/demos/arkanoid/pmndrs.json
+++ b/demos/arkanoid/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Arkanoid",
   "description": "Simple arkanoid implementation using cannon physics.",
   "tags": ["physics", "cannon", "game", "audio"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-05-25",
   "source": "https://codesandbox.io/s/2yqpv",
   "libraries": ["@react-spring/three", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "zustand"],
   "assets": []

--- a/demos/audio-analyser/package.json
+++ b/demos/audio-analyser/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/audio-analyser",
   "version": "1.0.0",
-  "description": "Combining audio analysis with gltf cell fracture and reflections.",
-  "homepage": "https://codesandbox.io/s/dvokj",
-  "keywords": [
-    "gltf",
-    "audio",
-    "reflections",
-    "cell-fracture"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/audio-analyser/pmndrs.json
+++ b/demos/audio-analyser/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Audio Analyser",
+  "description": "Combining audio analysis with gltf cell fracture and reflections.",
+  "tags": ["gltf", "audio", "reflections", "cell-fracture"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/dvokj",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/audio-analyser/pmndrs.json
+++ b/demos/audio-analyser/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Audio Analyser",
   "description": "Combining audio analysis with gltf cell fracture and reflections.",
   "tags": ["gltf", "audio", "reflections", "cell-fracture"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-02-01",
   "source": "https://codesandbox.io/s/dvokj",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/backdrop-and-cables/package.json
+++ b/demos/backdrop-and-cables/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/backdrop-and-cables",
   "version": "1.0.0",
-  "description": "Using a studio backdrop, quadratic bezier line and contact shadows.",
-  "homepage": "https://codesandbox.io/s/2ij9u",
-  "keywords": [
-    "quadraticbezierline",
-    "contact-shadows",
-    "backdrop"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/backdrop-and-cables/pmndrs.json
+++ b/demos/backdrop-and-cables/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Backdrop And Cables",
+  "description": "Using a studio backdrop, quadratic bezier line and contact shadows.",
+  "tags": ["quadraticbezierline", "contact-shadows", "backdrop"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2ij9u",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/backdrop-and-cables/pmndrs.json
+++ b/demos/backdrop-and-cables/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Backdrop And Cables",
   "description": "Using a studio backdrop, quadratic bezier line and contact shadows.",
   "tags": ["quadraticbezierline", "contact-shadows", "backdrop"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-11-28",
   "source": "https://codesandbox.io/s/2ij9u",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/baking-soft-shadows/package.json
+++ b/demos/baking-soft-shadows/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/baking-soft-shadows",
   "version": "1.0.0",
-  "description": "How to use drei/AccumulativeShadows and RandomizedLight",
-  "homepage": "https://codesandbox.io/s/hxcc1x",
-  "keywords": [
-    "baking",
-    "softshadows",
-    "shadows",
-    "lightmap",
-    "progressive"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/baking-soft-shadows/pmndrs.json
+++ b/demos/baking-soft-shadows/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Baking Soft Shadows",
+  "description": "How to use drei/AccumulativeShadows and RandomizedLight",
+  "tags": ["baking", "softshadows", "shadows", "lightmap", "progressive"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/hxcc1x",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/baking-soft-shadows/pmndrs.json
+++ b/demos/baking-soft-shadows/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Baking Soft Shadows",
   "description": "How to use drei/AccumulativeShadows and RandomizedLight",
   "tags": ["baking", "softshadows", "shadows", "lightmap", "progressive"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-07-30",
   "source": "https://codesandbox.io/s/hxcc1x",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/basic-ballpit/package.json
+++ b/demos/basic-ballpit/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/basic-ballpit",
   "version": "1.0.0",
-  "description": "Physics simulation using cannon.",
-  "homepage": "https://codesandbox.io/s/0fqow2",
-  "keywords": [
-    "physics",
-    "cannon"
-  ],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/fiber": "^8.17.5",

--- a/demos/basic-ballpit/pmndrs.json
+++ b/demos/basic-ballpit/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Basic Ballpit",
   "description": "Physics simulation using cannon.",
   "tags": ["physics", "cannon"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-06-29",
   "source": "https://codesandbox.io/s/0fqow2",
   "libraries": ["@react-three/cannon", "@react-three/fiber"],
   "assets": []

--- a/demos/basic-ballpit/pmndrs.json
+++ b/demos/basic-ballpit/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Basic Ballpit",
+  "description": "Physics simulation using cannon.",
+  "tags": ["physics", "cannon"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0fqow2",
+  "libraries": ["@react-three/cannon", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/basic-demo/package.json
+++ b/demos/basic-demo/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/basic-demo",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/rrppl0y8l4",
-  "keywords": [
-    "interaction",
-    "pointer-events"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/basic-demo/pmndrs.json
+++ b/demos/basic-demo/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Basic Demo",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": ["interaction", "pointer-events"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/rrppl0y8l4",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/basic-demo/pmndrs.json
+++ b/demos/basic-demo/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Basic Demo",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["interaction", "pointer-events"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-03-12",
   "source": "https://codesandbox.io/s/rrppl0y8l4",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/bestservedbold-christmas-baubles/package.json
+++ b/demos/bestservedbold-christmas-baubles/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/bestservedbold-christmas-baubles",
   "version": "1.0.0",
-  "description": "Physics, effects, lights and colors.",
-  "homepage": "https://codesandbox.io/s/zxpv7",
-  "keywords": [
-    "effects",
-    "physics",
-    "baubles"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/bestservedbold-christmas-baubles/pmndrs.json
+++ b/demos/bestservedbold-christmas-baubles/pmndrs.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Best Served Bold Christmas Baubles",
+  "description": "Physics, effects, lights and colors.",
+  "tags": [
+    "effects",
+    "physics",
+    "baubles"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/zxpv7",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing",
+    "@react-three/rapier"
+  ],
+  "assets": []
+}

--- a/demos/bestservedbold-christmas-baubles/pmndrs.json
+++ b/demos/bestservedbold-christmas-baubles/pmndrs.json
@@ -7,7 +7,8 @@
     "physics",
     "baubles"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-08-03",
   "source": "https://codesandbox.io/s/zxpv7",
   "libraries": [
     "@react-three/drei",

--- a/demos/bezier-curves-and-nodes/package.json
+++ b/demos/bezier-curves-and-nodes/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/bezier-curves-and-nodes",
   "version": "1.0.0",
-  "description": "Creating node diagrams with drei's Line and bezier curves.",
-  "homepage": "https://codesandbox.io/s/3k4g6",
-  "keywords": [
-    "line2",
-    "graph",
-    "nodes",
-    "bezier"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/bezier-curves-and-nodes/pmndrs.json
+++ b/demos/bezier-curves-and-nodes/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Bezier Curves And Nodes",
+  "description": "Creating node diagrams with drei's Line and bezier curves.",
+  "tags": ["line2", "graph", "nodes", "bezier"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/3k4g6",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@use-gesture/react"],
+  "assets": []
+}

--- a/demos/bezier-curves-and-nodes/pmndrs.json
+++ b/demos/bezier-curves-and-nodes/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Bezier Curves And Nodes",
   "description": "Creating node diagrams with drei's Line and bezier curves.",
   "tags": ["line2", "graph", "nodes", "bezier"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-02-26",
   "source": "https://codesandbox.io/s/3k4g6",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@use-gesture/react"],
   "assets": []

--- a/demos/bloom-hdr-workflow-gltf/package.json
+++ b/demos/bloom-hdr-workflow-gltf/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/bloom-hdr-workflow-gltf",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/whnhyr",
-  "keywords": [
-    "bloom",
-    "hdr",
-    "glow",
-    "gltf",
-    "selective"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/bloom-hdr-workflow-gltf/pmndrs.json
+++ b/demos/bloom-hdr-workflow-gltf/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Bloom HDR Workflow GLTF",
   "description": "",
   "tags": ["bloom", "hdr", "glow", "gltf", "selective"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-06-23",
   "source": "https://codesandbox.io/s/whnhyr",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/bloom-hdr-workflow-gltf/pmndrs.json
+++ b/demos/bloom-hdr-workflow-gltf/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Bloom HDR Workflow GLTF",
+  "description": "",
+  "tags": ["bloom", "hdr", "glow", "gltf", "selective"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/whnhyr",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/bouncy-watch/package.json
+++ b/demos/bouncy-watch/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/bouncy-watch",
   "version": "1.0.0",
-  "description": "Custom springy controls using use-gesture and react-spring.",
-  "homepage": "https://codesandbox.io/s/qyz5r",
-  "keywords": [
-    "use-gesture",
-    "custom-controls",
-    "react-spring",
-    "tag-heuer"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/bouncy-watch/pmndrs.json
+++ b/demos/bouncy-watch/pmndrs.json
@@ -2,8 +2,9 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Bouncy Watch",
   "description": "Custom springy controls using use-gesture and react-spring.",
-  "tags": ["use-gesture", "custom-controls", "react-spring", "tag-heuer"],
-  "authors": [],
+  "tags": ["use-gesture", "custom-controls", "react-spring", "tag-heuer", "html"],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-11-26",
   "source": "https://codesandbox.io/s/qyz5r",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/bouncy-watch/pmndrs.json
+++ b/demos/bouncy-watch/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Bouncy Watch",
+  "description": "Custom springy controls using use-gesture and react-spring.",
+  "tags": ["use-gesture", "custom-controls", "react-spring", "tag-heuer"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/qyz5r",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/bounds-and-makedefault/package.json
+++ b/demos/bounds-and-makedefault/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/bounds-and-makedefault",
   "version": "1.0.0",
-  "description": "Combining TransformControls, OrbitControls and Valtio.",
-  "homepage": "https://codesandbox.io/s/rz2g0",
-  "keywords": [
-    "fit-all",
-    "bounds"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/bounds-and-makedefault/pmndrs.json
+++ b/demos/bounds-and-makedefault/pmndrs.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Bounds and makeDefault",
+  "description": "Combining TransformControls, OrbitControls and Valtio.",
+  "tags": [
+    "fit-all",
+    "bounds"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/rz2g0",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/bounds-and-makedefault/pmndrs.json
+++ b/demos/bounds-and-makedefault/pmndrs.json
@@ -6,7 +6,8 @@
     "fit-all",
     "bounds"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-28",
   "source": "https://codesandbox.io/s/rz2g0",
   "libraries": [
     "@react-three/drei",

--- a/demos/bruno-simons-20k-challenge/package.json
+++ b/demos/bruno-simons-20k-challenge/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/bruno-simons-20k-challenge",
   "version": "1.0.0",
-  "description": "https://twitter.com/bruno_simon/status/1557355710089920513",
-  "homepage": "https://codesandbox.io/s/2qfxj4",
-  "keywords": [
-    "csg",
-    "rapier",
-    "postprocessing",
-    "drei",
-    "physics"
-  ],
   "dependencies": {
     "@react-three/csg": "^3.2.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/bruno-simons-20k-challenge/pmndrs.json
+++ b/demos/bruno-simons-20k-challenge/pmndrs.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Bruno Simon's 20K Challenge",
+  "description": "https://twitter.com/bruno_simon/status/1557355710089920513",
+  "tags": [
+    "csg",
+    "rapier",
+    "postprocessing",
+    "drei",
+    "physics"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2qfxj4",
+  "libraries": [
+    "@react-three/csg",
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing",
+    "@react-three/rapier"
+  ],
+  "assets": []
+}

--- a/demos/bruno-simons-20k-challenge/pmndrs.json
+++ b/demos/bruno-simons-20k-challenge/pmndrs.json
@@ -9,7 +9,8 @@
     "drei",
     "physics"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-08-10",
   "source": "https://codesandbox.io/s/2qfxj4",
   "libraries": [
     "@react-three/csg",

--- a/demos/building-dynamic-envmaps/package.json
+++ b/demos/building-dynamic-envmaps/package.json
@@ -1,16 +1,6 @@
 {
   "name": "@demo/building-dynamic-envmaps",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/e662p3",
-  "keywords": [
-    "ssr",
-    "reflections",
-    "glow",
-    "environment",
-    "bloom",
-    "lut"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/building-dynamic-envmaps/pmndrs.json
+++ b/demos/building-dynamic-envmaps/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Building Dynamic Env Maps",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["ssr", "reflections", "glow", "environment", "bloom", "lut"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-04",
   "source": "https://codesandbox.io/s/e662p3",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []

--- a/demos/building-dynamic-envmaps/pmndrs.json
+++ b/demos/building-dynamic-envmaps/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Building Dynamic Env Maps",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": ["ssr", "reflections", "glow", "environment", "bloom", "lut"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/e662p3",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/building-live-envmaps/package.json
+++ b/demos/building-live-envmaps/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/building-live-envmaps",
   "version": "1.0.0",
-  "description": "Shows how to build declarative environment that are live and animated.",
-  "homepage": "https://codesandbox.io/s/lwo219",
-  "keywords": [
-    "lightformer"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/building-live-envmaps/pmndrs.json
+++ b/demos/building-live-envmaps/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Building Live Env Maps",
   "description": "Shows how to build declarative environment that are live and animated.",
   "tags": ["lightformer"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-05",
   "source": "https://codesandbox.io/s/lwo219",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "lamina"],
   "assets": []

--- a/demos/building-live-envmaps/pmndrs.json
+++ b/demos/building-live-envmaps/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Building Live Env Maps",
+  "description": "Shows how to build declarative environment that are live and animated.",
+  "tags": ["lightformer"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/lwo219",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "lamina"],
+  "assets": []
+}

--- a/demos/bvh/package.json
+++ b/demos/bvh/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/bvh",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/txzeq8",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/bvh/pmndrs.json
+++ b/demos/bvh/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "BVH",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/txzeq8",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/bvh/pmndrs.json
+++ b/demos/bvh/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "BVH",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-25",
   "source": "https://codesandbox.io/s/txzeq8",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/camera-scroll/package.json
+++ b/demos/camera-scroll/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/camera-scroll",
   "version": "1.0.0",
-  "description": "Tying scroll to a GLTF camera path with snapping points.",
-  "homepage": "https://codesandbox.io/s/tu24h",
-  "keywords": [
-    "snap",
-    "scroll",
-    "gtlf",
-    "html"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/camera-scroll/pmndrs.json
+++ b/demos/camera-scroll/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Camera Scroll",
   "description": "Tying scroll to a GLTF camera path with snapping points.",
   "tags": ["snap", "scroll", "gtlf", "html"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-29",
   "source": "https://codesandbox.io/s/tu24h",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/camera-scroll/pmndrs.json
+++ b/demos/camera-scroll/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Camera Scroll",
+  "description": "Tying scroll to a GLTF camera path with snapping points.",
+  "tags": ["snap", "scroll", "gtlf", "html"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/tu24h",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/camera-shake/package.json
+++ b/demos/camera-shake/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/camera-shake",
   "version": "1.0.0",
-  "description": "Testing dre's new CameraShake with a couple of primitives.",
-  "homepage": "https://codesandbox.io/s/t4l0f",
-  "keywords": [
-    "camera-shake",
-    "rectarea-lights",
-    "reflections"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/camera-shake/pmndrs.json
+++ b/demos/camera-shake/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Camera Shake",
   "description": "Testing dre's new CameraShake with a couple of primitives.",
   "tags": ["camera-shake", "rectarea-lights", "reflections"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-02-09",
   "source": "https://codesandbox.io/s/t4l0f",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/camera-shake/pmndrs.json
+++ b/demos/camera-shake/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Camera Shake",
+  "description": "Testing dre's new CameraShake with a couple of primitives.",
+  "tags": ["camera-shake", "rectarea-lights", "reflections"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/t4l0f",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/canvas-text/package.json
+++ b/demos/canvas-text/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/canvas-text",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/p9umgf",
-  "keywords": [],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "react": "^18.3.1",

--- a/demos/canvas-text/pmndrs.json
+++ b/demos/canvas-text/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Canvas Text",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-28",
   "source": "https://codesandbox.io/s/p9umgf",
   "libraries": ["@react-three/fiber"],
   "assets": []

--- a/demos/canvas-text/pmndrs.json
+++ b/demos/canvas-text/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Canvas Text",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/p9umgf",
+  "libraries": ["@react-three/fiber"],
+  "assets": []
+}

--- a/demos/cards-with-border-radius/package.json
+++ b/demos/cards-with-border-radius/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/cards-with-border-radius",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/9s2wd9",
-  "keywords": [],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/cards-with-border-radius/pmndrs.json
+++ b/demos/cards-with-border-radius/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Cards With Border Radius",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2024-01-18",
   "source": "https://codesandbox.io/s/9s2wd9",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/cards-with-border-radius/pmndrs.json
+++ b/demos/cards-with-border-radius/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Cards With Border Radius",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/9s2wd9",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/cards/package.json
+++ b/demos/cards/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/cards",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/dc5fjy",
-  "keywords": [],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",

--- a/demos/cards/pmndrs.json
+++ b/demos/cards/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Cards",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-12-11",
   "source": "https://codesandbox.io/s/dc5fjy",
   "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/cards/pmndrs.json
+++ b/demos/cards/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Cards",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/dc5fjy",
+  "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/caustics/package.json
+++ b/demos/caustics/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/caustics",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/szj6p7",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/caustics/pmndrs.json
+++ b/demos/caustics/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Caustics",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/szj6p7",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/caustics/pmndrs.json
+++ b/demos/caustics/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Caustics",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-09",
   "source": "https://codesandbox.io/s/szj6p7",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/cell-fracture/package.json
+++ b/demos/cell-fracture/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/cell-fracture",
   "version": "1.0.0",
-  "description": "Exploding GLTFs using Blenders cell-fracture and GLTFJSX.",
-  "homepage": "https://codesandbox.io/s/3rjsl",
-  "keywords": [
-    "animation",
-    "clell-fracture",
-    "gltf",
-    "gltfjsx"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/cell-fracture/pmndrs.json
+++ b/demos/cell-fracture/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Cell Fracture",
   "description": "Exploding GLTFs using Blenders cell-fracture and GLTFJSX.",
   "tags": ["animation", "clell-fracture", "gltf", "gltfjsx"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-01-24",
   "source": "https://codesandbox.io/s/3rjsl",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/cell-fracture/pmndrs.json
+++ b/demos/cell-fracture/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Cell Fracture",
+  "description": "Exploding GLTFs using Blenders cell-fracture and GLTFJSX.",
+  "tags": ["animation", "clell-fracture", "gltf", "gltfjsx"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/3rjsl",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/clones/package.json
+++ b/demos/clones/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/clones",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/42glz0",
-  "keywords": [
-    "gltf",
-    "drei",
-    "clone"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/clones/pmndrs.json
+++ b/demos/clones/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Clones",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["gltf", "drei", "clone"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-19",
   "source": "https://codesandbox.io/s/42glz0",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/clones/pmndrs.json
+++ b/demos/clones/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Clones",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": ["gltf", "drei", "clone"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/42glz0",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/clouds/package.json
+++ b/demos/clouds/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@demo/clouds",
   "version": "0.1.0",
-  "homepage": "https://codesandbox.io/s/mbfzf",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^9.109.5",
@@ -36,11 +35,6 @@
       "last 1 safari version"
     ]
   },
-  "keywords": [
-    "clouds",
-    "drei"
-  ],
-  "description": "Trying out drei's new cloud component.",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/clouds/pmndrs.json
+++ b/demos/clouds/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Clouds",
+  "description": "Trying out drei's new cloud component.",
+  "tags": ["clouds", "drei"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/mbfzf",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/clouds/pmndrs.json
+++ b/demos/clouds/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Clouds",
   "description": "Trying out drei's new cloud component.",
   "tags": ["clouds", "drei"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-11-16",
   "source": "https://codesandbox.io/s/mbfzf",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/color-grading/package.json
+++ b/demos/color-grading/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/color-grading",
   "version": "1.0.0",
-  "description": "Shows how to use LUTPass to grade colors.",
-  "homepage": "https://codesandbox.io/s/wvgxp",
-  "keywords": [
-    "grading"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/color-grading/pmndrs.json
+++ b/demos/color-grading/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Color Grading",
   "description": "Shows how to use LUTPass to grade colors.",
   "tags": ["grading"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-11-09",
   "source": "https://codesandbox.io/s/wvgxp",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/color-grading/pmndrs.json
+++ b/demos/color-grading/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Color Grading",
+  "description": "Shows how to use LUTPass to grade colors.",
+  "tags": ["grading"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/wvgxp",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/confetti/package.json
+++ b/demos/confetti/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/confetti",
   "version": "1.0.0",
-  "description": "Meshline particles.",
-  "homepage": "https://codesandbox.io/s/vl221",
-  "keywords": [
-    "particles",
-    "meshline",
-    "confetti"
-  ],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "@react-three/postprocessing": "^2.16.2",

--- a/demos/confetti/pmndrs.json
+++ b/demos/confetti/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Confetti",
+  "description": "Meshline particles.",
+  "tags": ["particles", "meshline", "confetti"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/vl221",
+  "libraries": ["@react-three/fiber", "@react-three/postprocessing", "leva", "maath", "meshline"],
+  "assets": []
+}

--- a/demos/confetti/pmndrs.json
+++ b/demos/confetti/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Confetti",
   "description": "Meshline particles.",
   "tags": ["particles", "meshline", "confetti"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-10-19",
   "source": "https://codesandbox.io/s/vl221",
   "libraries": ["@react-three/fiber", "@react-three/postprocessing", "leva", "maath", "meshline"],
   "assets": []

--- a/demos/csg-bunny-usegroups/package.json
+++ b/demos/csg-bunny-usegroups/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/csg-bunny-usegroups",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/mlgzsc",
-  "keywords": [],
   "dependencies": {
     "@react-three/csg": "^3.2.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/csg-bunny-usegroups/pmndrs.json
+++ b/demos/csg-bunny-usegroups/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "CSG Bunny useGroups",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-21",
   "source": "https://codesandbox.io/s/mlgzsc",
   "libraries": [
     "@react-three/csg",

--- a/demos/csg-bunny-usegroups/pmndrs.json
+++ b/demos/csg-bunny-usegroups/pmndrs.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "CSG Bunny useGroups",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/mlgzsc",
+  "libraries": [
+    "@react-three/csg",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/csg-house/package.json
+++ b/demos/csg-house/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/csg-house",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/y52tmt",
-  "keywords": [],
   "dependencies": {
     "@react-three/csg": "^3.2.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/csg-house/pmndrs.json
+++ b/demos/csg-house/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "CSG House",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/y52tmt",
+  "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/csg-house/pmndrs.json
+++ b/demos/csg-house/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "CSG House",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-22",
   "source": "https://codesandbox.io/s/y52tmt",
   "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/csg-operations-rapier-physics/package.json
+++ b/demos/csg-operations-rapier-physics/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/csg-operations-rapier-physics",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/mw0dtc",
-  "keywords": [
-    "csg",
-    "rapier"
-  ],
   "dependencies": {
     "@react-three/csg": "^3.2.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/csg-operations-rapier-physics/pmndrs.json
+++ b/demos/csg-operations-rapier-physics/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "CSG Operations Rapier Physics",
   "description": "",
   "tags": ["csg", "rapier"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-07-22",
   "source": "https://codesandbox.io/s/mw0dtc",
   "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber", "@react-three/rapier", "lamina", "leva"],
   "assets": []

--- a/demos/csg-operations-rapier-physics/pmndrs.json
+++ b/demos/csg-operations-rapier-physics/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "CSG Operations Rapier Physics",
+  "description": "",
+  "tags": ["csg", "rapier"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/mw0dtc",
+  "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber", "@react-three/rapier", "lamina", "leva"],
+  "assets": []
+}

--- a/demos/dbismut-furniture/package.json
+++ b/demos/dbismut-furniture/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/dbismut-furniture",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/62o18n",
-  "keywords": [],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-three/drei": "^9.109.5",

--- a/demos/dbismut-furniture/pmndrs.json
+++ b/demos/dbismut-furniture/pmndrs.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "D. Bismut Furniture",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/62o18n",
+  "libraries": [
+    "@react-spring/three",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/dbismut-furniture/pmndrs.json
+++ b/demos/dbismut-furniture/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "D. Bismut Furniture",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-03-27",
   "source": "https://codesandbox.io/s/62o18n",
   "libraries": [
     "@react-spring/three",

--- a/demos/diamond-refraction/package.json
+++ b/demos/diamond-refraction/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/diamond-refraction",
   "version": "1.0.0",
-  "description": "Diamon refraction material",
-  "homepage": "https://codesandbox.io/s/zqrreo",
-  "keywords": [
-    "diamond",
-    "refraction",
-    "raycast",
-    "bvh"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/diamond-refraction/pmndrs.json
+++ b/demos/diamond-refraction/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Diamond Refraction",
+  "description": "Diamon refraction material",
+  "tags": ["diamond", "refraction", "raycast", "bvh"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/zqrreo",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/diamond-refraction/pmndrs.json
+++ b/demos/diamond-refraction/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Diamond Refraction",
   "description": "Diamon refraction material",
   "tags": ["diamond", "refraction", "raycast", "bvh"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-09-13",
   "source": "https://codesandbox.io/s/zqrreo",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []

--- a/demos/diamond-ring/package.json
+++ b/demos/diamond-ring/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/diamond-ring",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/4gy946",
-  "keywords": [
-    "bloom",
-    "refraction",
-    "diamond",
-    "ring",
-    "html"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/diamond-ring/pmndrs.json
+++ b/demos/diamond-ring/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Diamond Ring",
   "description": "",
   "tags": ["bloom", "refraction", "diamond", "ring", "html"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-09-18",
   "source": "https://codesandbox.io/s/4gy946",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/diamond-ring/pmndrs.json
+++ b/demos/diamond-ring/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Diamond Ring",
+  "description": "",
+  "tags": ["bloom", "refraction", "diamond", "ring", "html"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/4gy946",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/drei-rendertexture/package.json
+++ b/demos/drei-rendertexture/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/drei-rendertexture",
   "version": "1.0.0",
-  "description": "Portal a live scene events and all into a texture.",
-  "homepage": "https://codesandbox.io/s/0z8i2c",
-  "keywords": [
-    "portals",
-    "rendertexture"
-  ],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/drei-rendertexture/pmndrs.json
+++ b/demos/drei-rendertexture/pmndrs.json
@@ -6,7 +6,8 @@
     "portals",
     "rendertexture"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-05-04",
   "source": "https://codesandbox.io/s/0z8i2c",
   "libraries": [
     "@pmndrs/assets",

--- a/demos/drei-rendertexture/pmndrs.json
+++ b/demos/drei-rendertexture/pmndrs.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Drei RenderTexture",
+  "description": "Portal a live scene events and all into a texture.",
+  "tags": [
+    "portals",
+    "rendertexture"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0z8i2c",
+  "libraries": [
+    "@pmndrs/assets",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/ecctrl-fisheye/package.json
+++ b/demos/ecctrl-fisheye/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/ecctrl-fisheye",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/nvk9pf",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/ecctrl-fisheye/pmndrs.json
+++ b/demos/ecctrl-fisheye/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Ecctrl Fisheye",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-10-10",
   "source": "https://codesandbox.io/s/nvk9pf",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "ecctrl"],
   "assets": []

--- a/demos/ecctrl-fisheye/pmndrs.json
+++ b/demos/ecctrl-fisheye/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Ecctrl Fisheye",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/nvk9pf",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "ecctrl"],
+  "assets": []
+}

--- a/demos/edgesgeometry/package.json
+++ b/demos/edgesgeometry/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/edgesgeometry",
   "version": "1.0.0",
-  "description": "How to use EdgesGeometry, which expects its target as a constructor argument.",
-  "homepage": "https://codesandbox.io/s/iup24",
-  "keywords": [
-    "outlines",
-    "gltf",
-    "geometry"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/edgesgeometry/pmndrs.json
+++ b/demos/edgesgeometry/pmndrs.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "EdgesGeometry",
+  "description": "How to use EdgesGeometry, which expects its target as a constructor argument.",
+  "tags": [
+    "outlines",
+    "gltf",
+    "geometry"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/iup24",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/edgesgeometry/pmndrs.json
+++ b/demos/edgesgeometry/pmndrs.json
@@ -7,7 +7,8 @@
     "gltf",
     "geometry"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-04-06",
   "source": "https://codesandbox.io/s/iup24",
   "libraries": [
     "@react-three/drei",

--- a/demos/enter-portals/package.json
+++ b/demos/enter-portals/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/enter-portals",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/9m4tpc",
-  "keywords": [],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",

--- a/demos/enter-portals/pmndrs.json
+++ b/demos/enter-portals/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Enter Portals",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/9m4tpc",
+  "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/enter-portals/pmndrs.json
+++ b/demos/enter-portals/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Enter Portals",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-06-14",
   "source": "https://codesandbox.io/s/9m4tpc",
   "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/environment-blur-and-transitions/package.json
+++ b/demos/environment-blur-and-transitions/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/environment-blur-and-transitions",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/pj7zjq",
-  "keywords": [
-    "environment",
-    "blur"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/environment-blur-and-transitions/pmndrs.json
+++ b/demos/environment-blur-and-transitions/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Environment Blur And Transitions",
+  "description": "",
+  "tags": ["environment", "blur"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/pj7zjq",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/environment-blur-and-transitions/pmndrs.json
+++ b/demos/environment-blur-and-transitions/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Environment Blur And Transitions",
   "description": "",
   "tags": ["environment", "blur"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-10-28",
   "source": "https://codesandbox.io/s/pj7zjq",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/envmap-ground-projection/package.json
+++ b/demos/envmap-ground-projection/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/envmap-ground-projection",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/q48jgy",
-  "keywords": [
-    "cube camera",
-    "reflections"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/envmap-ground-projection/pmndrs.json
+++ b/demos/envmap-ground-projection/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Env Map Ground Projection",
+  "description": "",
+  "tags": ["cube camera", "reflections"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/q48jgy",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/envmap-ground-projection/pmndrs.json
+++ b/demos/envmap-ground-projection/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Env Map Ground Projection",
   "description": "",
   "tags": ["cube camera", "reflections"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-04-10",
   "source": "https://codesandbox.io/s/q48jgy",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/faucets-select-highlight/package.json
+++ b/demos/faucets-select-highlight/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/faucets-select-highlight",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/8flefh",
-  "keywords": [
-    "bounds",
-    "highlight",
-    "selection",
-    "metal",
-    "reflections"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/faucets-select-highlight/pmndrs.json
+++ b/demos/faucets-select-highlight/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Faucets Select Highlight",
   "description": "",
   "tags": ["bounds", "highlight", "selection", "metal", "reflections"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-07-15",
   "source": "https://codesandbox.io/s/8flefh",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/faucets-select-highlight/pmndrs.json
+++ b/demos/faucets-select-highlight/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Faucets Select Highlight",
+  "description": "",
+  "tags": ["bounds", "highlight", "selection", "metal", "reflections"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/8flefh",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/flexbox-yoga-in-webgl/package.json
+++ b/demos/flexbox-yoga-in-webgl/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@demo/flexbox-yoga-in-webgl",
   "version": "0.1.0",
-  "homepage": "https://codesandbox.io/s/7psew",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^9.109.5",
@@ -41,14 +40,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.0"
   },
-  "keywords": [
-    "layout",
-    "yoga",
-    "scroll",
-    "flexbox",
-    "text"
-  ],
-  "description": "This example uses yoga to create flex-box layouts.",
   "repository": {
     "type": "git",
     "url": "https://github.com/pmndrs/examples/tree/main/demos/flexbox-yoga-in-webgl"

--- a/demos/flexbox-yoga-in-webgl/pmndrs.json
+++ b/demos/flexbox-yoga-in-webgl/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Flexbox Yoga In WebGL",
+  "description": "This example uses yoga to create flex-box layouts.",
+  "tags": ["layout", "yoga", "scroll", "flexbox", "text"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/7psew",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/flex"],
+  "assets": []
+}

--- a/demos/flexbox-yoga-in-webgl/pmndrs.json
+++ b/demos/flexbox-yoga-in-webgl/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Flexbox Yoga In WebGL",
   "description": "This example uses yoga to create flex-box layouts.",
   "tags": ["layout", "yoga", "scroll", "flexbox", "text"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-09-07",
   "source": "https://codesandbox.io/s/7psew",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/flex"],
   "assets": []

--- a/demos/floating-diamonds/package.json
+++ b/demos/floating-diamonds/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/floating-diamonds",
   "version": "1.0.0",
-  "description": "Mixing refraction shaders and animations.",
-  "homepage": "https://codesandbox.io/s/prb9t",
-  "keywords": [
-    "gltf",
-    "refraction",
-    "useframe",
-    "useaspect",
-    "drei"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/floating-diamonds/pmndrs.json
+++ b/demos/floating-diamonds/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Floating Diamonds",
   "description": "Mixing refraction shaders and animations.",
   "tags": ["gltf", "refraction", "useframe", "useaspect", "drei"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-10-29",
   "source": "https://codesandbox.io/s/prb9t",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/floating-diamonds/pmndrs.json
+++ b/demos/floating-diamonds/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Floating Diamonds",
+  "description": "Mixing refraction shaders and animations.",
+  "tags": ["gltf", "refraction", "useframe", "useaspect", "drei"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/prb9t",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/floating-instanced-shoes/package.json
+++ b/demos/floating-instanced-shoes/package.json
@@ -7,13 +7,8 @@
     "react-dom": "^18.3.1",
     "three": "^0.165.0"
   },
-  "keywords": [
-    "instances"
-  ],
   "name": "@demo/floating-instanced-shoes",
   "version": "1.0.0",
-  "description": "Using drei/instances and events.",
-  "homepage": "https://codesandbox.io/s/h8o2d",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/floating-instanced-shoes/pmndrs.json
+++ b/demos/floating-instanced-shoes/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Floating Instanced Shoes",
+  "description": "Using drei/instances and events.",
+  "tags": ["instances"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/h8o2d",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/floating-instanced-shoes/pmndrs.json
+++ b/demos/floating-instanced-shoes/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Floating Instanced Shoes",
   "description": "Using drei/instances and events.",
   "tags": ["instances"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-14",
   "source": "https://codesandbox.io/s/h8o2d",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/floating-laptop/package.json
+++ b/demos/floating-laptop/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/floating-laptop",
   "version": "1.0.0",
-  "description": "Animating GLTFs with react-spring.",
-  "homepage": "https://codesandbox.io/s/q23sw",
-  "keywords": [
-    "gltf",
-    "animation",
-    "react-spring"
-  ],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-spring/web": "^9.7.4",

--- a/demos/floating-laptop/pmndrs.json
+++ b/demos/floating-laptop/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Floating Laptop",
   "description": "Animating GLTFs with react-spring.",
   "tags": ["gltf", "animation", "react-spring"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-06-05",
   "source": "https://codesandbox.io/s/q23sw",
   "libraries": ["@react-spring/three", "@react-spring/web", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/floating-laptop/pmndrs.json
+++ b/demos/floating-laptop/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Floating Laptop",
+  "description": "Animating GLTFs with react-spring.",
+  "tags": ["gltf", "animation", "react-spring"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/q23sw",
+  "libraries": ["@react-spring/three", "@react-spring/web", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/flow-shield/package.json
+++ b/demos/flow-shield/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/flow-shield",
   "version": "1.0.0",
-  "description": "Interactive force-shield playground with hit reactions, presets, and model import.",
-  "homepage": "https://codesandbox.io/s/github/pmndrs/examples/tree/main/demos/flow-shield",
-  "keywords": [
-    "shader",
-    "shield",
-    "postprocessing",
-    "leva"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/flow-shield/pmndrs.json
+++ b/demos/flow-shield/pmndrs.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Flow Shield",
+  "description": "Interactive force-shield playground with hit reactions, presets, and model import.",
+  "tags": ["shader", "shield", "postprocessing", "leva"],
+  "authors": ["Kris Baumgartner"],
+  "publishedAt": "2026-03-24",
+  "source": "https://codesandbox.io/s/github/pmndrs/examples/tree/main/demos/flow-shield",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/flow-shield/pmndrs.json
+++ b/demos/flow-shield/pmndrs.json
@@ -3,9 +3,9 @@
   "title": "Flow Shield",
   "description": "Interactive force-shield playground with hit reactions, presets, and model import.",
   "tags": ["shader", "shield", "postprocessing", "leva"],
-  "authors": ["Kris Baumgartner"],
+  "authors": ["Christian Ortiz"],
   "publishedAt": "2026-03-24",
-  "source": "https://codesandbox.io/s/github/pmndrs/examples/tree/main/demos/flow-shield",
+  "source": "http://github.com/cortiz2894/flow-shield-effect",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []
 }

--- a/demos/flying-bananas/package.json
+++ b/demos/flying-bananas/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/flying-bananas",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/2ycs3",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/flying-bananas/pmndrs.json
+++ b/demos/flying-bananas/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Flying Bananas",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-29",
   "source": "https://codesandbox.io/s/2ycs3",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/flying-bananas/pmndrs.json
+++ b/demos/flying-bananas/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Flying Bananas",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2ycs3",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/frosted-glass/package.json
+++ b/demos/frosted-glass/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/frosted-glass",
   "version": "1.0.0",
-  "description": "Shader mip-map blur to mimic frosted glass. ",
-  "homepage": "https://codesandbox.io/s/imn42",
-  "keywords": [
-    "frosted-glas",
-    "shaders"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/frosted-glass/pmndrs.json
+++ b/demos/frosted-glass/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Frosted Glass",
   "description": "Shader mip-map blur to mimic frosted glass. ",
   "tags": ["frosted-glas", "shaders"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-03-22",
   "source": "https://codesandbox.io/s/imn42",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "valtio"],
   "assets": []

--- a/demos/frosted-glass/pmndrs.json
+++ b/demos/frosted-glass/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Frosted Glass",
+  "description": "Shader mip-map blur to mimic frosted glass. ",
+  "tags": ["frosted-glas", "shaders"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/imn42",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "valtio"],
+  "assets": []
+}

--- a/demos/gatsby-stars/package.json
+++ b/demos/gatsby-stars/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/gatsby-stars",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/2csbr1",
-  "keywords": [
-    "stars",
-    "text",
-    "gradient",
-    "instances",
-    "gatsby"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/gatsby-stars/pmndrs.json
+++ b/demos/gatsby-stars/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Gatsby Stars",
   "description": "",
   "tags": ["stars", "text", "gradient", "instances", "gatsby"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-02-25",
   "source": "https://codesandbox.io/s/2csbr1",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "maath"],
   "assets": []

--- a/demos/gatsby-stars/pmndrs.json
+++ b/demos/gatsby-stars/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Gatsby Stars",
+  "description": "",
+  "tags": ["stars", "text", "gradient", "instances", "gatsby"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2csbr1",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "maath"],
+  "assets": []
+}

--- a/demos/glass-flower/package.json
+++ b/demos/glass-flower/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/glass-flower",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/dq6wwe",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/glass-flower/pmndrs.json
+++ b/demos/glass-flower/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Glass Flower",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-04-13",
   "source": "https://codesandbox.io/s/dq6wwe",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/glass-flower/pmndrs.json
+++ b/demos/glass-flower/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Glass Flower",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/dq6wwe",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/gltf-animations-re-used/package.json
+++ b/demos/gltf-animations-re-used/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/gltf-animations-re-used",
   "version": "1.0.0",
-  "description": "This examples shows how to blend GLTF animation keyframes and to re-use an existing model even it's being keyframed.",
-  "homepage": "https://codesandbox.io/s/k8phr",
-  "keywords": [],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-three/drei": "^9.109.5",

--- a/demos/gltf-animations-re-used/pmndrs.json
+++ b/demos/gltf-animations-re-used/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "GLTF Animations Reused",
   "description": "This examples shows how to blend GLTF animation keyframes and to re-use an existing model even it's being keyframed.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/k8phr",
   "libraries": [
     "@react-spring/three",

--- a/demos/gltf-animations-re-used/pmndrs.json
+++ b/demos/gltf-animations-re-used/pmndrs.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "GLTF Animations Reused",
+  "description": "This examples shows how to blend GLTF animation keyframes and to re-use an existing model even it's being keyframed.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/k8phr",
+  "libraries": [
+    "@react-spring/three",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/gltf-animations-tied-to-scroll/package.json
+++ b/demos/gltf-animations-tied-to-scroll/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/gltf-animations-tied-to-scroll",
   "version": "1.0.0",
-  "description": "This examples shows how to blend GLTF animation keyframes.",
-  "homepage": "https://codesandbox.io/s/hg3ejl",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/gltf-animations-tied-to-scroll/pmndrs.json
+++ b/demos/gltf-animations-tied-to-scroll/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "GLTF Animations Tied To Scroll",
   "description": "This examples shows how to blend GLTF animation keyframes.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-05-15",
   "source": "https://codesandbox.io/s/hg3ejl",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/gltf-animations-tied-to-scroll/pmndrs.json
+++ b/demos/gltf-animations-tied-to-scroll/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "GLTF Animations Tied To Scroll",
+  "description": "This examples shows how to blend GLTF animation keyframes.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/hg3ejl",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/gltf-animations/package.json
+++ b/demos/gltf-animations/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/gltf-animations",
   "version": "1.0.0",
-  "description": "This examples shows how to blend GLTF animation keyframes.",
-  "homepage": "https://codesandbox.io/s/pecl6",
-  "keywords": [
-    "skinnedmesh",
-    "gltf",
-    "bones",
-    "animations",
-    "useanimations"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/gltf-animations/pmndrs.json
+++ b/demos/gltf-animations/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "GLTF Animations",
+  "description": "This examples shows how to blend GLTF animation keyframes.",
+  "tags": ["skinnedmesh", "gltf", "bones", "animations", "useanimations"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/pecl6",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/gltf-animations/pmndrs.json
+++ b/demos/gltf-animations/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "GLTF Animations",
   "description": "This examples shows how to blend GLTF animation keyframes.",
   "tags": ["skinnedmesh", "gltf", "bones", "animations", "useanimations"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-12-06",
   "source": "https://codesandbox.io/s/pecl6",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/gltfjsx-400kb-drone/package.json
+++ b/demos/gltfjsx-400kb-drone/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/gltfjsx-400kb-drone",
   "version": "1.0.0",
-  "description": "Shows the results of gltfjsx transform compression.",
-  "homepage": "https://codesandbox.io/s/pbwi6i",
-  "keywords": [
-    "bloom",
-    "gltfjsx",
-    "drone"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/gltfjsx-400kb-drone/pmndrs.json
+++ b/demos/gltfjsx-400kb-drone/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "GLTFJSX 400KB Drone",
   "description": "Shows the results of gltfjsx transform compression.",
   "tags": ["bloom", "gltfjsx", "drone"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-12-29",
   "source": "https://codesandbox.io/s/pbwi6i",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "maath"],
   "assets": []

--- a/demos/gltfjsx-400kb-drone/pmndrs.json
+++ b/demos/gltfjsx-400kb-drone/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "GLTFJSX 400KB Drone",
+  "description": "Shows the results of gltfjsx transform compression.",
+  "tags": ["bloom", "gltfjsx", "drone"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/pbwi6i",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "maath"],
+  "assets": []
+}

--- a/demos/gpgpu-curl-noise-dof/package.json
+++ b/demos/gpgpu-curl-noise-dof/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/gpgpu-curl-noise-dof",
   "version": "1.0.0",
-  "description": "Curl noise and depth of field.",
-  "homepage": "https://codesandbox.io/s/zgsyn",
-  "keywords": [
-    "gpu",
-    "shader",
-    "curl",
-    "dof"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/gpgpu-curl-noise-dof/pmndrs.json
+++ b/demos/gpgpu-curl-noise-dof/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "GPGPU Curl Noise DOF",
+  "description": "Curl noise and depth of field.",
+  "tags": ["gpu", "shader", "curl", "dof"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/zgsyn",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/gpgpu-curl-noise-dof/pmndrs.json
+++ b/demos/gpgpu-curl-noise-dof/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "GPGPU Curl Noise DOF",
   "description": "Curl noise and depth of field.",
   "tags": ["gpu", "shader", "curl", "dof"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-05",
   "source": "https://codesandbox.io/s/zgsyn",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/grass-shader/package.json
+++ b/demos/grass-shader/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/grass-shader",
   "version": "1.0.0",
-  "description": "Grass shader using simplex noise.",
-  "homepage": "https://codesandbox.io/s/5xho4",
-  "keywords": [
-    "noise",
-    "shader",
-    "simplex",
-    "grass"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/grass-shader/pmndrs.json
+++ b/demos/grass-shader/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Grass Shader",
+  "description": "Grass shader using simplex noise.",
+  "tags": ["noise", "shader", "simplex", "grass"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/5xho4",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/grass-shader/pmndrs.json
+++ b/demos/grass-shader/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Grass Shader",
   "description": "Grass shader using simplex noise.",
   "tags": ["noise", "shader", "simplex", "grass"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-06-10",
   "source": "https://codesandbox.io/s/5xho4",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/ground-projected-envmaps-lamina/package.json
+++ b/demos/ground-projected-envmaps-lamina/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/ground-projected-envmaps-lamina",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/0c5hv9",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/ground-projected-envmaps-lamina/pmndrs.json
+++ b/demos/ground-projected-envmaps-lamina/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Ground Projected Env Maps Lamina",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-04-08",
   "source": "https://codesandbox.io/s/0c5hv9",
   "libraries": ["@react-three/drei", "@react-three/fiber", "lamina"],
   "assets": []

--- a/demos/ground-projected-envmaps-lamina/pmndrs.json
+++ b/demos/ground-projected-envmaps-lamina/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Ground Projected Env Maps Lamina",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0c5hv9",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "lamina"],
+  "assets": []
+}

--- a/demos/ground-reflections-and-video-textures/package.json
+++ b/demos/ground-reflections-and-video-textures/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/ground-reflections-and-video-textures",
   "version": "1.0.0",
-  "description": "This example shows drei's new Reflector in combination with video textures.",
-  "homepage": "https://codesandbox.io/s/bfplr",
-  "keywords": [
-    "reflections"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/ground-reflections-and-video-textures/pmndrs.json
+++ b/demos/ground-reflections-and-video-textures/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Ground Reflections And Video Textures",
   "description": "This example shows drei's new Reflector in combination with video textures.",
   "tags": ["reflections"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-01-26",
   "source": "https://codesandbox.io/s/bfplr",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/ground-reflections-and-video-textures/pmndrs.json
+++ b/demos/ground-reflections-and-video-textures/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Ground Reflections And Video Textures",
+  "description": "This example shows drei's new Reflector in combination with video textures.",
+  "tags": ["reflections"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/bfplr",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/hi-key-bubbles/package.json
+++ b/demos/hi-key-bubbles/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/hi-key-bubbles",
   "version": "1.0.0",
-  "description": "Shows to use drei/instances how far gamma-correction can stretch colors.",
-  "homepage": "https://codesandbox.io/s/i6t0j",
-  "keywords": [
-    "instances"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/hi-key-bubbles/pmndrs.json
+++ b/demos/hi-key-bubbles/pmndrs.json
@@ -5,7 +5,8 @@
   "tags": [
     "instances"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-17",
   "source": "https://codesandbox.io/s/i6t0j",
   "libraries": [
     "@react-three/drei",

--- a/demos/hi-key-bubbles/pmndrs.json
+++ b/demos/hi-key-bubbles/pmndrs.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "High-key Bubbles",
+  "description": "Shows to use drei/instances how far gamma-correction can stretch colors.",
+  "tags": [
+    "instances"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/i6t0j",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing"
+  ],
+  "assets": []
+}

--- a/demos/horizontal-tiles/package.json
+++ b/demos/horizontal-tiles/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/horizontal-tiles",
   "version": "1.0.0",
-  "description": "Horizontal scrollcontrols with expanding tiles.",
-  "homepage": "https://codesandbox.io/s/l4klb",
-  "keywords": [
-    "expand",
-    "scrollcontrols",
-    "tiles",
-    "horizontal"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/horizontal-tiles/pmndrs.json
+++ b/demos/horizontal-tiles/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Horizontal Tiles",
   "description": "Horizontal scrollcontrols with expanding tiles.",
   "tags": ["expand", "scrollcontrols", "tiles", "horizontal"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-16",
   "source": "https://codesandbox.io/s/l4klb",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "valtio"],
   "assets": []

--- a/demos/horizontal-tiles/pmndrs.json
+++ b/demos/horizontal-tiles/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Horizontal Tiles",
+  "description": "Horizontal scrollcontrols with expanding tiles.",
+  "tags": ["expand", "scrollcontrols", "tiles", "horizontal"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/l4klb",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "valtio"],
+  "assets": []
+}

--- a/demos/html-annotations/package.json
+++ b/demos/html-annotations/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/html-annotations",
   "version": "1.0.0",
-  "description": "Shows how to set up annotations with a distance factor.",
-  "homepage": "https://codesandbox.io/s/zu2wo",
-  "keywords": [
-    "distance",
-    "html",
-    "annotations"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/html-annotations/pmndrs.json
+++ b/demos/html-annotations/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "HTML Annotations",
+  "description": "Shows how to set up annotations with a distance factor.",
+  "tags": ["distance", "html", "annotations"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/zu2wo",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/html-annotations/pmndrs.json
+++ b/demos/html-annotations/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "HTML Annotations",
   "description": "Shows how to set up annotations with a distance factor.",
   "tags": ["distance", "html", "annotations"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-11-27",
   "source": "https://codesandbox.io/s/zu2wo",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/html-input-fields/package.json
+++ b/demos/html-input-fields/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/html-input-fields",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/024uom",
-  "keywords": [
-    "text",
-    "html",
-    "input"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/html-input-fields/pmndrs.json
+++ b/demos/html-input-fields/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "HTML Input Fields",
+  "description": "",
+  "tags": ["text", "html", "input"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/024uom",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/html-input-fields/pmndrs.json
+++ b/demos/html-input-fields/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "HTML Input Fields",
   "description": "",
   "tags": ["text", "html", "input"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-12-06",
   "source": "https://codesandbox.io/s/024uom",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/html-markers/package.json
+++ b/demos/html-markers/package.json
@@ -28,15 +28,8 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "keywords": [
-    "annotations",
-    "html",
-    "markers"
-  ],
   "name": "@demo/html-markers",
   "version": "1.0.0",
-  "description": "Occluding HTML annotations/markers.",
-  "homepage": "https://codesandbox.io/s/6oei7",
   "type": "module",
   "repository": {
     "type": "git",

--- a/demos/html-markers/pmndrs.json
+++ b/demos/html-markers/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "HTML Markers",
+  "description": "Occluding HTML annotations/markers.",
+  "tags": ["annotations", "html", "markers"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/6oei7",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/html-markers/pmndrs.json
+++ b/demos/html-markers/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "HTML Markers",
   "description": "Occluding HTML annotations/markers.",
   "tags": ["annotations", "html", "markers"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-06-23",
   "source": "https://codesandbox.io/s/6oei7",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/image-gallery/package.json
+++ b/demos/image-gallery/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/image-gallery",
   "version": "1.0.0",
-  "description": "Stage a couple of frames with a reflective, blurred out ground.",
-  "homepage": "https://codesandbox.io/s/lx2h8",
-  "keywords": [
-    "image",
-    "meshreflectormaterial"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/image-gallery/pmndrs.json
+++ b/demos/image-gallery/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Image Gallery",
+  "description": "Stage a couple of frames with a reflective, blurred out ground.",
+  "tags": ["image", "meshreflectormaterial"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/lx2h8",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],
+  "assets": []
+}

--- a/demos/image-gallery/pmndrs.json
+++ b/demos/image-gallery/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Image Gallery",
   "description": "Stage a couple of frames with a reflective, blurred out ground.",
   "tags": ["image", "meshreflectormaterial"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-01-05",
   "source": "https://codesandbox.io/s/lx2h8",
   "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],
   "assets": []

--- a/demos/infinite-scroll/package.json
+++ b/demos/infinite-scroll/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/infinite-scroll",
   "version": "1.0.0",
-  "description": "Horizontal scrollcontrols that scroll infinitely.",
-  "homepage": "https://codesandbox.io/s/x8gvs",
-  "keywords": [
-    "horizontal",
-    "scrollcontrols",
-    "infinite"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/infinite-scroll/pmndrs.json
+++ b/demos/infinite-scroll/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Infinite Scroll",
   "description": "Horizontal scrollcontrols that scroll infinitely.",
   "tags": ["horizontal", "scrollcontrols", "infinite"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-16",
   "source": "https://codesandbox.io/s/x8gvs",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/infinite-scroll/pmndrs.json
+++ b/demos/infinite-scroll/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Infinite Scroll",
+  "description": "Horizontal scrollcontrols that scroll infinitely.",
+  "tags": ["horizontal", "scrollcontrols", "infinite"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/x8gvs",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/instanced-particles-effects/package.json
+++ b/demos/instanced-particles-effects/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/instanced-particles-effects",
   "version": "1.0.0",
-  "description": "Instancing, swirling particles and effects.",
-  "homepage": "https://codesandbox.io/s/qpfgyp",
-  "keywords": [
-    "effects",
-    "film",
-    "water",
-    "bloom",
-    "particles"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/instanced-particles-effects/pmndrs.json
+++ b/demos/instanced-particles-effects/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Instanced Particles Effects",
+  "description": "Instancing, swirling particles and effects.",
+  "tags": ["effects", "film", "water", "bloom", "particles"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/qpfgyp",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/instanced-particles-effects/pmndrs.json
+++ b/demos/instanced-particles-effects/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Instanced Particles Effects",
   "description": "Instancing, swirling particles and effects.",
   "tags": ["effects", "film", "water", "bloom", "particles"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-12-07",
   "source": "https://codesandbox.io/s/qpfgyp",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/instanced-vertex-colors/package.json
+++ b/demos/instanced-vertex-colors/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/instanced-vertex-colors",
   "version": "1.0.0",
-  "description": "Instancing objectes with variable colors and effects.",
-  "homepage": "https://codesandbox.io/s/8fo01",
-  "keywords": [
-    "vertex-colors",
-    "ambient-occlusion",
-    "bloom",
-    "instancing"
-  ],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "@react-three/postprocessing": "^2.16.2",

--- a/demos/instanced-vertex-colors/pmndrs.json
+++ b/demos/instanced-vertex-colors/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Instanced Vertex Colors",
   "description": "Instancing objectes with variable colors and effects.",
   "tags": ["vertex-colors", "ambient-occlusion", "bloom", "instancing"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-01-18",
   "source": "https://codesandbox.io/s/8fo01",
   "libraries": ["@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/instanced-vertex-colors/pmndrs.json
+++ b/demos/instanced-vertex-colors/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Instanced Vertex Colors",
+  "description": "Instancing objectes with variable colors and effects.",
+  "tags": ["vertex-colors", "ambient-occlusion", "bloom", "instancing"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/8fo01",
+  "libraries": ["@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/instances/package.json
+++ b/demos/instances/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/instances",
   "version": "1.0.0",
-  "description": "Creating fixed-position instances with varying vertex colors.",
-  "homepage": "https://codesandbox.io/s/h873k",
-  "keywords": [
-    "instances",
-    "vertex-colors"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/instances/pmndrs.json
+++ b/demos/instances/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Instances",
+  "description": "Creating fixed-position instances with varying vertex colors.",
+  "tags": ["instances", "vertex-colors"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/h873k",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/instances/pmndrs.json
+++ b/demos/instances/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Instances",
   "description": "Creating fixed-position instances with varying vertex colors.",
   "tags": ["instances", "vertex-colors"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-10-02",
   "source": "https://codesandbox.io/s/h873k",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/inter-epoxy-resin/package.json
+++ b/demos/inter-epoxy-resin/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/inter-epoxy-resin",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/lxvqek",
-  "keywords": [
-    "refraction",
-    "shaders",
-    "glass",
-    "epoxy"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/inter-epoxy-resin/pmndrs.json
+++ b/demos/inter-epoxy-resin/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Inter Epoxy Resin",
+  "description": "",
+  "tags": ["refraction", "shaders", "glass", "epoxy"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/lxvqek",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/inter-epoxy-resin/pmndrs.json
+++ b/demos/inter-epoxy-resin/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Inter Epoxy Resin",
   "description": "",
   "tags": ["refraction", "shaders", "glass", "epoxy"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-10-25",
   "source": "https://codesandbox.io/s/lxvqek",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []

--- a/demos/interactive-spline-scene-live-html/package.json
+++ b/demos/interactive-spline-scene-live-html/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/interactive-spline-scene-live-html",
   "version": "1.0.0",
-  "description": "Scene exported with Spline",
-  "homepage": "https://codesandbox.io/s/f79ucc",
-  "keywords": [
-    "spline",
-    "stencil"
-  ],
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.2.0",

--- a/demos/interactive-spline-scene-live-html/pmndrs.json
+++ b/demos/interactive-spline-scene-live-html/pmndrs.json
@@ -2,8 +2,9 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Interactive Spline Scene Live HTML",
   "description": "Scene exported with Spline",
-  "tags": ["spline", "stencil"],
-  "authors": [],
+  "tags": ["spline", "stencil", "html"],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-06-15",
   "source": "https://codesandbox.io/s/f79ucc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/interactive-spline-scene-live-html/pmndrs.json
+++ b/demos/interactive-spline-scene-live-html/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Interactive Spline Scene Live HTML",
+  "description": "Scene exported with Spline",
+  "tags": ["spline", "stencil"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/f79ucc",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/inverted-stencil-buffer/package.json
+++ b/demos/inverted-stencil-buffer/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/inverted-stencil-buffer",
   "version": "1.0.0",
-  "description": "How to invert a masked stencil.",
-  "homepage": "https://codesandbox.io/s/7n2yru",
-  "keywords": [
-    "stencil",
-    "drei",
-    "portal"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/inverted-stencil-buffer/pmndrs.json
+++ b/demos/inverted-stencil-buffer/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Inverted Stencil Buffer",
+  "description": "How to invert a masked stencil.",
+  "tags": ["stencil", "drei", "portal"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/7n2yru",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/inverted-stencil-buffer/pmndrs.json
+++ b/demos/inverted-stencil-buffer/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Inverted Stencil Buffer",
   "description": "How to invert a masked stencil.",
   "tags": ["stencil", "drei", "portal"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-05-20",
   "source": "https://codesandbox.io/s/7n2yru",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/iridescent-decals/package.json
+++ b/demos/iridescent-decals/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/iridescent-decals",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/qvb1vk",
-  "keywords": [
-    "decal"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/iridescent-decals/pmndrs.json
+++ b/demos/iridescent-decals/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Iridescent Decals",
+  "description": "",
+  "tags": ["decal"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/qvb1vk",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/iridescent-decals/pmndrs.json
+++ b/demos/iridescent-decals/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Iridescent Decals",
   "description": "",
   "tags": ["decal"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-12-30",
   "source": "https://codesandbox.io/s/qvb1vk",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/lamina-1x/package.json
+++ b/demos/lamina-1x/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/lamina-1x",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/ledhe1",
-  "keywords": [
-    "lamina",
-    "depth"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/lamina-1x/pmndrs.json
+++ b/demos/lamina-1x/pmndrs.json
@@ -6,7 +6,8 @@
     "lamina",
     "depth"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-15",
   "source": "https://codesandbox.io/s/ledhe1",
   "libraries": [
     "@pmndrs/branding",

--- a/demos/lamina-1x/pmndrs.json
+++ b/demos/lamina-1x/pmndrs.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Lamina 1.x",
+  "description": "",
+  "tags": [
+    "lamina",
+    "depth"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ledhe1",
+  "libraries": [
+    "@pmndrs/branding",
+    "@react-three/drei",
+    "@react-three/fiber",
+    "lamina"
+  ],
+  "assets": []
+}

--- a/demos/landing-page/package.json
+++ b/demos/landing-page/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/landing-page",
   "version": "1.0.0",
-  "description": "Transparent backdrop and model staging",
-  "homepage": "https://codesandbox.io/s/n60qg",
-  "keywords": [
-    "contact shadows"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/landing-page/pmndrs.json
+++ b/demos/landing-page/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Landing Page",
   "description": "Transparent backdrop and model staging",
   "tags": ["contact shadows"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-21",
   "source": "https://codesandbox.io/s/n60qg",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/landing-page/pmndrs.json
+++ b/demos/landing-page/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Landing Page",
+  "description": "Transparent backdrop and model staging",
+  "tags": ["contact shadows"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/n60qg",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/learn-with-jason/package.json
+++ b/demos/learn-with-jason/package.json
@@ -31,12 +31,6 @@
       "last 1 safari version"
     ]
   },
-  "keywords": [
-    "animation",
-    "gltf"
-  ],
-  "description": "Small example made for a Learn-with-Jason episode.",
-  "homepage": "https://codesandbox.io/s/oep9o",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/learn-with-jason/pmndrs.json
+++ b/demos/learn-with-jason/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Learn With Jason",
+  "description": "Small example made for a Learn-with-Jason episode.",
+  "tags": ["animation", "gltf"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/oep9o",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/learn-with-jason/pmndrs.json
+++ b/demos/learn-with-jason/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Learn With Jason",
   "description": "Small example made for a Learn-with-Jason episode.",
   "tags": ["animation", "gltf"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/oep9o",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/lulaby-city/package.json
+++ b/demos/lulaby-city/package.json
@@ -54,13 +54,6 @@
       "last 1 safari version"
     ]
   },
-  "keywords": [
-    "positional",
-    "gltf",
-    "audio"
-  ],
-  "description": "Panning around a city with positional audio.",
-  "homepage": "https://codesandbox.io/s/gkfhr",
   "type": "module",
   "repository": {
     "type": "git",

--- a/demos/lulaby-city/pmndrs.json
+++ b/demos/lulaby-city/pmndrs.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Lullaby City",
+  "description": "Panning around a city with positional audio.",
+  "tags": [
+    "positional",
+    "gltf",
+    "audio"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/gkfhr",
+  "libraries": [
+    "@pmndrs/branding",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/lulaby-city/pmndrs.json
+++ b/demos/lulaby-city/pmndrs.json
@@ -7,7 +7,8 @@
     "gltf",
     "audio"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-02-10",
   "source": "https://codesandbox.io/s/gkfhr",
   "libraries": [
     "@pmndrs/branding",

--- a/demos/lusion-connectors/package.json
+++ b/demos/lusion-connectors/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/lusion-connectors",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/xy8c8z",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/lusion-connectors/pmndrs.json
+++ b/demos/lusion-connectors/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Lusion Connectors",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-09-12",
   "source": "https://codesandbox.io/s/xy8c8z",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier"],
   "assets": []

--- a/demos/lusion-connectors/pmndrs.json
+++ b/demos/lusion-connectors/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Lusion Connectors",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/xy8c8z",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier"],
+  "assets": []
+}

--- a/demos/magic-box/package.json
+++ b/demos/magic-box/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/magic-box",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/drc6qg",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/magic-box/pmndrs.json
+++ b/demos/magic-box/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Magic Box",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-06-07",
   "source": "https://codesandbox.io/s/drc6qg",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/magic-box/pmndrs.json
+++ b/demos/magic-box/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Magic Box",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/drc6qg",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/merged-instance/package.json
+++ b/demos/merged-instance/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/merged-instance",
   "version": "1.0.0",
-  "description": "Loading massive assemblies and re-using their parts while keeping the natural  scene graph alive.",
-  "homepage": "https://codesandbox.io/s/kud9p",
-  "keywords": [
-    "batching",
-    "merging",
-    "instancing"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/merged-instance/pmndrs.json
+++ b/demos/merged-instance/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Merged Instance",
+  "description": "Loading massive assemblies and re-using their parts while keeping the natural  scene graph alive.",
+  "tags": ["batching", "merging", "instancing"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/kud9p",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/merged-instance/pmndrs.json
+++ b/demos/merged-instance/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Merged Instance",
   "description": "Loading massive assemblies and re-using their parts while keeping the natural  scene graph alive.",
   "tags": ["batching", "merging", "instancing"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-19",
   "source": "https://codesandbox.io/s/kud9p",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/minecraft/package.json
+++ b/demos/minecraft/package.json
@@ -34,13 +34,6 @@
       "last 1 safari version"
     ]
   },
-  "keywords": [
-    "pointerlock-controls",
-    "game",
-    "minecraft"
-  ],
-  "description": "Mini Minecraft implementation.",
-  "homepage": "https://codesandbox.io/s/vkgi6",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/minecraft/pmndrs.json
+++ b/demos/minecraft/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Minecraft",
   "description": "Mini Minecraft implementation.",
   "tags": ["pointerlock-controls", "game", "minecraft"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-09-09",
   "source": "https://codesandbox.io/s/vkgi6",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/rapier", "zustand"],
   "assets": []

--- a/demos/minecraft/pmndrs.json
+++ b/demos/minecraft/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Minecraft",
+  "description": "Mini Minecraft implementation.",
+  "tags": ["pointerlock-controls", "game", "minecraft"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/vkgi6",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/rapier", "zustand"],
+  "assets": []
+}

--- a/demos/mixing-controls/package.json
+++ b/demos/mixing-controls/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/mixing-controls",
   "version": "1.0.0",
-  "description": "Switching off one control while the other is active.",
-  "homepage": "https://codesandbox.io/s/hf1cs",
-  "keywords": [
-    "orbit-controls",
-    "controls",
-    "transform-controls"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/mixing-controls/pmndrs.json
+++ b/demos/mixing-controls/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Mixing Controls",
+  "description": "Switching off one control while the other is active.",
+  "tags": ["orbit-controls", "controls", "transform-controls"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/hf1cs",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/mixing-controls/pmndrs.json
+++ b/demos/mixing-controls/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Mixing Controls",
   "description": "Switching off one control while the other is active.",
   "tags": ["orbit-controls", "controls", "transform-controls"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-09-10",
   "source": "https://codesandbox.io/s/hf1cs",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/mixing-html-and-webgl-w-occlusion/package.json
+++ b/demos/mixing-html-and-webgl-w-occlusion/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/mixing-html-and-webgl-w-occlusion",
   "version": "1.0.0",
-  "description": "Having HTML and WebGL in the same scene with the addition of occlusion.",
-  "homepage": "https://codesandbox.io/s/9keg6",
-  "keywords": [
-    "occlusion",
-    "drei",
-    "html"
-  ],
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.2.0",

--- a/demos/mixing-html-and-webgl-w-occlusion/pmndrs.json
+++ b/demos/mixing-html-and-webgl-w-occlusion/pmndrs.json
@@ -7,7 +7,8 @@
     "drei",
     "html"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-05-29",
   "source": "https://codesandbox.io/s/9keg6",
   "libraries": [
     "@react-three/drei",

--- a/demos/mixing-html-and-webgl-w-occlusion/pmndrs.json
+++ b/demos/mixing-html-and-webgl-w-occlusion/pmndrs.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Mixing HTML and WebGL with Occlusion",
+  "description": "Having HTML and WebGL in the same scene with the addition of occlusion.",
+  "tags": [
+    "occlusion",
+    "drei",
+    "html"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/9keg6",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/mixing-html-and-webgl/package.json
+++ b/demos/mixing-html-and-webgl/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/mixing-html-and-webgl",
   "version": "1.0.0",
-  "description": "Adding HTML into the scene.",
-  "homepage": "https://codesandbox.io/s/7ucso",
-  "keywords": [
-    "html",
-    "transforms",
-    "drei"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/mixing-html-and-webgl/pmndrs.json
+++ b/demos/mixing-html-and-webgl/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Mixing HTML And WebGL",
+  "description": "Adding HTML into the scene.",
+  "tags": ["html", "transforms", "drei"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/7ucso",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/mixing-html-and-webgl/pmndrs.json
+++ b/demos/mixing-html-and-webgl/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Mixing HTML And WebGL",
   "description": "Adding HTML into the scene.",
   "tags": ["html", "transforms", "drei"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-03-24",
   "source": "https://codesandbox.io/s/7ucso",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/moksha/package.json
+++ b/demos/moksha/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/moksha",
   "version": "1.0.0",
-  "description": "Exploration into scroll containers tied to webgl content made for codrops.",
-  "homepage": "https://codesandbox.io/s/f1ixt",
-  "keywords": [
-    "codrops",
-    "shaders",
-    "refraction",
-    "scroll",
-    "gltf"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/moksha/pmndrs.json
+++ b/demos/moksha/pmndrs.json
@@ -2,8 +2,9 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Moksha",
   "description": "Exploration into scroll containers tied to webgl content made for codrops.",
-  "tags": ["codrops", "shaders", "refraction", "scroll", "gltf"],
-  "authors": [],
+  "tags": ["codrops", "shaders", "refraction", "scroll", "gltf", "html"],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-12-16",
   "source": "https://codesandbox.io/s/f1ixt",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/moksha/pmndrs.json
+++ b/demos/moksha/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Moksha",
+  "description": "Exploration into scroll containers tied to webgl content made for codrops.",
+  "tags": ["codrops", "shaders", "refraction", "scroll", "gltf"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/f1ixt",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/monitors/package.json
+++ b/demos/monitors/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/monitors",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/bst0cy",
-  "keywords": [
-    "bloom"
-  ],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",

--- a/demos/monitors/pmndrs.json
+++ b/demos/monitors/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Monitors",
+  "description": "",
+  "tags": ["bloom"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/bst0cy",
+  "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "maath"],
+  "assets": []
+}

--- a/demos/monitors/pmndrs.json
+++ b/demos/monitors/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Monitors",
   "description": "",
   "tags": ["bloom"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-12-15",
   "source": "https://codesandbox.io/s/bst0cy",
   "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "maath"],
   "assets": []

--- a/demos/motionpathcontrols/package.json
+++ b/demos/motionpathcontrols/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/motionpathcontrols",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/2y73c6",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/motionpathcontrols/pmndrs.json
+++ b/demos/motionpathcontrols/pmndrs.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "MotionPathControls",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2y73c6",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing",
+    "leva"
+  ],
+  "assets": []
+}

--- a/demos/motionpathcontrols/pmndrs.json
+++ b/demos/motionpathcontrols/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "MotionPathControls",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-09-17",
   "source": "https://codesandbox.io/s/2y73c6",
   "libraries": [
     "@react-three/drei",

--- a/demos/mount-transitions/package.json
+++ b/demos/mount-transitions/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/mount-transitions",
   "version": "1.0.0",
-  "description": "Shows how to use react-spring mount/unmount transitions, soft-shadows and AO.",
-  "homepage": "https://codesandbox.io/s/1sccp",
-  "keywords": [
-    "soft-shadows",
-    "animation",
-    "ambient-occlusion",
-    "transitions",
-    "react-spring"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-spring/three": "^9.7.3",

--- a/demos/mount-transitions/pmndrs.json
+++ b/demos/mount-transitions/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Mount Transitions",
   "description": "Shows how to use react-spring mount/unmount transitions, soft-shadows and AO.",
   "tags": ["soft-shadows", "animation", "ambient-occlusion", "transitions", "react-spring"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-09-18",
   "source": "https://codesandbox.io/s/1sccp",
   "libraries": ["@pmndrs/branding", "@react-spring/three", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/mount-transitions/pmndrs.json
+++ b/demos/mount-transitions/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Mount Transitions",
+  "description": "Shows how to use react-spring mount/unmount transitions, soft-shadows and AO.",
+  "tags": ["soft-shadows", "animation", "ambient-occlusion", "transitions", "react-spring"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/1sccp",
+  "libraries": ["@pmndrs/branding", "@react-spring/three", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/multiple-views-with-uniform-controls/package.json
+++ b/demos/multiple-views-with-uniform-controls/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/multiple-views-with-uniform-controls",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/r9w2ob",
-  "keywords": [],
   "dependencies": {
     "@mantine/core": "^5.10.5",
     "@mantine/hooks": "^5.10.1",

--- a/demos/multiple-views-with-uniform-controls/pmndrs.json
+++ b/demos/multiple-views-with-uniform-controls/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Multiple Views With Uniform Controls",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-19",
   "source": "https://codesandbox.io/s/r9w2ob",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/multiple-views-with-uniform-controls/pmndrs.json
+++ b/demos/multiple-views-with-uniform-controls/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Multiple Views With Uniform Controls",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/r9w2ob",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/nextjs-prism/package.json
+++ b/demos/nextjs-prism/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/nextjs-prism",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/j3ycvl",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/nextjs-prism/pmndrs.json
+++ b/demos/nextjs-prism/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Next.js Prism",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-08-17",
   "source": "https://codesandbox.io/s/j3ycvl",
   "libraries": [
     "@react-three/drei",

--- a/demos/nextjs-prism/pmndrs.json
+++ b/demos/nextjs-prism/pmndrs.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Next.js Prism",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/j3ycvl",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing"
+  ],
+  "assets": []
+}

--- a/demos/night-train/package.json
+++ b/demos/night-train/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/night-train",
   "version": "1.0.0",
-  "description": "Stacking a couple of drei helpers",
-  "homepage": "https://codesandbox.io/s/l900i",
-  "keywords": [
-    "merged",
-    "scroll-controls",
-    "meshreflectormaterial",
-    "instances"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/night-train/pmndrs.json
+++ b/demos/night-train/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Night Train",
+  "description": "Stacking a couple of drei helpers",
+  "tags": ["merged", "scroll-controls", "meshreflectormaterial", "instances"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/l900i",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/night-train/pmndrs.json
+++ b/demos/night-train/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Night Train",
   "description": "Stacking a couple of drei helpers",
   "tags": ["merged", "scroll-controls", "meshreflectormaterial", "instances"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-08-07",
   "source": "https://codesandbox.io/s/l900i",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/object-clump/package.json
+++ b/demos/object-clump/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/object-clump",
   "version": "1.0.0",
-  "description": "How to make a clump of objects that move towards the center point.",
-  "homepage": "https://codesandbox.io/s/ssbdsw",
-  "keywords": [
-    "physics",
-    "cannon-es",
-    "use-cannon"
-  ],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/object-clump/pmndrs.json
+++ b/demos/object-clump/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Object Clump",
   "description": "How to make a clump of objects that move towards the center point.",
   "tags": ["physics", "cannon-es", "use-cannon"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-02-22",
   "source": "https://codesandbox.io/s/ssbdsw",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []

--- a/demos/object-clump/pmndrs.json
+++ b/demos/object-clump/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Object Clump",
+  "description": "How to make a clump of objects that move towards the center point.",
+  "tags": ["physics", "cannon-es", "use-cannon"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ssbdsw",
+  "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/pairing-threejs-to-ui/package.json
+++ b/demos/pairing-threejs-to-ui/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/pairing-threejs-to-ui",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/wlz1o0",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/pairing-threejs-to-ui/pmndrs.json
+++ b/demos/pairing-threejs-to-ui/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Pairing Three.js To UI",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-07-04",
   "source": "https://codesandbox.io/s/wlz1o0",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva", "tunnel-rat"],
   "assets": []

--- a/demos/pairing-threejs-to-ui/pmndrs.json
+++ b/demos/pairing-threejs-to-ui/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Pairing Three.js To UI",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/wlz1o0",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva", "tunnel-rat"],
+  "assets": []
+}

--- a/demos/pass-through-portals/package.json
+++ b/demos/pass-through-portals/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/pass-through-portals",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/qvk72r",
-  "keywords": [
-    "portal"
-  ],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",

--- a/demos/pass-through-portals/pmndrs.json
+++ b/demos/pass-through-portals/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Pass Through Portals",
+  "description": "",
+  "tags": ["portal"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/qvk72r",
+  "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/pass-through-portals/pmndrs.json
+++ b/demos/pass-through-portals/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Pass Through Portals",
   "description": "",
   "tags": ["portal"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-06-17",
   "source": "https://codesandbox.io/s/qvk72r",
   "libraries": ["@pmndrs/assets", "@pmndrs/branding", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/physics-with-convex-polyhedrons/package.json
+++ b/demos/physics-with-convex-polyhedrons/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/physics-with-convex-polyhedrons",
   "version": "1.0.0",
-  "description": "Using cannon collisions with GLTFs converted into convex hulls.",
-  "homepage": "https://codesandbox.io/s/08s1u",
-  "keywords": [
-    "physics",
-    "collisions",
-    "convex-polyhedron",
-    "cannon",
-    "gltf"
-  ],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/physics-with-convex-polyhedrons/pmndrs.json
+++ b/demos/physics-with-convex-polyhedrons/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Physics With Convex Polyhedrons",
   "description": "Using cannon collisions with GLTFs converted into convex hulls.",
   "tags": ["physics", "collisions", "convex-polyhedron", "cannon", "gltf"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-03-13",
   "source": "https://codesandbox.io/s/08s1u",
   "libraries": [
     "@react-three/cannon",

--- a/demos/physics-with-convex-polyhedrons/pmndrs.json
+++ b/demos/physics-with-convex-polyhedrons/pmndrs.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Physics With Convex Polyhedrons",
+  "description": "Using cannon collisions with GLTFs converted into convex hulls.",
+  "tags": ["physics", "collisions", "convex-polyhedron", "cannon", "gltf"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/08s1u",
+  "libraries": [
+    "@react-three/cannon",
+    "@react-three/drei",
+    "@react-three/fiber",
+    "three-stdlib"
+  ],
+  "assets": []
+}

--- a/demos/pinball-in-70-lines/package.json
+++ b/demos/pinball-in-70-lines/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/pinball-in-70-lines",
   "version": "1.0.0",
-  "description": "Super small pinball barebones implementation.",
-  "homepage": "https://codesandbox.io/s/rmfcq",
-  "keywords": [
-    "cannon-es",
-    "physics",
-    "pinball",
-    "arkanoid",
-    "game"
-  ],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/pinball-in-70-lines/pmndrs.json
+++ b/demos/pinball-in-70-lines/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Pinball In 70 Lines",
+  "description": "Super small pinball barebones implementation.",
+  "tags": ["cannon-es", "physics", "pinball", "arkanoid", "game"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/rmfcq",
+  "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/pinball-in-70-lines/pmndrs.json
+++ b/demos/pinball-in-70-lines/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Pinball In 70 Lines",
   "description": "Super small pinball barebones implementation.",
   "tags": ["cannon-es", "physics", "pinball", "arkanoid", "game"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-08-02",
   "source": "https://codesandbox.io/s/rmfcq",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/pmndrs-vercel/package.json
+++ b/demos/pmndrs-vercel/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/pmndrs-vercel",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/go0b4w",
-  "keywords": [
-    "gradient",
-    "lamina"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/cannon": "^6.6.0",

--- a/demos/pmndrs-vercel/pmndrs.json
+++ b/demos/pmndrs-vercel/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "pmndrs Vercel",
+  "description": "",
+  "tags": ["gradient", "lamina"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/go0b4w",
+  "libraries": ["@pmndrs/branding", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "lamina"],
+  "assets": []
+}

--- a/demos/pmndrs-vercel/pmndrs.json
+++ b/demos/pmndrs-vercel/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "pmndrs Vercel",
   "description": "",
   "tags": ["gradient", "lamina"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-13",
   "source": "https://codesandbox.io/s/go0b4w",
   "libraries": ["@pmndrs/branding", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "lamina"],
   "assets": []

--- a/demos/portal-shapes/package.json
+++ b/demos/portal-shapes/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/portal-shapes",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/8j36ok",
-  "keywords": [],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/portal-shapes/pmndrs.json
+++ b/demos/portal-shapes/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Portal Shapes",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-31",
   "source": "https://codesandbox.io/s/8j36ok",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/rapier"],
   "assets": []

--- a/demos/portal-shapes/pmndrs.json
+++ b/demos/portal-shapes/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Portal Shapes",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/8j36ok",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/rapier"],
+  "assets": []
+}

--- a/demos/portals/package.json
+++ b/demos/portals/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/portals",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/ik11ln",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/portals/pmndrs.json
+++ b/demos/portals/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Portals",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-06-05",
   "source": "https://codesandbox.io/s/ik11ln",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/portals/pmndrs.json
+++ b/demos/portals/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Portals",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ik11ln",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/progressive-loading-states-with-suspense/package.json
+++ b/demos/progressive-loading-states-with-suspense/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/progressive-loading-states-with-suspense",
   "version": "1.0.0",
-  "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense.",
-  "homepage": "https://codesandbox.io/s/7duy8",
-  "keywords": [
-    "gltf",
-    "suspense",
-    "loading"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/progressive-loading-states-with-suspense/pmndrs.json
+++ b/demos/progressive-loading-states-with-suspense/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Progressive Loading States With Suspense",
   "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense.",
   "tags": ["gltf", "suspense", "loading"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-02-08",
   "source": "https://codesandbox.io/s/7duy8",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/progressive-loading-states-with-suspense/pmndrs.json
+++ b/demos/progressive-loading-states-with-suspense/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Progressive Loading States With Suspense",
+  "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense.",
+  "tags": ["gltf", "suspense", "loading"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/7duy8",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/racing-game/package.json
+++ b/demos/racing-game/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/racing-game",
   "version": "1.0.0",
-  "description": "A semi-complete racing game.",
-  "homepage": "https://codesandbox.io/s/lo6kp",
-  "keywords": [
-    "game",
-    "vehicle",
-    "raycast-vehicle",
-    "racing",
-    "physics"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/cannon": "^6.6.0",

--- a/demos/racing-game/pmndrs.json
+++ b/demos/racing-game/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Racing Game",
   "description": "A semi-complete racing game.",
   "tags": ["game", "vehicle", "raycast-vehicle", "racing", "physics"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-07-23",
   "source": "https://codesandbox.io/s/lo6kp",
   "libraries": ["@pmndrs/branding", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "leva", "use-asset"],
   "assets": []

--- a/demos/racing-game/pmndrs.json
+++ b/demos/racing-game/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Racing Game",
+  "description": "A semi-complete racing game.",
+  "tags": ["game", "vehicle", "raycast-vehicle", "racing", "physics"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/lo6kp",
+  "libraries": ["@pmndrs/branding", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "leva", "use-asset"],
+  "assets": []
+}

--- a/demos/ragdoll-physics/package.json
+++ b/demos/ragdoll-physics/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/ragdoll-physics",
   "version": "1.0.0",
-  "description": "A mini game using cannon ragdoll physics. Throw the little guy around.",
-  "homepage": "https://codesandbox.io/s/wdzv4",
-  "keywords": [
-    "game",
-    "ragdoll",
-    "cannon",
-    "physics"
-  ],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/ragdoll-physics/pmndrs.json
+++ b/demos/ragdoll-physics/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Ragdoll Physics",
+  "description": "A mini game using cannon ragdoll physics. Throw the little guy around.",
+  "tags": ["game", "ragdoll", "cannon", "physics"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/wdzv4",
+  "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/ragdoll-physics/pmndrs.json
+++ b/demos/ragdoll-physics/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Ragdoll Physics",
   "description": "A mini game using cannon ragdoll physics. Throw the little guy around.",
   "tags": ["game", "ragdoll", "cannon", "physics"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-09-25",
   "source": "https://codesandbox.io/s/wdzv4",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/rapier-physics/package.json
+++ b/demos/rapier-physics/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/rapier-physics",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/7e9y1b",
-  "keywords": [
-    "rapier"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/rapier-physics/pmndrs.json
+++ b/demos/rapier-physics/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Rapier Physics",
   "description": "",
   "tags": ["rapier"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-07-16",
   "source": "https://codesandbox.io/s/7e9y1b",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "leva"],
   "assets": []

--- a/demos/rapier-physics/pmndrs.json
+++ b/demos/rapier-physics/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Rapier Physics",
+  "description": "",
+  "tags": ["rapier"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/7e9y1b",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "leva"],
+  "assets": []
+}

--- a/demos/rapier-ping-pong/package.json
+++ b/demos/rapier-ping-pong/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/rapier-ping-pong",
   "version": "1.0.0",
-  "description": "Mini ping-pong implementation using rapier-physics.",
-  "homepage": "https://codesandbox.io/s/ptdgrn",
-  "keywords": [],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/rapier-ping-pong/pmndrs.json
+++ b/demos/rapier-ping-pong/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Rapier Ping Pong",
   "description": "Mini ping-pong implementation using rapier-physics.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2024-01-20",
   "source": "https://codesandbox.io/s/ptdgrn",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier", "valtio"],
   "assets": []

--- a/demos/rapier-ping-pong/pmndrs.json
+++ b/demos/rapier-ping-pong/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Rapier Ping Pong",
+  "description": "Mini ping-pong implementation using rapier-physics.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ptdgrn",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier", "valtio"],
+  "assets": []
+}

--- a/demos/raycast-cycling/package.json
+++ b/demos/raycast-cycling/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/raycast-cycling",
   "version": "1.0.0",
-  "description": "Bringing multiple objects underneath the cursor up front through raycast cycling",
-  "homepage": "https://codesandbox.io/s/ls503",
-  "keywords": [
-    "raycast",
-    "cycling"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/raycast-cycling/pmndrs.json
+++ b/demos/raycast-cycling/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Raycast Cycling",
   "description": "Bringing multiple objects underneath the cursor up front through raycast cycling",
   "tags": ["raycast", "cycling"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-22",
   "source": "https://codesandbox.io/s/ls503",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/raycast-cycling/pmndrs.json
+++ b/demos/raycast-cycling/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Raycast Cycling",
+  "description": "Bringing multiple objects underneath the cursor up front through raycast cycling",
+  "tags": ["raycast", "cycling"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ls503",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/re-using-geometry-and-level-of-detail/package.json
+++ b/demos/re-using-geometry-and-level-of-detail/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/re-using-geometry-and-level-of-detail",
   "version": "1.0.0",
-  "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense, and using them as a LOD.",
-  "homepage": "https://codesandbox.io/s/12nmp",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/re-using-geometry-and-level-of-detail/pmndrs.json
+++ b/demos/re-using-geometry-and-level-of-detail/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Re Using Geometry And Level Of Detail",
+  "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense, and using them as a LOD.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/12nmp",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/re-using-geometry-and-level-of-detail/pmndrs.json
+++ b/demos/re-using-geometry-and-level-of-detail/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Re Using Geometry And Level Of Detail",
   "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense, and using them as a LOD.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-07-04",
   "source": "https://codesandbox.io/s/12nmp",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/re-using-gltfs/package.json
+++ b/demos/re-using-gltfs/package.json
@@ -6,15 +6,8 @@
     "react-dom": "^18.3.1",
     "three": "^0.165.0"
   },
-  "keywords": [
-    "gltfjsx",
-    "re-use",
-    "gltf"
-  ],
   "name": "@demo/re-using-gltfs",
   "version": "1.0.0",
-  "description": "When you use GLTFJSX it creates a immutable snapshot of your assets, these can be reused.",
-  "homepage": "https://codesandbox.io/s/dix1y",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/re-using-gltfs/pmndrs.json
+++ b/demos/re-using-gltfs/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Re Using GLTFs",
+  "description": "When you use GLTFJSX it creates a immutable snapshot of your assets, these can be reused.",
+  "tags": ["gltfjsx", "re-use", "gltf"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/dix1y",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/re-using-gltfs/pmndrs.json
+++ b/demos/re-using-gltfs/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Re Using GLTFs",
   "description": "When you use GLTFJSX it creates a immutable snapshot of your assets, these can be reused.",
   "tags": ["gltfjsx", "re-use", "gltf"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-08",
   "source": "https://codesandbox.io/s/dix1y",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/react-ellipsecurve/package.json
+++ b/demos/react-ellipsecurve/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/react-ellipsecurve",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/xzi6ps",
-  "keywords": [
-    "trails"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/react-ellipsecurve/pmndrs.json
+++ b/demos/react-ellipsecurve/pmndrs.json
@@ -5,7 +5,8 @@
   "tags": [
     "trails"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-10-20",
   "source": "https://codesandbox.io/s/xzi6ps",
   "libraries": [
     "@react-three/drei",

--- a/demos/react-ellipsecurve/pmndrs.json
+++ b/demos/react-ellipsecurve/pmndrs.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "React EllipseCurve",
+  "description": "",
+  "tags": [
+    "trails"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/xzi6ps",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing"
+  ],
+  "assets": []
+}

--- a/demos/react-pp-outlines/package.json
+++ b/demos/react-pp-outlines/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/react-pp-outlines",
   "version": "1.0.0",
-  "description": "How to build declarative, nested outlines where higher-ups take precedence.",
-  "homepage": "https://codesandbox.io/s/nurp5t",
-  "keywords": [
-    "outlines"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/react-pp-outlines/pmndrs.json
+++ b/demos/react-pp-outlines/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "React Postprocessing Outlines",
+  "description": "How to build declarative, nested outlines where higher-ups take precedence.",
+  "tags": ["outlines"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/nurp5t",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/react-pp-outlines/pmndrs.json
+++ b/demos/react-pp-outlines/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "React Postprocessing Outlines",
   "description": "How to build declarative, nested outlines where higher-ups take precedence.",
   "tags": ["outlines"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-11",
   "source": "https://codesandbox.io/s/nurp5t",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []

--- a/demos/react-spring-animations/package.json
+++ b/demos/react-spring-animations/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/react-spring-animations",
   "version": "1.0.0",
-  "description": "This is react-spring animating both the dom as well as the canvas with a single spring.",
-  "homepage": "https://codesandbox.io/s/6hi1y",
-  "keywords": [
-    "react-spring",
-    "gltf",
-    "physics",
-    "spring",
-    "animation"
-  ],
   "dependencies": {
     "@react-spring/core": "^9.7.4",
     "@react-spring/three": "^9.7.3",

--- a/demos/react-spring-animations/pmndrs.json
+++ b/demos/react-spring-animations/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "React Spring Animations",
+  "description": "This is react-spring animating both the dom as well as the canvas with a single spring.",
+  "tags": ["react-spring", "gltf", "physics", "spring", "animation"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/6hi1y",
+  "libraries": ["@react-spring/core", "@react-spring/three", "@react-spring/web", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/react-spring-animations/pmndrs.json
+++ b/demos/react-spring-animations/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "React Spring Animations",
   "description": "This is react-spring animating both the dom as well as the canvas with a single spring.",
   "tags": ["react-spring", "gltf", "physics", "spring", "animation"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-05-06",
   "source": "https://codesandbox.io/s/6hi1y",
   "libraries": ["@react-spring/core", "@react-spring/three", "@react-spring/web", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/room-with-soft-shadows/package.json
+++ b/demos/room-with-soft-shadows/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/room-with-soft-shadows",
   "version": "1.0.0",
-  "description": "Percentage closer soft shadows.",
-  "homepage": "https://codesandbox.io/s/ykfpwf",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/room-with-soft-shadows/pmndrs.json
+++ b/demos/room-with-soft-shadows/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Room With Soft Shadows",
   "description": "Percentage closer soft shadows.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-02-27",
   "source": "https://codesandbox.io/s/ykfpwf",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/room-with-soft-shadows/pmndrs.json
+++ b/demos/room-with-soft-shadows/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Room With Soft Shadows",
+  "description": "Percentage closer soft shadows.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ykfpwf",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/router-transitions/package.json
+++ b/demos/router-transitions/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/router-transitions",
   "version": "1.0.0",
-  "description": "Shows how to implement routes and mount/unmount transition within the canvas using Wouter.",
-  "homepage": "https://codesandbox.io/s/4j2q2",
-  "keywords": [
-    "wouter",
-    "router",
-    "trnasitions"
-  ],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/router-transitions/pmndrs.json
+++ b/demos/router-transitions/pmndrs.json
@@ -2,8 +2,9 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Router Transitions",
   "description": "Shows how to implement routes and mount/unmount transition within the canvas using Wouter.",
-  "tags": ["wouter", "router", "trnasitions"],
-  "authors": [],
+  "tags": ["wouter", "router", "trnasitions", "html"],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/4j2q2",
   "libraries": ["@pmndrs/assets", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/router-transitions/pmndrs.json
+++ b/demos/router-transitions/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Router Transitions",
+  "description": "Shows how to implement routes and mount/unmount transition within the canvas using Wouter.",
+  "tags": ["wouter", "router", "trnasitions"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/4j2q2",
+  "libraries": ["@pmndrs/assets", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/scrollcontrols-and-lens-refraction/package.json
+++ b/demos/scrollcontrols-and-lens-refraction/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/scrollcontrols-and-lens-refraction",
   "version": "1.0.0",
-  "description": "Vertical scrollcontrols and minimaps.",
-  "homepage": "https://codesandbox.io/s/2n98yj",
-  "keywords": [],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/scrollcontrols-and-lens-refraction/pmndrs.json
+++ b/demos/scrollcontrols-and-lens-refraction/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "ScrollControls and Lens Refraction",
   "description": "Vertical scrollcontrols and minimaps.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-07",
   "source": "https://codesandbox.io/s/2n98yj",
   "libraries": [
     "@pmndrs/branding",

--- a/demos/scrollcontrols-and-lens-refraction/pmndrs.json
+++ b/demos/scrollcontrols-and-lens-refraction/pmndrs.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "ScrollControls and Lens Refraction",
+  "description": "Vertical scrollcontrols and minimaps.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/2n98yj",
+  "libraries": [
+    "@pmndrs/branding",
+    "@react-three/drei",
+    "@react-three/fiber",
+    "maath"
+  ],
+  "assets": []
+}

--- a/demos/scrollcontrols-gltf/package.json
+++ b/demos/scrollcontrols-gltf/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/scrollcontrols-gltf",
   "version": "1.0.0",
-  "description": "Connecting models with useScroll",
-  "homepage": "https://codesandbox.io/s/4jr4p",
-  "keywords": [
-    "gltf",
-    "scrollcontrols"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/scrollcontrols-gltf/pmndrs.json
+++ b/demos/scrollcontrols-gltf/pmndrs.json
@@ -6,7 +6,8 @@
     "gltf",
     "scrollcontrols"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-22",
   "source": "https://codesandbox.io/s/4jr4p",
   "libraries": [
     "@react-three/drei",

--- a/demos/scrollcontrols-gltf/pmndrs.json
+++ b/demos/scrollcontrols-gltf/pmndrs.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "ScrollControls GLTF",
+  "description": "Connecting models with useScroll",
+  "tags": [
+    "gltf",
+    "scrollcontrols"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/4jr4p",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/scrollcontrols-with-minimap/package.json
+++ b/demos/scrollcontrols-with-minimap/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/scrollcontrols-with-minimap",
   "version": "1.0.0",
-  "description": "Vertical scrollcontrols and minimaps.",
-  "homepage": "https://codesandbox.io/s/yjhzv",
-  "keywords": [
-    "vertical",
-    "minimap"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/scrollcontrols-with-minimap/pmndrs.json
+++ b/demos/scrollcontrols-with-minimap/pmndrs.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "ScrollControls with Minimap",
+  "description": "Vertical scrollcontrols and minimaps.",
+  "tags": [
+    "vertical",
+    "minimap"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/yjhzv",
+  "libraries": [
+    "@pmndrs/branding",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/scrollcontrols-with-minimap/pmndrs.json
+++ b/demos/scrollcontrols-with-minimap/pmndrs.json
@@ -6,7 +6,8 @@
     "vertical",
     "minimap"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-13",
   "source": "https://codesandbox.io/s/yjhzv",
   "libraries": [
     "@pmndrs/branding",

--- a/demos/selective-outlines/package.json
+++ b/demos/selective-outlines/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/selective-outlines",
   "version": "1.0.0",
-  "description": "Using postprocessing to give seletcive objects outlines.",
-  "homepage": "https://codesandbox.io/s/d36mw",
-  "keywords": [
-    "postprocessing",
-    "outlines"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/selective-outlines/pmndrs.json
+++ b/demos/selective-outlines/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Selective Outlines",
   "description": "Using postprocessing to give seletcive objects outlines.",
   "tags": ["postprocessing", "outlines"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-05-07",
   "source": "https://codesandbox.io/s/d36mw",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/selective-outlines/pmndrs.json
+++ b/demos/selective-outlines/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Selective Outlines",
+  "description": "Using postprocessing to give seletcive objects outlines.",
+  "tags": ["postprocessing", "outlines"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/d36mw",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/shader-fire/package.json
+++ b/demos/shader-fire/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/shader-fire",
   "version": "1.0.0",
-  "description": "A volumetric fire effect.",
-  "homepage": "https://codesandbox.io/s/3878x",
-  "keywords": [
-    "fire",
-    "volumetric",
-    "shader"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/shader-fire/pmndrs.json
+++ b/demos/shader-fire/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Shader Fire",
+  "description": "A volumetric fire effect.",
+  "tags": ["fire", "volumetric", "shader"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/3878x",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/shader-fire/pmndrs.json
+++ b/demos/shader-fire/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Shader Fire",
   "description": "A volumetric fire effect.",
   "tags": ["fire", "volumetric", "shader"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-05-14",
   "source": "https://codesandbox.io/s/3878x",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/shader-hmr/package.json
+++ b/demos/shader-hmr/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/shader-hmr",
   "version": "1.0.0",
-  "description": "Shows how to create HMR shaders",
-  "homepage": "https://codesandbox.io/s/ib0jc",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/shader-hmr/pmndrs.json
+++ b/demos/shader-hmr/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Shader HMR",
   "description": "Shows how to create HMR shaders",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-07-18",
   "source": "https://codesandbox.io/s/ib0jc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/shader-hmr/pmndrs.json
+++ b/demos/shader-hmr/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Shader HMR",
+  "description": "Shows how to create HMR shaders",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ib0jc",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/shadermaterials/package.json
+++ b/demos/shadermaterials/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/shadermaterials",
   "version": "1.0.0",
-  "description": "How to set up shader materials declaratively.",
-  "homepage": "https://codesandbox.io/s/1g4qq",
-  "keywords": [
-    "material",
-    "shader"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/shadermaterials/pmndrs.json
+++ b/demos/shadermaterials/pmndrs.json
@@ -6,7 +6,8 @@
     "material",
     "shader"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-12-11",
   "source": "https://codesandbox.io/s/1g4qq",
   "libraries": [
     "@react-three/drei",

--- a/demos/shadermaterials/pmndrs.json
+++ b/demos/shadermaterials/pmndrs.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Shader Materials",
+  "description": "How to set up shader materials declaratively.",
+  "tags": [
+    "material",
+    "shader"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/1g4qq",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/shoe-configurator/package.json
+++ b/demos/shoe-configurator/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/shoe-configurator",
   "version": "1.0.0",
-  "description": "A super small configurator that shows you how to make GLTF assets dynamic.",
-  "homepage": "https://codesandbox.io/s/qxjoj",
-  "keywords": [
-    "valtio",
-    "state",
-    "gltf",
-    "configurator"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/shoe-configurator/pmndrs.json
+++ b/demos/shoe-configurator/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Shoe Configurator",
   "description": "A super small configurator that shows you how to make GLTF assets dynamic.",
   "tags": ["valtio", "state", "gltf", "configurator"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-12-11",
   "source": "https://codesandbox.io/s/qxjoj",
   "libraries": ["@react-three/drei", "@react-three/fiber", "valtio"],
   "assets": []

--- a/demos/shoe-configurator/pmndrs.json
+++ b/demos/shoe-configurator/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Shoe Configurator",
+  "description": "A super small configurator that shows you how to make GLTF assets dynamic.",
+  "tags": ["valtio", "state", "gltf", "configurator"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/qxjoj",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "valtio"],
+  "assets": []
+}

--- a/demos/shopping/package.json
+++ b/demos/shopping/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/shopping",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/4gy946",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/shopping/pmndrs.json
+++ b/demos/shopping/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Shopping",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/4gy946",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/shopping/pmndrs.json
+++ b/demos/shopping/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Shopping",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-09-18",
   "source": "https://codesandbox.io/s/4gy946",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/simple-audio-analyser/package.json
+++ b/demos/simple-audio-analyser/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/simple-audio-analyser",
   "version": "1.0.0",
-  "description": "Audio frequency analysis.",
-  "homepage": "https://codesandbox.io/s/wu51m",
-  "keywords": [
-    "analyser",
-    "audio"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/fiber": "^8.17.5",

--- a/demos/simple-audio-analyser/pmndrs.json
+++ b/demos/simple-audio-analyser/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Simple Audio Analyser",
+  "description": "Audio frequency analysis.",
+  "tags": ["analyser", "audio"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/wu51m",
+  "libraries": ["@pmndrs/branding", "@react-three/fiber", "suspend-react"],
+  "assets": []
+}

--- a/demos/simple-audio-analyser/pmndrs.json
+++ b/demos/simple-audio-analyser/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Simple Audio Analyser",
   "description": "Audio frequency analysis.",
   "tags": ["analyser", "audio"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-09-02",
   "source": "https://codesandbox.io/s/wu51m",
   "libraries": ["@pmndrs/branding", "@react-three/fiber", "suspend-react"],
   "assets": []

--- a/demos/simple-physics-demo-with-debug-bounds/package.json
+++ b/demos/simple-physics-demo-with-debug-bounds/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/simple-physics-demo-with-debug-bounds",
   "version": "1.0.0",
-  "description": "A box dropping onto a plane using use-cannon / cannon-es.",
-  "homepage": "https://codesandbox.io/s/0k27n",
-  "keywords": [],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/fiber": "^8.17.5",

--- a/demos/simple-physics-demo-with-debug-bounds/pmndrs.json
+++ b/demos/simple-physics-demo-with-debug-bounds/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Simple Physics Demo With Debug Bounds",
   "description": "A box dropping onto a plane using use-cannon / cannon-es.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-06-08",
   "source": "https://codesandbox.io/s/0k27n",
   "libraries": ["@react-three/cannon", "@react-three/fiber"],
   "assets": []

--- a/demos/simple-physics-demo-with-debug-bounds/pmndrs.json
+++ b/demos/simple-physics-demo-with-debug-bounds/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Simple Physics Demo With Debug Bounds",
+  "description": "A box dropping onto a plane using use-cannon / cannon-es.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0k27n",
+  "libraries": ["@react-three/cannon", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/simple-physics-demo/package.json
+++ b/demos/simple-physics-demo/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/simple-physics-demo",
   "version": "1.0.0",
-  "description": "A box dropping onto a plane using use-cannon / cannon-es.",
-  "homepage": "https://codesandbox.io/s/z8e6m",
-  "keywords": [
-    "physics",
-    "cannon-es",
-    "use-cannon"
-  ],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/fiber": "^8.17.5",

--- a/demos/simple-physics-demo/pmndrs.json
+++ b/demos/simple-physics-demo/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Simple Physics Demo",
+  "description": "A box dropping onto a plane using use-cannon / cannon-es.",
+  "tags": ["physics", "cannon-es", "use-cannon"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/z8e6m",
+  "libraries": ["@react-three/cannon", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/simple-physics-demo/pmndrs.json
+++ b/demos/simple-physics-demo/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Simple Physics Demo",
   "description": "A box dropping onto a plane using use-cannon / cannon-es.",
   "tags": ["physics", "cannon-es", "use-cannon"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-05-26",
   "source": "https://codesandbox.io/s/z8e6m",
   "libraries": ["@react-three/cannon", "@react-three/fiber"],
   "assets": []

--- a/demos/sky-dome-with-annotations/package.json
+++ b/demos/sky-dome-with-annotations/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/sky-dome-with-annotations",
   "version": "1.0.0",
-  "description": "Dome projecting texture and HTML annotations.",
-  "homepage": "https://codesandbox.io/s/wbrfs",
-  "keywords": [
-    "annotations",
-    "html",
-    "dome"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/sky-dome-with-annotations/pmndrs.json
+++ b/demos/sky-dome-with-annotations/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Sky Dome With Annotations",
   "description": "Dome projecting texture and HTML annotations.",
   "tags": ["annotations", "html", "dome"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-02-10",
   "source": "https://codesandbox.io/s/wbrfs",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/sky-dome-with-annotations/pmndrs.json
+++ b/demos/sky-dome-with-annotations/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Sky Dome With Annotations",
+  "description": "Dome projecting texture and HTML annotations.",
+  "tags": ["annotations", "html", "dome"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/wbrfs",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/soft-shadows/package.json
+++ b/demos/soft-shadows/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/soft-shadows",
   "version": "1.0.0",
-  "description": "Percentage closer soft shadows.",
-  "homepage": "https://codesandbox.io/s/dh2jc",
-  "keywords": [
-    "pcss",
-    "soft-shadows",
-    "drei"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/soft-shadows/pmndrs.json
+++ b/demos/soft-shadows/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Soft Shadows",
+  "description": "Percentage closer soft shadows.",
+  "tags": ["pcss", "soft-shadows", "drei"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/dh2jc",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/soft-shadows/pmndrs.json
+++ b/demos/soft-shadows/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Soft Shadows",
   "description": "Percentage closer soft shadows.",
   "tags": ["pcss", "soft-shadows", "drei"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-09-28",
   "source": "https://codesandbox.io/s/dh2jc",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/space-game/package.json
+++ b/demos/space-game/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/space-game",
   "version": "1.0.0",
-  "description": "A small demo that shows how to manage game entities.",
-  "homepage": "https://codesandbox.io/s/i2160",
-  "keywords": [
-    "zustand",
-    "physics",
-    "game",
-    "drei"
-  ],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "@react-three/drei": "^9.109.5",

--- a/demos/space-game/pmndrs.json
+++ b/demos/space-game/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Space Game",
+  "description": "A small demo that shows how to manage game entities.",
+  "tags": ["zustand", "physics", "game", "drei"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/i2160",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "three-stdlib", "zustand"],
+  "assets": []
+}

--- a/demos/space-game/pmndrs.json
+++ b/demos/space-game/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Space Game",
   "description": "A small demo that shows how to manage game entities.",
   "tags": ["zustand", "physics", "game", "drei"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-10-16",
   "source": "https://codesandbox.io/s/i2160",
   "libraries": ["@react-three/drei", "@react-three/fiber", "three-stdlib", "zustand"],
   "assets": []

--- a/demos/sparks-and-effects/package.json
+++ b/demos/sparks-and-effects/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/sparks-and-effects",
   "version": "1.0.0",
-  "description": "Demonstrating fake-particles, mesh-lines and effect composition.",
-  "homepage": "https://codesandbox.io/s/sbf2i",
-  "keywords": [
-    "glow",
-    "mesh-line",
-    "effects",
-    "particles",
-    "text-geometry"
-  ],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "react": "^18.3.1",

--- a/demos/sparks-and-effects/pmndrs.json
+++ b/demos/sparks-and-effects/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Sparks And Effects",
   "description": "Demonstrating fake-particles, mesh-lines and effect composition.",
   "tags": ["glow", "mesh-line", "effects", "particles", "text-geometry"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-01-10",
   "source": "https://codesandbox.io/s/sbf2i",
   "libraries": ["@react-three/fiber"],
   "assets": []

--- a/demos/sparks-and-effects/pmndrs.json
+++ b/demos/sparks-and-effects/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Sparks And Effects",
+  "description": "Demonstrating fake-particles, mesh-lines and effect composition.",
+  "tags": ["glow", "mesh-line", "effects", "particles", "text-geometry"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/sbf2i",
+  "libraries": ["@react-three/fiber"],
+  "assets": []
+}

--- a/demos/spline-glass-shapes/package.json
+++ b/demos/spline-glass-shapes/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/spline-glass-shapes",
   "version": "1.0.0",
-  "description": "Scene exported with Spline",
-  "homepage": "https://codesandbox.io/s/ju368j",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/spline-glass-shapes/pmndrs.json
+++ b/demos/spline-glass-shapes/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Spline Glass Shapes",
   "description": "Scene exported with Spline",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-01-07",
   "source": "https://codesandbox.io/s/ju368j",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/spline-glass-shapes/pmndrs.json
+++ b/demos/spline-glass-shapes/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Spline Glass Shapes",
+  "description": "Scene exported with Spline",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ju368j",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/sport-hall/package.json
+++ b/demos/sport-hall/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/sport-hall",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/s006f",
-  "keywords": [
-    "box projected",
-    "environment",
-    "ground mapping",
-    "reflections"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/sport-hall/pmndrs.json
+++ b/demos/sport-hall/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Sport Hall",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": ["box projected", "environment", "ground mapping", "reflections"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/s006f",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/sport-hall/pmndrs.json
+++ b/demos/sport-hall/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Sport Hall",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["box projected", "environment", "ground mapping", "reflections"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-02-09",
   "source": "https://codesandbox.io/s/s006f",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/springy-boxes/package.json
+++ b/demos/springy-boxes/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/springy-boxes",
   "version": "1.0.0",
-  "description": "Colorfull boxes changing position with spring physics",
-  "homepage": "https://codesandbox.io/s/jz9l97qn89",
-  "keywords": [
-    "springs",
-    "react-spring",
-    "physics",
-    "animation"
-  ],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-three/fiber": "^8.17.5",

--- a/demos/springy-boxes/pmndrs.json
+++ b/demos/springy-boxes/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Springy Boxes",
+  "description": "Colorfull boxes changing position with spring physics",
+  "tags": ["springs", "react-spring", "physics", "animation"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/jz9l97qn89",
+  "libraries": ["@react-spring/three", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/springy-boxes/pmndrs.json
+++ b/demos/springy-boxes/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Springy Boxes",
   "description": "Colorfull boxes changing position with spring physics",
   "tags": ["springs", "react-spring", "physics", "animation"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-04-02",
   "source": "https://codesandbox.io/s/jz9l97qn89",
   "libraries": ["@react-spring/three", "@react-three/fiber"],
   "assets": []

--- a/demos/ssgi-spheres-with-rapier-physics/package.json
+++ b/demos/ssgi-spheres-with-rapier-physics/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/ssgi-spheres-with-rapier-physics",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/5w35n6",
-  "keywords": [],
   "dependencies": {
     "@babel/runtime": "^7.25.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/ssgi-spheres-with-rapier-physics/pmndrs.json
+++ b/demos/ssgi-spheres-with-rapier-physics/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "SSGI Spheres With Rapier Physics",
+  "description": "",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/5w35n6",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "maath"],
+  "assets": []
+}

--- a/demos/ssgi-spheres-with-rapier-physics/pmndrs.json
+++ b/demos/ssgi-spheres-with-rapier-physics/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "SSGI Spheres With Rapier Physics",
   "description": "",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-11-12",
   "source": "https://codesandbox.io/s/5w35n6",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "maath"],
   "assets": []

--- a/demos/ssr-test/package.json
+++ b/demos/ssr-test/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/ssr-test",
   "version": "1.0.0",
-  "description": "Screen space reflections",
-  "homepage": "https://codesandbox.io/s/8pbw1f",
-  "keywords": [
-    "ssr",
-    "postprocessing"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/ssr-test/pmndrs.json
+++ b/demos/ssr-test/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "SSR Test",
   "description": "Screen space reflections",
   "tags": ["ssr", "postprocessing"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-06-30",
   "source": "https://codesandbox.io/s/8pbw1f",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []

--- a/demos/ssr-test/pmndrs.json
+++ b/demos/ssr-test/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "SSR Test",
+  "description": "Screen space reflections",
+  "tags": ["ssr", "postprocessing"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/8pbw1f",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
+  "assets": []
+}

--- a/demos/stage-presets-gltfjsx/package.json
+++ b/demos/stage-presets-gltfjsx/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/stage-presets-gltfjsx",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/if9crg",
-  "keywords": [
-    "gltfjsx",
-    "stage",
-    "drei"
-  ],
   "dependencies": {
     "@babel/runtime": "^7.25.0",
     "@pmndrs/branding": "^0.0.8",

--- a/demos/stage-presets-gltfjsx/pmndrs.json
+++ b/demos/stage-presets-gltfjsx/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Stage Presets GLTFJSX",
   "description": "",
   "tags": ["gltfjsx", "stage", "drei"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-12-20",
   "source": "https://codesandbox.io/s/if9crg",
   "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/stage-presets-gltfjsx/pmndrs.json
+++ b/demos/stage-presets-gltfjsx/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Stage Presets GLTFJSX",
+  "description": "",
+  "tags": ["gltfjsx", "stage", "drei"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/if9crg",
+  "libraries": ["@pmndrs/branding", "@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/staging-and-camerashake/package.json
+++ b/demos/staging-and-camerashake/package.json
@@ -27,15 +27,8 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "keywords": [
-    "stage",
-    "camera-shake",
-    "controls"
-  ],
   "name": "@demo/staging-and-camerashake",
   "version": "1.0.0",
-  "description": "How to stage and shake models while using controls at the same time.",
-  "homepage": "https://codesandbox.io/s/0ycwe",
   "type": "module",
   "repository": {
     "type": "git",

--- a/demos/staging-and-camerashake/pmndrs.json
+++ b/demos/staging-and-camerashake/pmndrs.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Staging and CameraShake",
+  "description": "How to stage and shake models while using controls at the same time.",
+  "tags": [
+    "stage",
+    "camera-shake",
+    "controls"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0ycwe",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/staging-and-camerashake/pmndrs.json
+++ b/demos/staging-and-camerashake/pmndrs.json
@@ -7,7 +7,8 @@
     "camera-shake",
     "controls"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-13",
   "source": "https://codesandbox.io/s/0ycwe",
   "libraries": [
     "@react-three/drei",

--- a/demos/starwars/package.json
+++ b/demos/starwars/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/starwars",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/fslt99",
-  "keywords": [
-    "ssr",
-    "bloom",
-    "hdr"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/starwars/pmndrs.json
+++ b/demos/starwars/pmndrs.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Star Wars",
+  "description": "",
+  "tags": [
+    "ssr",
+    "bloom",
+    "hdr"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/fslt99",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing",
+    "leva"
+  ],
+  "assets": []
+}

--- a/demos/starwars/pmndrs.json
+++ b/demos/starwars/pmndrs.json
@@ -7,7 +7,8 @@
     "bloom",
     "hdr"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-07-12",
   "source": "https://codesandbox.io/s/fslt99",
   "libraries": [
     "@react-three/drei",

--- a/demos/stencil-mask/package.json
+++ b/demos/stencil-mask/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/stencil-mask",
   "version": "1.0.0",
-  "description": "Using the stencil mask to cut out areas of the screen.",
-  "homepage": "https://codesandbox.io/s/z3f2mw",
-  "keywords": [
-    "stencil",
-    "mask"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/stencil-mask/pmndrs.json
+++ b/demos/stencil-mask/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Stencil Mask",
+  "description": "Using the stencil mask to cut out areas of the screen.",
+  "tags": ["stencil", "mask"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/z3f2mw",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
+  "assets": []
+}

--- a/demos/stencil-mask/pmndrs.json
+++ b/demos/stencil-mask/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Stencil Mask",
   "description": "Using the stencil mask to cut out areas of the screen.",
   "tags": ["stencil", "mask"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-05-11",
   "source": "https://codesandbox.io/s/z3f2mw",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],
   "assets": []

--- a/demos/svg-maps-with-html-annotations/package.json
+++ b/demos/svg-maps-with-html-annotations/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/svg-maps-with-html-annotations",
   "version": "1.0.0",
-  "description": "Using SVGLoader, converting each path into cell components with annotations and map controls.",
-  "homepage": "https://codesandbox.io/s/mkq8e",
-  "keywords": [
-    "html",
-    "svg"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/svg-maps-with-html-annotations/pmndrs.json
+++ b/demos/svg-maps-with-html-annotations/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "SVG Maps With HTML Annotations",
   "description": "Using SVGLoader, converting each path into cell components with annotations and map controls.",
   "tags": ["html", "svg"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-09-16",
   "source": "https://codesandbox.io/s/mkq8e",
   "libraries": ["@react-three/drei", "@react-three/fiber", "three-stdlib"],
   "assets": []

--- a/demos/svg-maps-with-html-annotations/pmndrs.json
+++ b/demos/svg-maps-with-html-annotations/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "SVG Maps With HTML Annotations",
+  "description": "Using SVGLoader, converting each path into cell components with annotations and map controls.",
+  "tags": ["html", "svg"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/mkq8e",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "three-stdlib"],
+  "assets": []
+}

--- a/demos/svg-renderer/package.json
+++ b/demos/svg-renderer/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/svg-renderer",
   "version": "1.0.0",
-  "description": "Using the render function to inject custom renderers.",
-  "homepage": "https://codesandbox.io/s/zcuqh",
-  "keywords": [
-    "custom-renderer",
-    "svg-renderer"
-  ],
   "dependencies": {
     "@react-three/fiber": "^8.17.5",
     "react": "^18.3.1",

--- a/demos/svg-renderer/pmndrs.json
+++ b/demos/svg-renderer/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "SVG Renderer",
   "description": "Using the render function to inject custom renderers.",
   "tags": ["custom-renderer", "svg-renderer"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-03-30",
   "source": "https://codesandbox.io/s/zcuqh",
   "libraries": ["@react-three/fiber", "three-stdlib"],
   "assets": []

--- a/demos/svg-renderer/pmndrs.json
+++ b/demos/svg-renderer/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "SVG Renderer",
+  "description": "Using the render function to inject custom renderers.",
+  "tags": ["custom-renderer", "svg-renderer"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/zcuqh",
+  "libraries": ["@react-three/fiber", "three-stdlib"],
+  "assets": []
+}

--- a/demos/t-shirt-configurator/package.json
+++ b/demos/t-shirt-configurator/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@demo/t-shirt-configurator",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/ioxywi",
-  "keywords": [
-    "decals"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/t-shirt-configurator/pmndrs.json
+++ b/demos/t-shirt-configurator/pmndrs.json
@@ -5,7 +5,8 @@
   "tags": [
     "decals"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-08-15",
   "source": "https://codesandbox.io/s/ioxywi",
   "libraries": [
     "@pmndrs/branding",

--- a/demos/t-shirt-configurator/pmndrs.json
+++ b/demos/t-shirt-configurator/pmndrs.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "T-Shirt Configurator",
+  "description": "",
+  "tags": [
+    "decals"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ioxywi",
+  "libraries": [
+    "@pmndrs/branding",
+    "@react-three/drei",
+    "@react-three/fiber",
+    "maath",
+    "valtio"
+  ],
+  "assets": []
+}

--- a/demos/the-three-graces/package.json
+++ b/demos/the-three-graces/package.json
@@ -40,14 +40,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.0"
   },
-  "keywords": [
-    "shadows",
-    "lights",
-    "gltf",
-    "html-annotations"
-  ],
-  "description": "Experimentaing with lights and shadows.",
-  "homepage": "https://codesandbox.io/s/0n9it",
   "type": "module",
   "repository": {
     "type": "git",

--- a/demos/the-three-graces/pmndrs.json
+++ b/demos/the-three-graces/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "The Three Graces",
+  "description": "Experimentaing with lights and shadows.",
+  "tags": ["shadows", "lights", "gltf", "html-annotations"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0n9it",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],
+  "assets": []
+}

--- a/demos/the-three-graces/pmndrs.json
+++ b/demos/the-three-graces/pmndrs.json
@@ -2,8 +2,9 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "The Three Graces",
   "description": "Experimentaing with lights and shadows.",
-  "tags": ["shadows", "lights", "gltf", "html-annotations"],
-  "authors": [],
+  "tags": ["shadows", "lights", "gltf", "html-annotations", "html"],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/0n9it",
   "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],
   "assets": []

--- a/demos/threejs-journey-lv-1-fisheye/package.json
+++ b/demos/threejs-journey-lv-1-fisheye/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/threejs-journey-lv-1-fisheye",
   "version": "1.0.0",
-  "description": "A recreation of the first level from https://threejs-journey.com.",
-  "homepage": "https://codesandbox.io/s/7qytdw",
-  "keywords": [],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-three/drei": "^9.109.5",

--- a/demos/threejs-journey-lv-1-fisheye/pmndrs.json
+++ b/demos/threejs-journey-lv-1-fisheye/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Three.js Journey Level 1 Fisheye",
   "description": "A recreation of the first level from https://threejs-journey.com.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-10-07",
   "source": "https://codesandbox.io/s/7qytdw",
   "libraries": [
     "@react-spring/three",

--- a/demos/threejs-journey-lv-1-fisheye/pmndrs.json
+++ b/demos/threejs-journey-lv-1-fisheye/pmndrs.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Three.js Journey Level 1 Fisheye",
+  "description": "A recreation of the first level from https://threejs-journey.com.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/7qytdw",
+  "libraries": [
+    "@react-spring/three",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/threejs-journey-portal/package.json
+++ b/demos/threejs-journey-portal/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/threejs-journey-portal",
   "version": "1.0.0",
-  "description": "The last scene from Bruno Simons Threejs journey in react-three-fiber",
-  "homepage": "https://codesandbox.io/s/ni6v4",
-  "keywords": [
-    "gltf",
-    "particles",
-    "shaders"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/threejs-journey-portal/pmndrs.json
+++ b/demos/threejs-journey-portal/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Three.js Journey Portal",
+  "description": "The last scene from Bruno Simons Threejs journey in react-three-fiber",
+  "tags": ["gltf", "particles", "shaders"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/ni6v4",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/threejs-journey-portal/pmndrs.json
+++ b/demos/threejs-journey-portal/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Three.js Journey Portal",
   "description": "The last scene from Bruno Simons Threejs journey in react-three-fiber",
   "tags": ["gltf", "particles", "shaders"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/ni6v4",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/thunder-clouds/package.json
+++ b/demos/thunder-clouds/package.json
@@ -36,9 +36,6 @@
       "last 1 safari version"
     ]
   },
-  "keywords": [],
-  "description": "Trying out drei's new cloud component.",
-  "homepage": "https://codesandbox.io/s/gwthnh",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/thunder-clouds/pmndrs.json
+++ b/demos/thunder-clouds/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Thunder Clouds",
   "description": "Trying out drei's new cloud component.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-09-25",
   "source": "https://codesandbox.io/s/gwthnh",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "maath"],
   "assets": []

--- a/demos/thunder-clouds/pmndrs.json
+++ b/demos/thunder-clouds/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Thunder Clouds",
+  "description": "Trying out drei's new cloud component.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/gwthnh",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "maath"],
+  "assets": []
+}

--- a/demos/transformcontrols-and-makedefault/package.json
+++ b/demos/transformcontrols-and-makedefault/package.json
@@ -1,15 +1,6 @@
 {
   "name": "@demo/transformcontrols-and-makedefault",
   "version": "1.0.0",
-  "description": "Combining TransformControls, OrbitControls and Valtio.",
-  "homepage": "https://codesandbox.io/s/btsbj",
-  "keywords": [
-    "controls",
-    "makedefault",
-    "orbit",
-    "transform",
-    "valtio"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/transformcontrols-and-makedefault/pmndrs.json
+++ b/demos/transformcontrols-and-makedefault/pmndrs.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "TransformControls and makeDefault",
+  "description": "Combining TransformControls, OrbitControls and Valtio.",
+  "tags": [
+    "controls",
+    "makedefault",
+    "orbit",
+    "transform",
+    "valtio"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/btsbj",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "valtio"
+  ],
+  "assets": []
+}

--- a/demos/transformcontrols-and-makedefault/pmndrs.json
+++ b/demos/transformcontrols-and-makedefault/pmndrs.json
@@ -9,7 +9,8 @@
     "transform",
     "valtio"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-08",
   "source": "https://codesandbox.io/s/btsbj",
   "libraries": [
     "@react-three/drei",

--- a/demos/transparent-aesop-bottles/package.json
+++ b/demos/transparent-aesop-bottles/package.json
@@ -9,13 +9,6 @@
     "react-dom": "^18.3.1",
     "three": "^0.165.0"
   },
-  "keywords": [
-    "reflections",
-    "transmission",
-    "glas"
-  ],
-  "description": "PBR transmission and thickness to emulate glas.",
-  "homepage": "https://codesandbox.io/s/kv7tv",
   "type": "module",
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demos/transparent-aesop-bottles/pmndrs.json
+++ b/demos/transparent-aesop-bottles/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Transparent Aesop Bottles",
+  "description": "PBR transmission and thickness to emulate glas.",
+  "tags": ["reflections", "transmission", "glas"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/kv7tv",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/transparent-aesop-bottles/pmndrs.json
+++ b/demos/transparent-aesop-bottles/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Transparent Aesop Bottles",
   "description": "PBR transmission and thickness to emulate glas.",
   "tags": ["reflections", "transmission", "glas"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-08",
   "source": "https://codesandbox.io/s/kv7tv",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/trigger-meshes/package.json
+++ b/demos/trigger-meshes/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/trigger-meshes",
   "version": "1.0.0",
-  "description": "Shows how to implement trigger meshes that inform the application of collisions.",
-  "homepage": "https://codesandbox.io/s/h545c",
-  "keywords": [],
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/trigger-meshes/pmndrs.json
+++ b/demos/trigger-meshes/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Trigger Meshes",
+  "description": "Shows how to implement trigger meshes that inform the application of collisions.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/h545c",
+  "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/trigger-meshes/pmndrs.json
+++ b/demos/trigger-meshes/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Trigger Meshes",
   "description": "Shows how to implement trigger meshes that inform the application of collisions.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-06-05",
   "source": "https://codesandbox.io/s/h545c",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/tying-canvas-to-scroll-offset/package.json
+++ b/demos/tying-canvas-to-scroll-offset/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/tying-canvas-to-scroll-offset",
   "version": "1.0.0",
-  "description": "How to tie canvas objects to scrollTop while events keep working.",
-  "homepage": "https://codesandbox.io/s/itfgk",
-  "keywords": [
-    "scroll",
-    "lerp",
-    "events",
-    "animation"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/tying-canvas-to-scroll-offset/pmndrs.json
+++ b/demos/tying-canvas-to-scroll-offset/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Tying Canvas To Scroll Offset",
+  "description": "How to tie canvas objects to scrollTop while events keep working.",
+  "tags": ["scroll", "lerp", "events", "animation"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/itfgk",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/tying-canvas-to-scroll-offset/pmndrs.json
+++ b/demos/tying-canvas-to-scroll-offset/pmndrs.json
@@ -2,8 +2,9 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Tying Canvas To Scroll Offset",
   "description": "How to tie canvas objects to scrollTop while events keep working.",
-  "tags": ["scroll", "lerp", "events", "animation"],
-  "authors": [],
+  "tags": ["scroll", "lerp", "events", "animation", "html"],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-17",
   "source": "https://codesandbox.io/s/itfgk",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/useintersect-and-scrollcontrols/package.json
+++ b/demos/useintersect-and-scrollcontrols/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/useintersect-and-scrollcontrols",
   "version": "1.0.0",
-  "description": "Combining useIntersect with scrollcontrols.",
-  "homepage": "https://codesandbox.io/s/gsm1y",
-  "keywords": [
-    "vertical",
-    "useintersect",
-    "intersection",
-    "scrollcontrols"
-  ],
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/drei": "^9.109.5",

--- a/demos/useintersect-and-scrollcontrols/pmndrs.json
+++ b/demos/useintersect-and-scrollcontrols/pmndrs.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "useIntersect and ScrollControls",
+  "description": "Combining useIntersect with scrollcontrols.",
+  "tags": [
+    "vertical",
+    "useintersect",
+    "intersection",
+    "scrollcontrols"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/gsm1y",
+  "libraries": [
+    "@pmndrs/branding",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/useintersect-and-scrollcontrols/pmndrs.json
+++ b/demos/useintersect-and-scrollcontrols/pmndrs.json
@@ -8,7 +8,8 @@
     "intersection",
     "scrollcontrols"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-10-18",
   "source": "https://codesandbox.io/s/gsm1y",
   "libraries": [
     "@pmndrs/branding",

--- a/demos/video-cookies/package.json
+++ b/demos/video-cookies/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/video-cookies",
   "version": "1.0.0",
-  "description": "How to use drei/AccumulativeShadows and RandomizedLight",
-  "homepage": "https://codesandbox.io/s/hmbn1l",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/video-cookies/pmndrs.json
+++ b/demos/video-cookies/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Video Cookies",
+  "description": "How to use drei/AccumulativeShadows and RandomizedLight",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/hmbn1l",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
+  "assets": []
+}

--- a/demos/video-cookies/pmndrs.json
+++ b/demos/video-cookies/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Video Cookies",
   "description": "How to use drei/AccumulativeShadows and RandomizedLight",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-08-31",
   "source": "https://codesandbox.io/s/hmbn1l",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []

--- a/demos/video-textures/package.json
+++ b/demos/video-textures/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/video-textures",
   "version": "1.0.0",
-  "description": "How to load, apply and play video textures, and how to calculate fullscreen, or \"cover\" aspect ratio. ",
-  "homepage": "https://codesandbox.io/s/39hg8",
-  "keywords": [
-    "video",
-    "texture",
-    "aspect-ratio"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/video-textures/pmndrs.json
+++ b/demos/video-textures/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Video Textures",
   "description": "How to load, apply and play video textures, and how to calculate fullscreen, or \"cover\" aspect ratio. ",
   "tags": ["video", "texture", "aspect-ratio"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-08-20",
   "source": "https://codesandbox.io/s/39hg8",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/video-textures/pmndrs.json
+++ b/demos/video-textures/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Video Textures",
+  "description": "How to load, apply and play video textures, and how to calculate fullscreen, or \"cover\" aspect ratio. ",
+  "tags": ["video", "texture", "aspect-ratio"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/39hg8",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/view-tracking/package.json
+++ b/demos/view-tracking/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@demo/view-tracking",
   "version": "1.0.0",
-  "description": "Shows how to form self-contained components with their own state and user interaction.",
-  "homepage": "https://codesandbox.io/s/bp6tmc",
-  "keywords": [],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/view-tracking/pmndrs.json
+++ b/demos/view-tracking/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "View Tracking",
+  "description": "Shows how to form self-contained components with their own state and user interaction.",
+  "tags": [],
+  "authors": [],
+  "source": "https://codesandbox.io/s/bp6tmc",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/view-tracking/pmndrs.json
+++ b/demos/view-tracking/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "View Tracking",
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2022-03-29",
   "source": "https://codesandbox.io/s/bp6tmc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/viewcube/package.json
+++ b/demos/viewcube/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/viewcube",
   "version": "1.0.0",
-  "description": "Shows how to do heads-up-displays using React.portals.",
-  "homepage": "https://codesandbox.io/s/py4db",
-  "keywords": [
-    "portal",
-    "viewcube",
-    "hud"
-  ],
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@react-three/drei": "^9.109.5",

--- a/demos/viewcube/pmndrs.json
+++ b/demos/viewcube/pmndrs.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "View Cube",
+  "description": "Shows how to do heads-up-displays using React.portals.",
+  "tags": [
+    "portal",
+    "viewcube",
+    "hud"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/py4db",
+  "libraries": [
+    "@pmndrs/assets",
+    "@react-three/drei",
+    "@react-three/fiber"
+  ],
+  "assets": []
+}

--- a/demos/viewcube/pmndrs.json
+++ b/demos/viewcube/pmndrs.json
@@ -7,7 +7,8 @@
     "viewcube",
     "hud"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2019-11-05",
   "source": "https://codesandbox.io/s/py4db",
   "libraries": [
     "@pmndrs/assets",

--- a/demos/viking-ship/package.json
+++ b/demos/viking-ship/package.json
@@ -39,12 +39,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.0"
   },
-  "keywords": [
-    "gltfjsx",
-    "gltf"
-  ],
-  "description": "GLTF workflow with GLTFJSX and camera rotations.",
-  "homepage": "https://codesandbox.io/s/0buje",
   "type": "module",
   "repository": {
     "type": "git",

--- a/demos/viking-ship/pmndrs.json
+++ b/demos/viking-ship/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Viking Ship",
   "description": "GLTF workflow with GLTFJSX and camera rotations.",
   "tags": ["gltfjsx", "gltf"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2020-05-02",
   "source": "https://codesandbox.io/s/0buje",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/viking-ship/pmndrs.json
+++ b/demos/viking-ship/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Viking Ship",
+  "description": "GLTF workflow with GLTFJSX and camera rotations.",
+  "tags": ["gltfjsx", "gltf"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/0buje",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/volumetric-light-godray/package.json
+++ b/demos/volumetric-light-godray/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/volumetric-light-godray",
   "version": "1.0.0",
-  "description": "Experimenting with volumetric lights.",
-  "homepage": "https://codesandbox.io/s/yggpw5",
-  "keywords": [
-    "postprocessing",
-    "godray"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/volumetric-light-godray/pmndrs.json
+++ b/demos/volumetric-light-godray/pmndrs.json
@@ -6,7 +6,8 @@
     "postprocessing",
     "godray"
   ],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2023-06-24",
   "source": "https://codesandbox.io/s/yggpw5",
   "libraries": [
     "@react-three/drei",

--- a/demos/volumetric-light-godray/pmndrs.json
+++ b/demos/volumetric-light-godray/pmndrs.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Volumetric Light God Rays",
+  "description": "Experimenting with volumetric lights.",
+  "tags": [
+    "postprocessing",
+    "godray"
+  ],
+  "authors": [],
+  "source": "https://codesandbox.io/s/yggpw5",
+  "libraries": [
+    "@react-three/drei",
+    "@react-three/fiber",
+    "@react-three/postprocessing"
+  ],
+  "assets": []
+}

--- a/demos/volumetric-spotlight/package.json
+++ b/demos/volumetric-spotlight/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@demo/volumetric-spotlight",
   "version": "1.0.0",
-  "description": "Volumetric soft particle spot lights.",
-  "homepage": "https://codesandbox.io/s/tx1pq",
-  "keywords": [
-    "volumetric",
-    "spotlight",
-    "soft-particles",
-    "spot"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/volumetric-spotlight/pmndrs.json
+++ b/demos/volumetric-spotlight/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Volumetric Spotlight",
   "description": "Volumetric soft particle spot lights.",
   "tags": ["volumetric", "spotlight", "soft-particles", "spot"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-05-24",
   "source": "https://codesandbox.io/s/tx1pq",
   "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/volumetric-spotlight/pmndrs.json
+++ b/demos/volumetric-spotlight/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Volumetric Spotlight",
+  "description": "Volumetric soft particle spot lights.",
+  "tags": ["volumetric", "spotlight", "soft-particles", "spot"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/tx1pq",
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/water-shader/package.json
+++ b/demos/water-shader/package.json
@@ -1,12 +1,6 @@
 {
   "name": "@demo/water-shader",
   "version": "1.0.0",
-  "description": "",
-  "homepage": "https://codesandbox.io/s/1b40u",
-  "keywords": [
-    "shader",
-    "water"
-  ],
   "dependencies": {
     "@react-three/drei": "^9.109.5",
     "@react-three/fiber": "^8.17.5",

--- a/demos/water-shader/pmndrs.json
+++ b/demos/water-shader/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Water Shader",
+  "description": "",
+  "tags": ["shader", "water"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/1b40u",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "three-stdlib"],
+  "assets": []
+}

--- a/demos/water-shader/pmndrs.json
+++ b/demos/water-shader/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Water Shader",
   "description": "",
   "tags": ["shader", "water"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-04-15",
   "source": "https://codesandbox.io/s/1b40u",
   "libraries": ["@react-three/drei", "@react-three/fiber", "three-stdlib"],
   "assets": []

--- a/demos/wobbling-sphere/package.json
+++ b/demos/wobbling-sphere/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@demo/wobbling-sphere",
   "version": "1.0.0",
-  "description": "Experimenting with environment maps.",
-  "homepage": "https://codesandbox.io/s/5oufp",
-  "keywords": [
-    "environment",
-    "reflections",
-    "soft-shadows"
-  ],
   "dependencies": {
     "@react-spring/three": "^9.7.3",
     "@react-three/drei": "^9.109.5",

--- a/demos/wobbling-sphere/pmndrs.json
+++ b/demos/wobbling-sphere/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Wobbling Sphere",
   "description": "Experimenting with environment maps.",
   "tags": ["environment", "reflections", "soft-shadows"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-01-07",
   "source": "https://codesandbox.io/s/5oufp",
   "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber"],
   "assets": []

--- a/demos/wobbling-sphere/pmndrs.json
+++ b/demos/wobbling-sphere/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Wobbling Sphere",
+  "description": "Experimenting with environment maps.",
+  "tags": ["environment", "reflections", "soft-shadows"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/5oufp",
+  "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber"],
+  "assets": []
+}

--- a/demos/zustand-site/package.json
+++ b/demos/zustand-site/package.json
@@ -49,14 +49,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.0"
   },
-  "keywords": [
-    "parallax",
-    "animation",
-    "dof",
-    "particles"
-  ],
-  "description": "Shows how to parallax layers with dept of field and particles.",
-  "homepage": "https://codesandbox.io/s/gpioq",
   "type": "module",
   "repository": {
     "type": "git",

--- a/demos/zustand-site/pmndrs.json
+++ b/demos/zustand-site/pmndrs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../schemas/pmndrs.schema.json",
+  "title": "Zustand Site",
+  "description": "Shows how to parallax layers with dept of field and particles.",
+  "tags": ["parallax", "animation", "dof", "particles"],
+  "authors": [],
+  "source": "https://codesandbox.io/s/gpioq",
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "meshline"],
+  "assets": []
+}

--- a/demos/zustand-site/pmndrs.json
+++ b/demos/zustand-site/pmndrs.json
@@ -3,7 +3,8 @@
   "title": "Zustand Site",
   "description": "Shows how to parallax layers with dept of field and particles.",
   "tags": ["parallax", "animation", "dof", "particles"],
-  "authors": [],
+  "authors": ["Paul Henschel"],
+  "publishedAt": "2021-03-26",
   "source": "https://codesandbox.io/s/gpioq",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "meshline"],
   "assets": []

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "postbuild": "./out.sh",
     "dev": "turbo dev2",
     "lint": "turbo lint",
+    "lint:metadata": "node bin/validate-pmndrs-metadata.mjs",
     "lint:versions": "syncpack lint",
     "fix:versions": "syncpack fix-mismatches",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/schemas/pmndrs.schema.json
+++ b/schemas/pmndrs.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pmndrs.github.io/examples/schemas/pmndrs.schema.json",
+  "title": "pmndrs example metadata",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "title",
+    "description",
+    "tags",
+    "authors",
+    "source",
+    "libraries",
+    "assets"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "../../schemas/pmndrs.schema.json"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "authors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "publishedAt": {
+      "type": "string",
+      "format": "date"
+    },
+    "source": {
+      "type": "string",
+      "format": "uri"
+    },
+    "libraries": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "@pmndrs/assets",
+          "@pmndrs/branding",
+          "@react-spring/core",
+          "@react-spring/three",
+          "@react-spring/web",
+          "@react-three/cannon",
+          "@react-three/csg",
+          "@react-three/drei",
+          "@react-three/fiber",
+          "@react-three/flex",
+          "@react-three/postprocessing",
+          "@react-three/rapier",
+          "@use-gesture/react",
+          "ecctrl",
+          "jotai",
+          "lamina",
+          "leva",
+          "maath",
+          "meshline",
+          "suspend-react",
+          "three-stdlib",
+          "tunnel-rat",
+          "use-asset",
+          "valtio",
+          "zustand"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "assets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/asset"
+      }
+    }
+  },
+  "$defs": {
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "creator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "format": "uri"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1
+        },
+        "licenseUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "modified": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds full pmndrs metadata for our usage.

| Field | What it stores |
|---|---|
| `$schema` | Fixed pointer to the schema file, enables editor validation |
| `title` | The demo's display name |
| `description` | A one-liner explaining what the demo shows |
| `tags` | Freeform keywords for search/filtering (unique, e.g. `"physics"`, `"html"`) |
| `authors` | Who made the demo, as a list of names |
| `publishedAt` | The date the demo was originally published (`YYYY-MM-DD`, optional) |
| `source` | URL of where the demo came from (its original CodeSandbox) |
| `libraries` | Which pmndrs packages it uses, from a fixed list (drei, fiber, cannon, zustand, …) |
| `assets` | Third-party files bundled with the demo (models, textures, fonts), each with its own credit info |
