### PR TITLE
Let Dependabot update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions" # Actions used in .github/workflows
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds a `github-actions` ecosystem entry to `.github/dependabot.yml` so action versions in `.github/workflows/` get bumped too (daily, same cadence as npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)