### PR TITLE
Notify demo maintainers when their demo breaks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write # broken-demos rollup issue (bin/notify-broken-demos.mjs)
 
 jobs:
   build-job:
@@ -30,6 +31,9 @@ jobs:
 
     container:
       image: mcr.microsoft.com/playwright:v1.62.0-jammy
+
+    outputs:
+      e2e-outcome: ${{ steps.e2e.outcome }}
 
     steps:
       #
@@ -51,14 +55,32 @@ jobs:
       #
       - run: pnpm lint:metadata
       - run: pnpm lint:versions
+      - run: pnpm test:unit
 
       #
       # Test
       #
+      # PRs: fail fast — a broken demo blocks the PR
       - run: pnpm test
-        if: ${{ !inputs.update_snapshots }}
+        if: ${{ github.event_name == 'pull_request' && !inputs.update_snapshots }}
         env:
           BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
+      # main (prod monitoring): play ALL tests; one broken demo must not hold
+      # the other demos hostage, so the job carries on (build+deploy still run)
+      # and the e2e-status-job turns the run red instead
+      - id: e2e
+        run: pnpm exec turbo test --continue=dependencies-successful --summarize
+        if: ${{ github.event_name != 'pull_request' && !inputs.update_snapshots }}
+        continue-on-error: true
+        env:
+          BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
+      # continue-on-error: a GitHub API hiccup must not block the deploy either
+      - name: Notify maintainers of broken demos
+        run: node bin/notify-broken-demos.mjs
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && !inputs.update_snapshots }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Baselines regen: gh workflow run CI --ref <branch> -f update_snapshots=true
       # --force: a regen must never replay cached test results (their cached
       # outputs would restore the stale baselines we're regenerating)
@@ -84,6 +106,17 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && !inputs.update_snapshots }}
         with:
           path: ./out${{ steps.configurepages.outputs.base_path }}
+
+  # Mirrors the outcome of the (continue-on-error) e2e step: keeps the run red
+  # when a demo is broken on main, without holding back build+deploy
+  e2e-status-job:
+    if: ${{ github.event_name != 'pull_request' && !inputs.update_snapshots }}
+    runs-on: ubuntu-latest
+    needs: build-job
+    steps:
+      - run: |
+          echo "e2e outcome: ${{ needs.build-job.outputs.e2e-outcome }}"
+          [ "${{ needs.build-job.outputs.e2e-outcome }}" != "failure" ]
 
   deploy-job:
     # only for pushes on main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Issues are tracked on GitHub (pmndrs/examples) via the `gh` CLI; external PRs ar
 
 Canonical vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
 
+### Broken demos & maintainers
+
+Each demo's `pmndrs.json` declares `maintainers` (GitHub logins). On main, CI plays all e2e tests and maintains one `broken-demos` issue per broken demo, @mentioning its maintainers on green→broken. See `docs/agents/broken-demos.md`.
+
 ### Domain docs
 
 Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/domain-modeling`). See `docs/agents/domain.md`.

--- a/apps/website/lib/helper.ts
+++ b/apps/website/lib/helper.ts
@@ -31,6 +31,7 @@ export type DemoMetadata = {
   description: string;
   tags: string[];
   authors: string[];
+  maintainers: string[];
   publishedAt?: string;
   source: string;
   libraries: string[];

--- a/bin/lib/broken-demos.mjs
+++ b/bin/lib/broken-demos.mjs
@@ -1,0 +1,66 @@
+// Pure logic behind bin/notify-broken-demos.mjs: which demos a turbo run
+// summary says are broken, and how each broken demo maps to / renders into
+// its own GitHub issue. Kept IO-free so it can be tested with node --test.
+
+export const ISSUE_LABEL = "broken-demos";
+
+const DEMO_TASKS = new Set(["build2", "test"]);
+// Hidden marker tying an issue to its demo: sturdier than parsing titles.
+const DEMO_MARKER = /<!-- broken-demo:([a-z0-9-]+) -->/;
+
+export function brokenDemosFromSummary(summary, packageToDir) {
+  const broken = new Set();
+  for (const task of summary.tasks ?? []) {
+    const dir = packageToDir.get(task.package);
+    if (!dir || !DEMO_TASKS.has(task.task)) continue;
+    // A task skipped by --continue=dependencies-successful has no (or a null)
+    // exitCode: only an actually-executed, non-zero task marks the demo broken.
+    const exitCode = task.execution?.exitCode;
+    if (Number.isInteger(exitCode) && exitCode !== 0) broken.add(dir);
+  }
+  return [...broken].sort();
+}
+
+export function issueTitle(demo) {
+  return `🔴 \`${demo}\` is broken on main`;
+}
+
+export function demoFromIssueBody(body) {
+  const match = (body ?? "").match(DEMO_MARKER);
+  return match ? match[1] : null;
+}
+
+function mentions(logins) {
+  return logins.map((login) => `@${login}`).join(" ");
+}
+
+export function renderIssueBody({
+  demo,
+  maintainers,
+  runUrl,
+  sha,
+  siteBaseUrl,
+}) {
+  const who = maintainers.length
+    ? `Maintainers: ${mentions(maintainers)}`
+    : `_No maintainer_ — add your GitHub login to \`demos/${demo}/pmndrs.json\` → \`maintainers\` to get pinged about this demo.`;
+  return [
+    `<!-- broken-demo:${demo} -->`,
+    "",
+    `[\`${demo}\`](${siteBaseUrl}/demos/${demo})'s e2e test (or build) fails on \`main\` — see [the run](${runUrl}) (\`${sha.slice(0, 7)}\`).`,
+    "",
+    who,
+    "",
+    "Managed by `bin/notify-broken-demos.mjs`: the body tracks the latest",
+    "failing run, and the issue closes itself once the demo is green again.",
+  ].join("\n");
+}
+
+export function renderReopenComment({ demo, maintainers, runUrl }) {
+  const cc = maintainers.length ? ` cc ${mentions(maintainers)}` : "";
+  return `🔴 \`${demo}\` is broken again on \`main\` ([run](${runUrl})).${cc}`;
+}
+
+export function renderFixedComment({ demo, runUrl }) {
+  return `✅ \`${demo}\` is green again on \`main\` ([run](${runUrl})). Closing.`;
+}

--- a/bin/lib/broken-demos.test.mjs
+++ b/bin/lib/broken-demos.test.mjs
@@ -1,0 +1,147 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  brokenDemosFromSummary,
+  issueTitle,
+  demoFromIssueBody,
+  renderIssueBody,
+  renderReopenComment,
+  renderFixedComment,
+} from "./broken-demos.mjs";
+
+const packageToDir = new Map([
+  ["@demo/aquarium", "aquarium"],
+  ["@demo/baking-soft-shadows", "baking-soft-shadows"],
+  ["@demo/backdrop-and-cables", "backdrop-and-cables"],
+]);
+
+function summaryTask(pkg, task, exitCode) {
+  return {
+    taskId: `${pkg}#${task}`,
+    package: pkg,
+    task,
+    execution: exitCode === undefined ? undefined : { exitCode },
+  };
+}
+
+test("brokenDemosFromSummary flags demos whose test failed", () => {
+  const summary = {
+    tasks: [
+      summaryTask("@demo/aquarium", "build2", 0),
+      summaryTask("@demo/aquarium", "test", 1),
+      summaryTask("@demo/baking-soft-shadows", "build2", 0),
+      summaryTask("@demo/baking-soft-shadows", "test", 0),
+    ],
+  };
+  assert.deepEqual(brokenDemosFromSummary(summary, packageToDir), ["aquarium"]);
+});
+
+test("brokenDemosFromSummary flags demos whose build failed (test skipped)", () => {
+  const summary = {
+    tasks: [
+      summaryTask("@demo/aquarium", "build2", 1),
+      // test task skipped by --continue=dependencies-successful: whether turbo
+      // reports it without execution or with a null exitCode, it is NOT an
+      // extra failure (build2 already marks the demo broken)
+      summaryTask("@demo/aquarium", "test", undefined),
+      summaryTask("@demo/baking-soft-shadows", "build2", 0),
+      summaryTask("@demo/baking-soft-shadows", "test", null),
+    ],
+  };
+  assert.deepEqual(brokenDemosFromSummary(summary, packageToDir), ["aquarium"]);
+});
+
+test("brokenDemosFromSummary dedupes, sorts, and ignores non-demo packages", () => {
+  const summary = {
+    tasks: [
+      summaryTask("website", "build3", 1),
+      summaryTask("@demo/backdrop-and-cables", "test", 1),
+      summaryTask("@demo/backdrop-and-cables", "build2", 1),
+      summaryTask("@demo/aquarium", "test", 1),
+    ],
+  };
+  assert.deepEqual(brokenDemosFromSummary(summary, packageToDir), [
+    "aquarium",
+    "backdrop-and-cables",
+  ]);
+});
+
+test("demoFromIssueBody roundtrips through renderIssueBody", () => {
+  const body = renderIssueBody({
+    demo: "re-using-geometry-and-level-of-detail",
+    maintainers: ["abernier"],
+    runUrl: "https://github.com/pmndrs/examples/actions/runs/1",
+    sha: "abc1234def",
+    siteBaseUrl: "https://pmndrs.github.io/examples",
+  });
+  assert.equal(
+    demoFromIssueBody(body),
+    "re-using-geometry-and-level-of-detail",
+  );
+});
+
+test("demoFromIssueBody returns null without a marker", () => {
+  assert.equal(demoFromIssueBody("no marker here"), null);
+  assert.equal(demoFromIssueBody(undefined), null);
+});
+
+test("renderIssueBody links the demo and mentions its maintainers", () => {
+  const body = renderIssueBody({
+    demo: "aquarium",
+    maintainers: ["abernier", "drcmda"],
+    runUrl: "https://github.com/pmndrs/examples/actions/runs/1",
+    sha: "abc1234def",
+    siteBaseUrl: "https://pmndrs.github.io/examples",
+  });
+  assert.match(body, /https:\/\/pmndrs\.github\.io\/examples\/demos\/aquarium/);
+  assert.match(body, /@abernier @drcmda/);
+  assert.match(body, /actions\/runs\/1/);
+  assert.match(body, /abc1234/);
+});
+
+test("renderIssueBody without maintainers points at pmndrs.json instead", () => {
+  const body = renderIssueBody({
+    demo: "aquarium",
+    maintainers: [],
+    runUrl: "https://github.com/pmndrs/examples/actions/runs/1",
+    sha: "abc1234def",
+    siteBaseUrl: "https://pmndrs.github.io/examples",
+  });
+  assert.match(body, /No maintainer/);
+  assert.match(body, /demos\/aquarium\/pmndrs\.json/);
+  assert.doesNotMatch(body, /@\w/);
+});
+
+test("renderReopenComment mentions maintainers", () => {
+  const comment = renderReopenComment({
+    demo: "aquarium",
+    maintainers: ["abernier"],
+    runUrl: "https://github.com/pmndrs/examples/actions/runs/2",
+  });
+  assert.match(comment, /broken again/);
+  assert.match(comment, /cc @abernier/);
+});
+
+test("renderReopenComment without maintainers has no mentions", () => {
+  const comment = renderReopenComment({
+    demo: "aquarium",
+    maintainers: [],
+    runUrl: "https://github.com/pmndrs/examples/actions/runs/2",
+  });
+  assert.doesNotMatch(comment, /@\w/);
+});
+
+test("renderFixedComment has no mentions", () => {
+  const comment = renderFixedComment({
+    demo: "aquarium",
+    runUrl: "https://github.com/pmndrs/examples/actions/runs/2",
+  });
+  assert.match(comment, /green again/);
+  assert.doesNotMatch(comment, /@\w/);
+});
+
+test("issueTitle is stable per demo", () => {
+  assert.equal(issueTitle("aquarium"), issueTitle("aquarium"));
+  assert.match(issueTitle("aquarium"), /aquarium/);
+});

--- a/bin/notify-broken-demos.mjs
+++ b/bin/notify-broken-demos.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+// Maintains one GitHub issue per broken demo from the latest turbo run
+// summary (produced by `turbo test --summarize` in CI). The set of open
+// `broken-demos` issues IS the previous state — no other storage. Delta-only
+// policy: maintainers are @mentioned when their demo goes green→broken (issue
+// body on creation, comment on reopen — editing a body never notifies); a
+// still-broken demo only gets its body refreshed; a repaired demo gets a
+// no-mention note and its issue closed.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ISSUE_LABEL,
+  brokenDemosFromSummary,
+  issueTitle,
+  demoFromIssueBody,
+  renderIssueBody,
+  renderReopenComment,
+  renderFixedComment,
+} from "./lib/broken-demos.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const dryRun = process.env.DRY_RUN === "1"; // print the broken list, touch nothing
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY ?? "pmndrs/examples";
+if (!token && !dryRun) {
+  console.error("GITHUB_TOKEN is required (or set DRY_RUN=1).");
+  process.exit(1);
+}
+const [owner, repo] = repository.split("/");
+const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+const runUrl = `${serverUrl}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+const sha = process.env.GITHUB_SHA ?? "unknown";
+const siteBaseUrl = `https://${owner}.github.io/${repo}`;
+
+// Plain fetch rather than the `gh` CLI (docs/agents/issue-tracker.md): this
+// runs inside the Playwright container in CI, which doesn't ship gh.
+async function github(method, endpoint, body) {
+  const response = await fetch(`${apiUrl}${endpoint}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${endpoint} → ${response.status}: ${await response.text()}`,
+    );
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+//
+// Which demos are broken, according to the latest turbo run summary?
+//
+
+const runsDirectory = path.join(root, ".turbo", "runs");
+const summaryFiles = fs.existsSync(runsDirectory)
+  ? fs.readdirSync(runsDirectory).filter((name) => name.endsWith(".json"))
+  : [];
+if (summaryFiles.length === 0) {
+  console.error(`No turbo run summary found in ${runsDirectory}.`);
+  process.exit(1);
+}
+const newestSummary = summaryFiles
+  .map((name) => path.join(runsDirectory, name))
+  .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0];
+const summary = JSON.parse(fs.readFileSync(newestSummary, "utf8"));
+
+const demosDirectory = path.join(root, "demos");
+const packageToDir = new Map();
+for (const dir of fs.readdirSync(demosDirectory)) {
+  const packagePath = path.join(demosDirectory, dir, "package.json");
+  if (!fs.existsSync(packagePath)) continue;
+  const { name } = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  packageToDir.set(name, dir);
+}
+
+const broken = brokenDemosFromSummary(summary, packageToDir);
+console.log(`Broken demos: ${broken.length ? broken.join(", ") : "none"}`);
+if (dryRun) process.exit(0);
+
+function maintainersOf(demo) {
+  const metadataPath = path.join(demosDirectory, demo, "pmndrs.json");
+  const { maintainers } = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  return maintainers ?? [];
+}
+
+//
+// Reconcile: one issue per demo, found via the marker in its body.
+// Newest issue wins when a demo somehow accumulated several.
+//
+
+const issues = (
+  await github(
+    "GET",
+    `/repos/${repository}/issues?labels=${ISSUE_LABEL}&state=all&sort=created&direction=desc&per_page=100`,
+  )
+).filter((issue) => !issue.pull_request);
+
+const issueByDemo = new Map();
+for (const issue of issues) {
+  const demo = demoFromIssueBody(issue.body);
+  if (demo && !issueByDemo.has(demo)) issueByDemo.set(demo, issue);
+}
+
+let labelEnsured = issues.length > 0;
+async function ensureLabel() {
+  if (labelEnsured) return;
+  labelEnsured = true;
+  try {
+    await github("POST", `/repos/${repository}/labels`, {
+      name: ISSUE_LABEL,
+      color: "d73a4a",
+      description: "Demos whose e2e test or build fails on main",
+    });
+  } catch {
+    // label already exists
+  }
+}
+
+for (const demo of broken) {
+  const maintainers = maintainersOf(demo);
+  const body = renderIssueBody({ demo, maintainers, runUrl, sha, siteBaseUrl });
+  const issue = issueByDemo.get(demo);
+
+  if (!issue) {
+    await ensureLabel();
+    // @mentions in the body of a freshly created issue already notify.
+    const created = await github("POST", `/repos/${repository}/issues`, {
+      title: issueTitle(demo),
+      body,
+      labels: [ISSUE_LABEL],
+    });
+    console.log(`${demo}: created #${created.number}.`);
+  } else if (issue.state === "closed") {
+    await github("PATCH", `/repos/${repository}/issues/${issue.number}`, {
+      body,
+      state: "open",
+    });
+    // The rewritten body carries the same @mentions as before, which doesn't
+    // re-notify — the reopen ping is the comment.
+    await github(
+      "POST",
+      `/repos/${repository}/issues/${issue.number}/comments`,
+      { body: renderReopenComment({ demo, maintainers, runUrl }) },
+    );
+    console.log(`${demo}: reopened #${issue.number}.`);
+  } else {
+    // Still broken: refresh the run link, stay silent.
+    await github("PATCH", `/repos/${repository}/issues/${issue.number}`, {
+      body,
+    });
+    console.log(`${demo}: still broken, refreshed #${issue.number}.`);
+  }
+}
+
+for (const [demo, issue] of issueByDemo) {
+  if (issue.state !== "open" || broken.includes(demo)) continue;
+  await github("POST", `/repos/${repository}/issues/${issue.number}/comments`, {
+    body: renderFixedComment({ demo, runUrl }),
+  });
+  await github("PATCH", `/repos/${repository}/issues/${issue.number}`, {
+    state: "closed",
+  });
+  console.log(`${demo}: green again, closed #${issue.number}.`);
+}

--- a/bin/validate-pmndrs-metadata.mjs
+++ b/bin/validate-pmndrs-metadata.mjs
@@ -9,6 +9,9 @@ const demosDirectory = path.join(root, "demos");
 const schemaPath = path.join(root, "schemas", "pmndrs.schema.json");
 const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
 const allowedLibraries = new Set(schema.properties.libraries.items.enum);
+const githubLoginPattern = new RegExp(
+  schema.properties.maintainers.items.pattern,
+);
 const requiredFields = new Set(schema.required);
 const allowedFields = new Set(Object.keys(schema.properties));
 const allowedAssetFields = new Set(Object.keys(schema.$defs.asset.properties));
@@ -91,11 +94,16 @@ for (const demoName of demoNames) {
     addError(demoName, '"description" must be a string');
   }
 
-  for (const field of ["tags", "authors", "libraries"]) {
+  for (const field of ["tags", "authors", "maintainers", "libraries"]) {
     if (!isStringArray(metadata[field])) {
       addError(demoName, `"${field}" must contain non-empty strings`);
     } else if (hasDuplicates(metadata[field])) {
       addError(demoName, `"${field}" contains duplicates`);
+    }
+  }
+  for (const login of metadata.maintainers ?? []) {
+    if (typeof login === "string" && !githubLoginPattern.test(login)) {
+      addError(demoName, `"maintainers" entry "${login}" is not a GitHub login`);
     }
   }
 

--- a/demos/aquarium/pmndrs.json
+++ b/demos/aquarium/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-29",
   "source": "https://codesandbox.io/s/n7jf0f",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/arkanoid-under-60-loc/pmndrs.json
+++ b/demos/arkanoid-under-60-loc/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Super small Arkanoid barebones implementation.",
   "tags": ["collisions", "arkanoid", "physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-06-19",
   "source": "https://codesandbox.io/s/66cd7",
   "libraries": ["@react-three/fiber", "@react-three/rapier"],

--- a/demos/arkanoid/pmndrs.json
+++ b/demos/arkanoid/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Simple arkanoid implementation using cannon physics.",
   "tags": ["physics", "game", "audio"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-05-25",
   "source": "https://codesandbox.io/s/2yqpv",
   "libraries": ["@react-spring/three", "@react-three/cannon", "@react-three/drei", "@react-three/fiber", "zustand"],

--- a/demos/audio-analyser/pmndrs.json
+++ b/demos/audio-analyser/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Combining audio analysis with gltf cell fracture and reflections.",
   "tags": ["gltf", "audio", "reflections", "cell-fracture"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-02-01",
   "source": "https://codesandbox.io/s/dvokj",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/backdrop-and-cables/pmndrs.json
+++ b/demos/backdrop-and-cables/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using a studio backdrop, quadratic bezier line and contact shadows.",
   "tags": ["quadraticbezierline", "contact-shadows", "backdrop"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-11-28",
   "source": "https://codesandbox.io/s/2ij9u",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/baking-soft-shadows/pmndrs.json
+++ b/demos/baking-soft-shadows/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to use drei/AccumulativeShadows and RandomizedLight",
   "tags": ["baking", "softshadows", "shadows", "lightmap", "progressive"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-07-30",
   "source": "https://codesandbox.io/s/hxcc1x",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/basic-ballpit/pmndrs.json
+++ b/demos/basic-ballpit/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Physics simulation using cannon.",
   "tags": ["physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-06-29",
   "source": "https://codesandbox.io/s/0fqow2",
   "libraries": ["@react-three/cannon", "@react-three/fiber"],

--- a/demos/basic-demo/pmndrs.json
+++ b/demos/basic-demo/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["interaction", "pointer-events"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-03-12",
   "source": "https://codesandbox.io/s/rrppl0y8l4",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/bestservedbold-christmas-baubles/pmndrs.json
+++ b/demos/bestservedbold-christmas-baubles/pmndrs.json
@@ -2,19 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Best Served Bold Christmas Baubles",
   "description": "Physics, effects, lights and colors.",
-  "tags": [
-    "effects",
-    "physics",
-    "baubles"
-  ],
+  "tags": ["effects", "physics", "baubles"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-08-03",
   "source": "https://codesandbox.io/s/zxpv7",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing",
-    "@react-three/rapier"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier"],
   "assets": []
 }

--- a/demos/bezier-curves-and-nodes/pmndrs.json
+++ b/demos/bezier-curves-and-nodes/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Creating node diagrams with drei's Line and bezier curves.",
   "tags": ["line2", "graph", "nodes", "bezier"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-02-26",
   "source": "https://codesandbox.io/s/3k4g6",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@use-gesture/react"],

--- a/demos/bloom-hdr-workflow-gltf/pmndrs.json
+++ b/demos/bloom-hdr-workflow-gltf/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["bloom", "hdr", "glow", "gltf", "selective"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-06-23",
   "source": "https://codesandbox.io/s/whnhyr",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/bouncy-watch/pmndrs.json
+++ b/demos/bouncy-watch/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Custom springy controls using use-gesture and react-spring.",
   "tags": ["interaction", "custom-controls", "animation", "tag-heuer", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-11-26",
   "source": "https://codesandbox.io/s/qyz5r",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/bounds-and-makedefault/pmndrs.json
+++ b/demos/bounds-and-makedefault/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Bounds and makeDefault",
   "description": "Combining TransformControls, OrbitControls and Valtio.",
-  "tags": [
-    "fit-all",
-    "bounds"
-  ],
+  "tags": ["fit-all", "bounds"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-28",
   "source": "https://codesandbox.io/s/rz2g0",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/bruno-simons-20k-challenge/pmndrs.json
+++ b/demos/bruno-simons-20k-challenge/pmndrs.json
@@ -4,14 +4,9 @@
   "description": "https://twitter.com/bruno_simon/status/1557355710089920513",
   "tags": ["csg", "postprocessing", "physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-08-10",
   "source": "https://codesandbox.io/s/2qfxj4",
-  "libraries": [
-    "@react-three/csg",
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing",
-    "@react-three/rapier"
-  ],
+  "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier"],
   "assets": []
 }

--- a/demos/building-dynamic-envmaps/pmndrs.json
+++ b/demos/building-dynamic-envmaps/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["ssr", "reflections", "glow", "environment", "bloom", "lut"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-04",
   "source": "https://codesandbox.io/s/e662p3",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/building-live-envmaps/pmndrs.json
+++ b/demos/building-live-envmaps/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to build declarative environment that are live and animated.",
   "tags": ["lightformer"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-05",
   "source": "https://codesandbox.io/s/lwo219",
   "libraries": ["@react-three/drei", "@react-three/fiber", "lamina"],

--- a/demos/bvh/pmndrs.json
+++ b/demos/bvh/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-25",
   "source": "https://codesandbox.io/s/txzeq8",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/camera-scroll/pmndrs.json
+++ b/demos/camera-scroll/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Tying scroll to a GLTF camera path with snapping points.",
   "tags": ["snap", "scroll", "gtlf", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-29",
   "source": "https://codesandbox.io/s/tu24h",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/camera-shake/pmndrs.json
+++ b/demos/camera-shake/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Testing dre's new CameraShake with a couple of primitives.",
   "tags": ["camera-shake", "rectarea-lights", "reflections"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-02-09",
   "source": "https://codesandbox.io/s/t4l0f",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/canvas-text/pmndrs.json
+++ b/demos/canvas-text/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-28",
   "source": "https://codesandbox.io/s/p9umgf",
   "libraries": ["@react-three/fiber"],

--- a/demos/cards-with-border-radius/pmndrs.json
+++ b/demos/cards-with-border-radius/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2024-01-18",
   "source": "https://codesandbox.io/s/9s2wd9",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/cards/pmndrs.json
+++ b/demos/cards/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-12-11",
   "source": "https://codesandbox.io/s/dc5fjy",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/caustics/pmndrs.json
+++ b/demos/caustics/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-09",
   "source": "https://codesandbox.io/s/szj6p7",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/cell-fracture/pmndrs.json
+++ b/demos/cell-fracture/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Exploding GLTFs using Blenders cell-fracture and GLTFJSX.",
   "tags": ["animation", "clell-fracture", "gltf"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-01-24",
   "source": "https://codesandbox.io/s/3rjsl",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/clones/pmndrs.json
+++ b/demos/clones/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["gltf", "clone"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-19",
   "source": "https://codesandbox.io/s/42glz0",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/clouds/pmndrs.json
+++ b/demos/clouds/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Trying out drei's new cloud component.",
   "tags": ["clouds"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-11-16",
   "source": "https://codesandbox.io/s/mbfzf",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/color-grading/pmndrs.json
+++ b/demos/color-grading/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to use LUTPass to grade colors.",
   "tags": ["grading"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-11-09",
   "source": "https://codesandbox.io/s/wvgxp",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/confetti/pmndrs.json
+++ b/demos/confetti/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Meshline particles.",
   "tags": ["particles", "confetti"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-10-19",
   "source": "https://codesandbox.io/s/vl221",
   "libraries": ["@react-three/fiber", "@react-three/postprocessing", "leva", "maath", "meshline"],

--- a/demos/csg-bunny-usegroups/pmndrs.json
+++ b/demos/csg-bunny-usegroups/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-21",
   "source": "https://codesandbox.io/s/mlgzsc",
-  "libraries": [
-    "@react-three/csg",
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/csg-house/pmndrs.json
+++ b/demos/csg-house/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-22",
   "source": "https://codesandbox.io/s/y52tmt",
   "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber"],

--- a/demos/csg-operations-rapier-physics/pmndrs.json
+++ b/demos/csg-operations-rapier-physics/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["csg", "physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-07-22",
   "source": "https://codesandbox.io/s/mw0dtc",
   "libraries": ["@react-three/csg", "@react-three/drei", "@react-three/fiber", "@react-three/rapier", "lamina", "leva"],

--- a/demos/dbismut-furniture/pmndrs.json
+++ b/demos/dbismut-furniture/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-03-27",
   "source": "https://codesandbox.io/s/62o18n",
-  "libraries": [
-    "@react-spring/three",
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/diamond-refraction/pmndrs.json
+++ b/demos/diamond-refraction/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Diamon refraction material",
   "tags": ["diamond", "refraction", "raycast", "bvh"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-09-13",
   "source": "https://codesandbox.io/s/zqrreo",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/diamond-ring/pmndrs.json
+++ b/demos/diamond-ring/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["bloom", "refraction", "diamond", "ring", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-09-18",
   "source": "https://codesandbox.io/s/4gy946",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/drei-rendertexture/pmndrs.json
+++ b/demos/drei-rendertexture/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Drei RenderTexture",
   "description": "Portal a live scene events and all into a texture.",
-  "tags": [
-    "portals",
-    "rendertexture"
-  ],
+  "tags": ["portals", "rendertexture"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-05-04",
   "source": "https://codesandbox.io/s/0z8i2c",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/ecctrl-fisheye/pmndrs.json
+++ b/demos/ecctrl-fisheye/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-10-10",
   "source": "https://codesandbox.io/s/nvk9pf",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "ecctrl"],

--- a/demos/edgesgeometry/pmndrs.json
+++ b/demos/edgesgeometry/pmndrs.json
@@ -2,17 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "EdgesGeometry",
   "description": "How to use EdgesGeometry, which expects its target as a constructor argument.",
-  "tags": [
-    "outlines",
-    "gltf",
-    "geometry"
-  ],
+  "tags": ["outlines", "gltf", "geometry"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-04-06",
   "source": "https://codesandbox.io/s/iup24",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/enter-portals/pmndrs.json
+++ b/demos/enter-portals/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-06-14",
   "source": "https://codesandbox.io/s/9m4tpc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/environment-blur-and-transitions/pmndrs.json
+++ b/demos/environment-blur-and-transitions/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["environment", "blur"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-10-28",
   "source": "https://codesandbox.io/s/pj7zjq",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/envmap-ground-projection/pmndrs.json
+++ b/demos/envmap-ground-projection/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["cube camera", "reflections"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-04-10",
   "source": "https://codesandbox.io/s/q48jgy",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/faucets-select-highlight/pmndrs.json
+++ b/demos/faucets-select-highlight/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["bounds", "highlight", "selection", "metal", "reflections"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-07-15",
   "source": "https://codesandbox.io/s/8flefh",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/flexbox-yoga-in-webgl/pmndrs.json
+++ b/demos/flexbox-yoga-in-webgl/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "This example uses yoga to create flex-box layouts.",
   "tags": ["layout", "scroll", "flexbox", "text"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-09-07",
   "source": "https://codesandbox.io/s/7psew",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/flex"],

--- a/demos/floating-diamonds/pmndrs.json
+++ b/demos/floating-diamonds/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Mixing refraction shaders and animations.",
   "tags": ["gltf", "refraction"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-10-29",
   "source": "https://codesandbox.io/s/prb9t",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/floating-instanced-shoes/pmndrs.json
+++ b/demos/floating-instanced-shoes/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using drei/instances and events.",
   "tags": ["instances"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-14",
   "source": "https://codesandbox.io/s/h8o2d",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/floating-laptop/pmndrs.json
+++ b/demos/floating-laptop/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Animating GLTFs with react-spring.",
   "tags": ["gltf", "animation"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-06-05",
   "source": "https://codesandbox.io/s/q23sw",
   "libraries": ["@react-spring/three", "@react-spring/web", "@react-three/drei", "@react-three/fiber"],

--- a/demos/flow-shield/pmndrs.json
+++ b/demos/flow-shield/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Interactive force-shield playground with hit reactions, presets, and model import.",
   "tags": ["shader", "shield", "postprocessing"],
   "authors": ["Christian Ortiz"],
+  "maintainers": [],
   "publishedAt": "2026-03-24",
   "source": "http://github.com/cortiz2894/flow-shield-effect",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/flying-bananas/pmndrs.json
+++ b/demos/flying-bananas/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-29",
   "source": "https://codesandbox.io/s/2ycs3",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/frosted-glass/pmndrs.json
+++ b/demos/frosted-glass/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shader mip-map blur to mimic frosted glass. ",
   "tags": ["frosted-glas", "shaders"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-03-22",
   "source": "https://codesandbox.io/s/imn42",
   "libraries": ["@react-three/drei", "@react-three/fiber", "valtio"],

--- a/demos/gatsby-stars/pmndrs.json
+++ b/demos/gatsby-stars/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["stars", "text", "gradient", "instances"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-02-25",
   "source": "https://codesandbox.io/s/2csbr1",
   "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],

--- a/demos/glass-flower/pmndrs.json
+++ b/demos/glass-flower/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-04-13",
   "source": "https://codesandbox.io/s/dq6wwe",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/gltf-animations-re-used/pmndrs.json
+++ b/demos/gltf-animations-re-used/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "This examples shows how to blend GLTF animation keyframes and to re-use an existing model even it's being keyframed.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/k8phr",
-  "libraries": [
-    "@react-spring/three",
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/gltf-animations-tied-to-scroll/pmndrs.json
+++ b/demos/gltf-animations-tied-to-scroll/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "This examples shows how to blend GLTF animation keyframes.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-05-15",
   "source": "https://codesandbox.io/s/hg3ejl",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/gltf-animations/pmndrs.json
+++ b/demos/gltf-animations/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "This examples shows how to blend GLTF animation keyframes.",
   "tags": ["skinnedmesh", "gltf", "bones", "animations", "useanimations"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-12-06",
   "source": "https://codesandbox.io/s/pecl6",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/gltfjsx-400kb-drone/pmndrs.json
+++ b/demos/gltfjsx-400kb-drone/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows the results of gltfjsx transform compression.",
   "tags": ["bloom", "compression", "drone", "gltf"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-12-29",
   "source": "https://codesandbox.io/s/pbwi6i",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "maath"],

--- a/demos/gpgpu-curl-noise-dof/pmndrs.json
+++ b/demos/gpgpu-curl-noise-dof/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Curl noise and depth of field.",
   "tags": ["gpu", "shader", "curl", "dof"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-05",
   "source": "https://codesandbox.io/s/zgsyn",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/grass-shader/pmndrs.json
+++ b/demos/grass-shader/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Grass shader using simplex noise.",
   "tags": ["noise", "shader", "simplex", "grass"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-06-10",
   "source": "https://codesandbox.io/s/5xho4",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/ground-projected-envmaps-lamina/pmndrs.json
+++ b/demos/ground-projected-envmaps-lamina/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-04-08",
   "source": "https://codesandbox.io/s/0c5hv9",
   "libraries": ["@react-three/drei", "@react-three/fiber", "lamina"],

--- a/demos/ground-reflections-and-video-textures/pmndrs.json
+++ b/demos/ground-reflections-and-video-textures/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "This example shows drei's new Reflector in combination with video textures.",
   "tags": ["reflections"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-01-26",
   "source": "https://codesandbox.io/s/bfplr",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/hi-key-bubbles/pmndrs.json
+++ b/demos/hi-key-bubbles/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "High-key Bubbles",
   "description": "Shows to use drei/instances how far gamma-correction can stretch colors.",
-  "tags": [
-    "instances"
-  ],
+  "tags": ["instances"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-17",
   "source": "https://codesandbox.io/s/i6t0j",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []
 }

--- a/demos/horizontal-tiles/pmndrs.json
+++ b/demos/horizontal-tiles/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Horizontal scrollcontrols with expanding tiles.",
   "tags": ["expand", "scrollcontrols", "tiles", "horizontal"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-16",
   "source": "https://codesandbox.io/s/l4klb",
   "libraries": ["@react-three/drei", "@react-three/fiber", "valtio"],

--- a/demos/html-annotations/pmndrs.json
+++ b/demos/html-annotations/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to set up annotations with a distance factor.",
   "tags": ["distance", "html", "annotations"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-11-27",
   "source": "https://codesandbox.io/s/zu2wo",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/html-input-fields/pmndrs.json
+++ b/demos/html-input-fields/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["text", "html", "input"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-12-06",
   "source": "https://codesandbox.io/s/024uom",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/html-markers/pmndrs.json
+++ b/demos/html-markers/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Occluding HTML annotations/markers.",
   "tags": ["annotations", "html", "markers"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-06-23",
   "source": "https://codesandbox.io/s/6oei7",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/image-gallery/pmndrs.json
+++ b/demos/image-gallery/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Stage a couple of frames with a reflective, blurred out ground.",
   "tags": ["image", "meshreflectormaterial"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-01-05",
   "source": "https://codesandbox.io/s/lx2h8",
   "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],

--- a/demos/infinite-scroll/pmndrs.json
+++ b/demos/infinite-scroll/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Horizontal scrollcontrols that scroll infinitely.",
   "tags": ["horizontal", "scrollcontrols", "infinite"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-16",
   "source": "https://codesandbox.io/s/x8gvs",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/instanced-particles-effects/pmndrs.json
+++ b/demos/instanced-particles-effects/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Instancing, swirling particles and effects.",
   "tags": ["effects", "film", "water", "bloom", "particles"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-12-07",
   "source": "https://codesandbox.io/s/qpfgyp",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/instanced-vertex-colors/pmndrs.json
+++ b/demos/instanced-vertex-colors/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Instancing objectes with variable colors and effects.",
   "tags": ["vertex-colors", "ambient-occlusion", "bloom", "instancing"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-01-18",
   "source": "https://codesandbox.io/s/8fo01",
   "libraries": ["@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/instances/pmndrs.json
+++ b/demos/instances/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Creating fixed-position instances with varying vertex colors.",
   "tags": ["instances", "vertex-colors"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-10-02",
   "source": "https://codesandbox.io/s/h873k",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/inter-epoxy-resin/pmndrs.json
+++ b/demos/inter-epoxy-resin/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["refraction", "shaders", "glass", "epoxy"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-10-25",
   "source": "https://codesandbox.io/s/lxvqek",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/interactive-spline-scene-live-html/pmndrs.json
+++ b/demos/interactive-spline-scene-live-html/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Scene exported with Spline",
   "tags": ["spline", "stencil", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-06-15",
   "source": "https://codesandbox.io/s/f79ucc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/inverted-stencil-buffer/pmndrs.json
+++ b/demos/inverted-stencil-buffer/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to invert a masked stencil.",
   "tags": ["stencil", "portal"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-05-20",
   "source": "https://codesandbox.io/s/7n2yru",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/iridescent-decals/pmndrs.json
+++ b/demos/iridescent-decals/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["decal"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-12-30",
   "source": "https://codesandbox.io/s/qvb1vk",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/lamina-1x/pmndrs.json
+++ b/demos/lamina-1x/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "",
   "tags": ["material", "depth"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-15",
   "source": "https://codesandbox.io/s/ledhe1",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "lamina"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "lamina"],
   "assets": []
 }

--- a/demos/landing-page/pmndrs.json
+++ b/demos/landing-page/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Transparent backdrop and model staging",
   "tags": ["contact shadows"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-21",
   "source": "https://codesandbox.io/s/n60qg",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/learn-with-jason/pmndrs.json
+++ b/demos/learn-with-jason/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Small example made for a Learn-with-Jason episode.",
   "tags": ["animation", "gltf"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/oep9o",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/lulaby-city/pmndrs.json
+++ b/demos/lulaby-city/pmndrs.json
@@ -2,17 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Lullaby City",
   "description": "Panning around a city with positional audio.",
-  "tags": [
-    "positional",
-    "gltf",
-    "audio"
-  ],
+  "tags": ["positional", "gltf", "audio"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-02-10",
   "source": "https://codesandbox.io/s/gkfhr",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/lusion-connectors/pmndrs.json
+++ b/demos/lusion-connectors/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-09-12",
   "source": "https://codesandbox.io/s/xy8c8z",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier"],

--- a/demos/magic-box/pmndrs.json
+++ b/demos/magic-box/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-06-07",
   "source": "https://codesandbox.io/s/drc6qg",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/merged-instance/pmndrs.json
+++ b/demos/merged-instance/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Loading massive assemblies and re-using their parts while keeping the natural  scene graph alive.",
   "tags": ["batching", "merging", "instancing"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-19",
   "source": "https://codesandbox.io/s/kud9p",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/minecraft/pmndrs.json
+++ b/demos/minecraft/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Mini Minecraft implementation.",
   "tags": ["pointerlock-controls", "game", "minecraft"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-09-09",
   "source": "https://codesandbox.io/s/vkgi6",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "zustand"],

--- a/demos/mixing-controls/pmndrs.json
+++ b/demos/mixing-controls/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Switching off one control while the other is active.",
   "tags": ["orbit-controls", "controls", "transform-controls"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-09-10",
   "source": "https://codesandbox.io/s/hf1cs",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/mixing-html-and-webgl-w-occlusion/pmndrs.json
+++ b/demos/mixing-html-and-webgl-w-occlusion/pmndrs.json
@@ -4,11 +4,9 @@
   "description": "Having HTML and WebGL in the same scene with the addition of occlusion.",
   "tags": ["occlusion", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-05-29",
   "source": "https://codesandbox.io/s/9keg6",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/mixing-html-and-webgl/pmndrs.json
+++ b/demos/mixing-html-and-webgl/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Adding HTML into the scene.",
   "tags": ["html", "transforms"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-03-24",
   "source": "https://codesandbox.io/s/7ucso",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/moksha/pmndrs.json
+++ b/demos/moksha/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Exploration into scroll containers tied to webgl content made for codrops.",
   "tags": ["codrops", "shaders", "refraction", "scroll", "gltf", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-12-16",
   "source": "https://codesandbox.io/s/f1ixt",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/monitors/pmndrs.json
+++ b/demos/monitors/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["bloom"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-12-15",
   "source": "https://codesandbox.io/s/bst0cy",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "maath"],

--- a/demos/motionpathcontrols/pmndrs.json
+++ b/demos/motionpathcontrols/pmndrs.json
@@ -4,13 +4,9 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-09-17",
   "source": "https://codesandbox.io/s/2y73c6",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing",
-    "leva"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []
 }

--- a/demos/mount-transitions/pmndrs.json
+++ b/demos/mount-transitions/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to use react-spring mount/unmount transitions, soft-shadows and AO.",
   "tags": ["soft-shadows", "animation", "ambient-occlusion", "transitions"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-09-18",
   "source": "https://codesandbox.io/s/1sccp",
   "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/multiple-views-with-uniform-controls/pmndrs.json
+++ b/demos/multiple-views-with-uniform-controls/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-19",
   "source": "https://codesandbox.io/s/r9w2ob",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/nextjs-prism/pmndrs.json
+++ b/demos/nextjs-prism/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-08-17",
   "source": "https://codesandbox.io/s/j3ycvl",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []
 }

--- a/demos/night-train/pmndrs.json
+++ b/demos/night-train/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Stacking a couple of drei helpers",
   "tags": ["merged", "scroll-controls", "meshreflectormaterial", "instances"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-08-07",
   "source": "https://codesandbox.io/s/l900i",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/object-clump/pmndrs.json
+++ b/demos/object-clump/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to make a clump of objects that move towards the center point.",
   "tags": ["physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-02-22",
   "source": "https://codesandbox.io/s/ssbdsw",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/pairing-threejs-to-ui/pmndrs.json
+++ b/demos/pairing-threejs-to-ui/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-07-04",
   "source": "https://codesandbox.io/s/wlz1o0",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/pass-through-portals/pmndrs.json
+++ b/demos/pass-through-portals/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["portal"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-06-17",
   "source": "https://codesandbox.io/s/qvk72r",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/physics-with-convex-polyhedrons/pmndrs.json
+++ b/demos/physics-with-convex-polyhedrons/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using cannon collisions with GLTFs converted into convex hulls.",
   "tags": ["physics", "collisions", "convex-polyhedron", "gltf"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-03-13",
   "source": "https://codesandbox.io/s/08s1u",
   "libraries": [

--- a/demos/pinball-in-70-lines/pmndrs.json
+++ b/demos/pinball-in-70-lines/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Super small pinball barebones implementation.",
   "tags": ["physics", "pinball", "arkanoid", "game"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-08-02",
   "source": "https://codesandbox.io/s/rmfcq",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],

--- a/demos/pmndrs-vercel/pmndrs.json
+++ b/demos/pmndrs-vercel/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["gradient", "material"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-13",
   "source": "https://codesandbox.io/s/go0b4w",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber", "lamina"],

--- a/demos/portal-shapes/pmndrs.json
+++ b/demos/portal-shapes/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-31",
   "source": "https://codesandbox.io/s/8j36ok",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier"],

--- a/demos/portals/pmndrs.json
+++ b/demos/portals/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-06-05",
   "source": "https://codesandbox.io/s/ik11ln",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/progressive-loading-states-with-suspense/pmndrs.json
+++ b/demos/progressive-loading-states-with-suspense/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense.",
   "tags": ["gltf", "suspense", "loading"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-02-08",
   "source": "https://codesandbox.io/s/7duy8",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/racing-game/pmndrs.json
+++ b/demos/racing-game/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A semi-complete racing game.",
   "tags": ["game", "vehicle", "racing", "physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-07-23",
   "source": "https://codesandbox.io/s/lo6kp",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/ragdoll-physics/pmndrs.json
+++ b/demos/ragdoll-physics/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A mini game using cannon ragdoll physics. Throw the little guy around.",
   "tags": ["game", "ragdoll", "physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-09-25",
   "source": "https://codesandbox.io/s/wdzv4",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],

--- a/demos/rapier-physics/pmndrs.json
+++ b/demos/rapier-physics/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-07-16",
   "source": "https://codesandbox.io/s/7e9y1b",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "leva"],

--- a/demos/rapier-ping-pong/pmndrs.json
+++ b/demos/rapier-ping-pong/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Mini ping-pong implementation using rapier-physics.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2024-01-20",
   "source": "https://codesandbox.io/s/ptdgrn",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "@react-three/rapier", "valtio"],

--- a/demos/raycast-cycling/pmndrs.json
+++ b/demos/raycast-cycling/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Bringing multiple objects underneath the cursor up front through raycast cycling",
   "tags": ["raycast", "cycling"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-22",
   "source": "https://codesandbox.io/s/ls503",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/re-using-geometry-and-level-of-detail/pmndrs.json
+++ b/demos/re-using-geometry-and-level-of-detail/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Demonstrates how to load a model progressively with fallbacks via React.Suspense, and using them as a LOD.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-07-04",
   "source": "https://codesandbox.io/s/12nmp",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/re-using-gltfs/pmndrs.json
+++ b/demos/re-using-gltfs/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "When you use GLTFJSX it creates a immutable snapshot of your assets, these can be reused.",
   "tags": ["re-use", "gltf"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-08",
   "source": "https://codesandbox.io/s/dix1y",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/react-ellipsecurve/pmndrs.json
+++ b/demos/react-ellipsecurve/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "React EllipseCurve",
   "description": "",
-  "tags": [
-    "trails"
-  ],
+  "tags": ["trails"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-10-20",
   "source": "https://codesandbox.io/s/xzi6ps",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []
 }

--- a/demos/react-pp-outlines/pmndrs.json
+++ b/demos/react-pp-outlines/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to build declarative, nested outlines where higher-ups take precedence.",
   "tags": ["outlines"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-11",
   "source": "https://codesandbox.io/s/nurp5t",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/react-spring-animations/pmndrs.json
+++ b/demos/react-spring-animations/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "This is react-spring animating both the dom as well as the canvas with a single spring.",
   "tags": ["gltf", "physics", "spring", "animation"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-05-06",
   "source": "https://codesandbox.io/s/6hi1y",
   "libraries": ["@react-spring/core", "@react-spring/three", "@react-spring/web", "@react-three/drei", "@react-three/fiber"],

--- a/demos/room-with-soft-shadows/pmndrs.json
+++ b/demos/room-with-soft-shadows/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Percentage closer soft shadows.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-02-27",
   "source": "https://codesandbox.io/s/ykfpwf",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/router-transitions/pmndrs.json
+++ b/demos/router-transitions/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to implement routes and mount/unmount transition within the canvas using Wouter.",
   "tags": ["router", "transitions", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/4j2q2",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/scrollcontrols-and-lens-refraction/pmndrs.json
+++ b/demos/scrollcontrols-and-lens-refraction/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "Vertical scrollcontrols and minimaps.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-07",
   "source": "https://codesandbox.io/s/2n98yj",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "maath"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],
   "assets": []
 }

--- a/demos/scrollcontrols-gltf/pmndrs.json
+++ b/demos/scrollcontrols-gltf/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "ScrollControls GLTF",
   "description": "Connecting models with useScroll",
-  "tags": [
-    "gltf",
-    "scrollcontrols"
-  ],
+  "tags": ["gltf", "scrollcontrols"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-22",
   "source": "https://codesandbox.io/s/4jr4p",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/scrollcontrols-with-minimap/pmndrs.json
+++ b/demos/scrollcontrols-with-minimap/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "ScrollControls with Minimap",
   "description": "Vertical scrollcontrols and minimaps.",
-  "tags": [
-    "vertical",
-    "minimap"
-  ],
+  "tags": ["vertical", "minimap"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-13",
   "source": "https://codesandbox.io/s/yjhzv",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/selective-outlines/pmndrs.json
+++ b/demos/selective-outlines/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using postprocessing to give seletcive objects outlines.",
   "tags": ["postprocessing", "outlines"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-05-07",
   "source": "https://codesandbox.io/s/d36mw",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/shader-fire/pmndrs.json
+++ b/demos/shader-fire/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A volumetric fire effect.",
   "tags": ["fire", "volumetric", "shader"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-05-14",
   "source": "https://codesandbox.io/s/3878x",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/shader-hmr/pmndrs.json
+++ b/demos/shader-hmr/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to create HMR shaders",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-07-18",
   "source": "https://codesandbox.io/s/ib0jc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/shadermaterials/pmndrs.json
+++ b/demos/shadermaterials/pmndrs.json
@@ -2,16 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Shader Materials",
   "description": "How to set up shader materials declaratively.",
-  "tags": [
-    "material",
-    "shader"
-  ],
+  "tags": ["material", "shader"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-12-11",
   "source": "https://codesandbox.io/s/1g4qq",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/shoe-configurator/pmndrs.json
+++ b/demos/shoe-configurator/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A super small configurator that shows you how to make GLTF assets dynamic.",
   "tags": ["state", "gltf", "configurator"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-12-11",
   "source": "https://codesandbox.io/s/qxjoj",
   "libraries": ["@react-three/drei", "@react-three/fiber", "valtio"],

--- a/demos/shopping/pmndrs.json
+++ b/demos/shopping/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-09-18",
   "source": "https://codesandbox.io/s/4gy946",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/simple-audio-analyser/pmndrs.json
+++ b/demos/simple-audio-analyser/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Audio frequency analysis.",
   "tags": ["analyser", "audio"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-09-02",
   "source": "https://codesandbox.io/s/wu51m",
   "libraries": ["@react-three/fiber"],

--- a/demos/simple-physics-demo-with-debug-bounds/pmndrs.json
+++ b/demos/simple-physics-demo-with-debug-bounds/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A box dropping onto a plane using use-cannon / cannon-es.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-06-08",
   "source": "https://codesandbox.io/s/0k27n",
   "libraries": ["@react-three/cannon", "@react-three/fiber"],

--- a/demos/simple-physics-demo/pmndrs.json
+++ b/demos/simple-physics-demo/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A box dropping onto a plane using use-cannon / cannon-es.",
   "tags": ["physics"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-05-26",
   "source": "https://codesandbox.io/s/z8e6m",
   "libraries": ["@react-three/cannon", "@react-three/fiber"],

--- a/demos/sky-dome-with-annotations/pmndrs.json
+++ b/demos/sky-dome-with-annotations/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Dome projecting texture and HTML annotations.",
   "tags": ["annotations", "html", "dome"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-02-10",
   "source": "https://codesandbox.io/s/wbrfs",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/soft-shadows/pmndrs.json
+++ b/demos/soft-shadows/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Percentage closer soft shadows.",
   "tags": ["pcss", "soft-shadows"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-09-28",
   "source": "https://codesandbox.io/s/dh2jc",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/space-game/pmndrs.json
+++ b/demos/space-game/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "A small demo that shows how to manage game entities.",
   "tags": ["physics", "game"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-10-16",
   "source": "https://codesandbox.io/s/i2160",
   "libraries": ["@react-three/drei", "@react-three/fiber", "zustand"],

--- a/demos/sparks-and-effects/pmndrs.json
+++ b/demos/sparks-and-effects/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Demonstrating fake-particles, mesh-lines and effect composition.",
   "tags": ["glow", "mesh-line", "effects", "particles", "text-geometry"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-01-10",
   "source": "https://codesandbox.io/s/sbf2i",
   "libraries": ["@react-three/fiber"],

--- a/demos/spline-glass-shapes/pmndrs.json
+++ b/demos/spline-glass-shapes/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Scene exported with Spline",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-01-07",
   "source": "https://codesandbox.io/s/ju368j",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/sport-hall/pmndrs.json
+++ b/demos/sport-hall/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": ["box projected", "environment", "ground mapping", "reflections"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-02-09",
   "source": "https://codesandbox.io/s/s006f",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/springy-boxes/pmndrs.json
+++ b/demos/springy-boxes/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Colorfull boxes changing position with spring physics",
   "tags": ["springs", "physics", "animation"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-04-02",
   "source": "https://codesandbox.io/s/jz9l97qn89",
   "libraries": ["@react-spring/three", "@react-three/fiber"],

--- a/demos/ssgi-spheres-with-rapier-physics/pmndrs.json
+++ b/demos/ssgi-spheres-with-rapier-physics/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-11-12",
   "source": "https://codesandbox.io/s/5w35n6",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "maath"],

--- a/demos/ssr-test/pmndrs.json
+++ b/demos/ssr-test/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Screen space reflections",
   "tags": ["ssr", "postprocessing"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-06-30",
   "source": "https://codesandbox.io/s/8pbw1f",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],

--- a/demos/stage-presets-gltfjsx/pmndrs.json
+++ b/demos/stage-presets-gltfjsx/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["gltf", "stage", "lighting"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-12-20",
   "source": "https://codesandbox.io/s/if9crg",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/staging-and-camerashake/pmndrs.json
+++ b/demos/staging-and-camerashake/pmndrs.json
@@ -2,17 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Staging and CameraShake",
   "description": "How to stage and shake models while using controls at the same time.",
-  "tags": [
-    "stage",
-    "camera-shake",
-    "controls"
-  ],
+  "tags": ["stage", "camera-shake", "controls"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-13",
   "source": "https://codesandbox.io/s/0ycwe",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/starwars/pmndrs.json
+++ b/demos/starwars/pmndrs.json
@@ -2,19 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Star Wars",
   "description": "",
-  "tags": [
-    "ssr",
-    "bloom",
-    "hdr"
-  ],
+  "tags": ["ssr", "bloom", "hdr"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-07-12",
   "source": "https://codesandbox.io/s/fslt99",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing",
-    "leva"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "leva"],
   "assets": []
 }

--- a/demos/stencil-mask/pmndrs.json
+++ b/demos/stencil-mask/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using the stencil mask to cut out areas of the screen.",
   "tags": ["stencil", "mask"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-05-11",
   "source": "https://codesandbox.io/s/z3f2mw",
   "libraries": ["@react-three/drei", "@react-three/fiber", "leva"],

--- a/demos/svg-maps-with-html-annotations/pmndrs.json
+++ b/demos/svg-maps-with-html-annotations/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using SVGLoader, converting each path into cell components with annotations and map controls.",
   "tags": ["html", "svg"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-09-16",
   "source": "https://codesandbox.io/s/mkq8e",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/svg-renderer/pmndrs.json
+++ b/demos/svg-renderer/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Using the render function to inject custom renderers.",
   "tags": ["custom-renderer", "svg-renderer"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-03-30",
   "source": "https://codesandbox.io/s/zcuqh",
   "libraries": ["@react-three/fiber"],

--- a/demos/t-shirt-configurator/pmndrs.json
+++ b/demos/t-shirt-configurator/pmndrs.json
@@ -2,17 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "T-Shirt Configurator",
   "description": "",
-  "tags": [
-    "decals"
-  ],
+  "tags": ["decals"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-08-15",
   "source": "https://codesandbox.io/s/ioxywi",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "maath",
-    "valtio"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "maath", "valtio"],
   "assets": []
 }

--- a/demos/the-three-graces/pmndrs.json
+++ b/demos/the-three-graces/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Experimentaing with lights and shadows.",
   "tags": ["shadows", "lights", "gltf", "html-annotations", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/0n9it",
   "libraries": ["@react-three/drei", "@react-three/fiber", "maath"],

--- a/demos/threejs-journey-lv-1-fisheye/pmndrs.json
+++ b/demos/threejs-journey-lv-1-fisheye/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "A recreation of the first level from https://threejs-journey.com.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-10-07",
   "source": "https://codesandbox.io/s/7qytdw",
-  "libraries": [
-    "@react-spring/three",
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/threejs-journey-portal/pmndrs.json
+++ b/demos/threejs-journey-portal/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "The last scene from Bruno Simons Threejs journey in react-three-fiber",
   "tags": ["gltf", "particles", "shaders"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-19",
   "source": "https://codesandbox.io/s/ni6v4",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/thunder-clouds/pmndrs.json
+++ b/demos/thunder-clouds/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Trying out drei's new cloud component.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-09-25",
   "source": "https://codesandbox.io/s/gwthnh",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/rapier", "maath"],

--- a/demos/transformcontrols-and-makedefault/pmndrs.json
+++ b/demos/transformcontrols-and-makedefault/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "Combining TransformControls, OrbitControls and Valtio.",
   "tags": ["controls", "state", "orbit", "transform"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-08",
   "source": "https://codesandbox.io/s/btsbj",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "valtio"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "valtio"],
   "assets": []
 }

--- a/demos/transparent-aesop-bottles/pmndrs.json
+++ b/demos/transparent-aesop-bottles/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "PBR transmission and thickness to emulate glas.",
   "tags": ["reflections", "transmission", "glas"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-08",
   "source": "https://codesandbox.io/s/kv7tv",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/trigger-meshes/pmndrs.json
+++ b/demos/trigger-meshes/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to implement trigger meshes that inform the application of collisions.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-06-05",
   "source": "https://codesandbox.io/s/h545c",
   "libraries": ["@react-three/cannon", "@react-three/drei", "@react-three/fiber"],

--- a/demos/tying-canvas-to-scroll-offset/pmndrs.json
+++ b/demos/tying-canvas-to-scroll-offset/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to tie canvas objects to scrollTop while events keep working.",
   "tags": ["scroll", "lerp", "events", "animation", "html"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-17",
   "source": "https://codesandbox.io/s/itfgk",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/useintersect-and-scrollcontrols/pmndrs.json
+++ b/demos/useintersect-and-scrollcontrols/pmndrs.json
@@ -2,18 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "useIntersect and ScrollControls",
   "description": "Combining useIntersect with scrollcontrols.",
-  "tags": [
-    "vertical",
-    "useintersect",
-    "intersection",
-    "scrollcontrols"
-  ],
+  "tags": ["vertical", "useintersect", "intersection", "scrollcontrols"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-10-18",
   "source": "https://codesandbox.io/s/gsm1y",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/video-cookies/pmndrs.json
+++ b/demos/video-cookies/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to use drei/AccumulativeShadows and RandomizedLight",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-08-31",
   "source": "https://codesandbox.io/s/hmbn1l",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],

--- a/demos/video-textures/pmndrs.json
+++ b/demos/video-textures/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "How to load, apply and play video textures, and how to calculate fullscreen, or \"cover\" aspect ratio. ",
   "tags": ["video", "texture", "aspect-ratio"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-08-20",
   "source": "https://codesandbox.io/s/39hg8",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/view-tracking/pmndrs.json
+++ b/demos/view-tracking/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to form self-contained components with their own state and user interaction.",
   "tags": [],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2022-03-29",
   "source": "https://codesandbox.io/s/bp6tmc",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/viewcube/pmndrs.json
+++ b/demos/viewcube/pmndrs.json
@@ -2,17 +2,11 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "View Cube",
   "description": "Shows how to do heads-up-displays using React.portals.",
-  "tags": [
-    "portal",
-    "viewcube",
-    "hud"
-  ],
+  "tags": ["portal", "viewcube", "hud"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2019-11-05",
   "source": "https://codesandbox.io/s/py4db",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber"],
   "assets": []
 }

--- a/demos/viking-ship/pmndrs.json
+++ b/demos/viking-ship/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "GLTF workflow with GLTFJSX and camera rotations.",
   "tags": ["gltf"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2020-05-02",
   "source": "https://codesandbox.io/s/0buje",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/volumetric-light-godray/pmndrs.json
+++ b/demos/volumetric-light-godray/pmndrs.json
@@ -4,12 +4,9 @@
   "description": "Experimenting with volumetric lights.",
   "tags": ["postprocessing", "godray"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2023-06-24",
   "source": "https://codesandbox.io/s/yggpw5",
-  "libraries": [
-    "@react-three/drei",
-    "@react-three/fiber",
-    "@react-three/postprocessing"
-  ],
+  "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing"],
   "assets": []
 }

--- a/demos/volumetric-spotlight/pmndrs.json
+++ b/demos/volumetric-spotlight/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Volumetric soft particle spot lights.",
   "tags": ["volumetric", "spotlight", "soft-particles", "spot"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-05-24",
   "source": "https://codesandbox.io/s/tx1pq",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/water-shader/pmndrs.json
+++ b/demos/water-shader/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "",
   "tags": ["shader", "water"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-04-15",
   "source": "https://codesandbox.io/s/1b40u",
   "libraries": ["@react-three/drei", "@react-three/fiber"],

--- a/demos/wobbling-sphere/pmndrs.json
+++ b/demos/wobbling-sphere/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Experimenting with environment maps.",
   "tags": ["environment", "reflections", "soft-shadows"],
   "authors": ["Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-01-07",
   "source": "https://codesandbox.io/s/5oufp",
   "libraries": ["@react-spring/three", "@react-three/drei", "@react-three/fiber"],

--- a/demos/zustand-site/pmndrs.json
+++ b/demos/zustand-site/pmndrs.json
@@ -4,6 +4,7 @@
   "description": "Shows how to parallax layers with dept of field and particles.",
   "tags": ["parallax", "animation", "dof", "particles"],
   "authors": ["Gianmarco Simone", "Paul Henschel"],
+  "maintainers": [],
   "publishedAt": "2021-03-26",
   "source": "https://codesandbox.io/s/gpioq",
   "libraries": ["@react-three/drei", "@react-three/fiber", "@react-three/postprocessing", "meshline"],

--- a/docs/agents/broken-demos.md
+++ b/docs/agents/broken-demos.md
@@ -1,0 +1,52 @@
+# Broken demos: prod monitoring & maintainer notifications
+
+## Maintainers
+
+Every demo declares its maintainers in `demos/<name>/pmndrs.json`:
+
+```json
+"maintainers": ["abernier"]
+```
+
+- Bare GitHub logins (no `@`), validated by `schemas/pmndrs.schema.json` and
+  `pnpm lint:metadata`.
+- The field is required; `[]` means "nobody to ping" — the demo still shows up
+  in the rollup issue, without mentions.
+- To adopt a demo, add your login and open a PR.
+
+## CI behavior
+
+Only demos with a `"test": "e2e-test ..."` script are monitored (see
+`packages/e2e`).
+
+- **PRs**: `pnpm test` fails fast — a broken demo blocks the PR. Unchanged.
+- **main (prod)**: `turbo test --continue=dependencies-successful --summarize`
+  plays **all** tests. The step is `continue-on-error`: build + Pages deploy
+  proceed even with broken demos (one broken demo must not freeze the site),
+  and `e2e-status-job` mirrors the outcome so the run still goes **red**.
+  Trade-off: a visual regression caught by snapshots IS deployed until fixed.
+- A demo is **broken** when its `build2` or `test` task exits non-zero.
+- Flakes: playwright retries twice in CI (`packages/e2e/playwright.config.ts`);
+  only a test failing 3 times in a row counts.
+- Snapshot-regen runs (`workflow_dispatch` + `update_snapshots`) never notify.
+
+## One issue per broken demo
+
+`bin/notify-broken-demos.mjs` (unit-tested logic in `bin/lib/broken-demos.mjs`,
+`pnpm test:unit`) maintains one issue per broken demo, labeled `broken-demos`,
+on every push to main:
+
+- Each issue is tied to its demo by a hidden `<!-- broken-demo:<name> -->`
+  marker in the body. The set of open `broken-demos` issues IS the previous
+  state — there is no other state store.
+- **Body** = latest failing run: demo link, maintainers, run link. Refreshed
+  on every failing run.
+- **Delta-only notifications**: maintainers are @mentioned only when their
+  demo goes green→broken — via the body at issue creation, or a comment on
+  reopen (editing a body never notifies, comments do). A still-broken demo
+  stays silent.
+- **Lifecycle**: closes itself (with a no-mention note) when its demo is
+  green again, reopens the same thread on the next failure.
+
+Local debugging: `DRY_RUN=1 node bin/notify-broken-demos.mjs` prints the
+broken list from the newest `.turbo/runs/*.json` without touching GitHub.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "turbo dev2",
     "lint": "turbo lint",
     "lint:metadata": "node bin/validate-pmndrs-metadata.mjs",
+    "test:unit": "node --test 'bin/**/*.test.mjs'",
     "lint:versions": "syncpack lint",
     "fix:versions": "syncpack fix-mismatches",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -4,6 +4,9 @@ import type { PlaywrightTestConfig } from "@playwright/test";
 const config: PlaywrightTestConfig = {
   // testDir: "/Users/abernier/code/pmndrs/examples/packages/e2e/src",
   timeout: 60_000, // default 30s flakes on 2-core CI runners under parallel load
+  // A flake on main would false-alarm the broken-demos rollup issue and ping
+  // maintainers for nothing: only a test that fails 3 times in a row counts.
+  retries: process.env.CI ? 2 : 0,
 };
 
 export default config;

--- a/schemas/pmndrs.schema.json
+++ b/schemas/pmndrs.schema.json
@@ -10,6 +10,7 @@
     "description",
     "tags",
     "authors",
+    "maintainers",
     "source",
     "libraries",
     "assets"
@@ -38,6 +39,15 @@
       "items": {
         "type": "string",
         "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "maintainers": {
+      "description": "GitHub logins (without @) notified when the demo breaks on main",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9](-?[a-zA-Z0-9]){0,38}$"
       },
       "uniqueItems": true
     },


### PR DESCRIPTION
## What

Every demo's `pmndrs.json` now declares **`maintainers`** (bare GitHub logins, required, `[]` allowed). On pushes to `main`, CI plays **all** e2e tests (`--continue=dependencies-successful`) and opens/maintains **one GitHub issue per broken demo**, @mentioning its maintainers. PR behavior is unchanged (fail-fast).

## How

- **Schema**: `maintainers` added to `schemas/pmndrs.schema.json` + the hand-rolled validator (login regex, uniqueness). All 158 `pmndrs.json` migrated with `"maintainers": []` and normalized to prettier style.
- **CI on main**: the e2e step is `continue-on-error` so build + Pages deploy always run — one broken demo no longer freezes the site. A final `e2e-status-job` still turns the run red. Snapshot-regen dispatch runs never notify.
- **Notifier** (`bin/notify-broken-demos.mjs`, pure logic unit-tested in `bin/lib/broken-demos.mjs`, `pnpm test:unit`): reads the turbo `--summarize` run summary (broken = `build2` or `test` exit ≠ 0); each issue is tied to its demo by a hidden body marker; the set of open `broken-demos` issues is the only state store. Delta-only pings: body mentions on creation, comment on reopen, silence while still broken, auto-close with a note once green.
- **Flakes**: playwright `retries: 2` in CI — a demo is only broken after 3 straight failures.
- **Docs**: `docs/agents/broken-demos.md` + pointer in `AGENTS.md`.

## Trade-off (deliberate)

A visual regression caught by snapshots **is deployed** until its maintainer fixes it: monitoring over gating.

## Test plan

- [x] `pnpm test:unit` (11 tests on the pure logic, also runs in CI)
- [x] `pnpm lint:metadata` over the 158 migrated files
- [x] `DRY_RUN=1 node bin/notify-broken-demos.mjs` against a real local turbo summary
- [x] Full `pnpm test` e2e suite locally
- [ ] After merge: watch the first main run (label + issues created on a real breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zSPJcxKxiSPKX1hkejGGC