### PR TITLE
Update demos to Vite 8

### DIFF
--- a/demos/aquarium/package.json
+++ b/demos/aquarium/package.json
@@ -17,9 +17,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/arkanoid-under-60-loc/package.json
+++ b/demos/arkanoid-under-60-loc/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/arkanoid/package.json
+++ b/demos/arkanoid/package.json
@@ -29,9 +29,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/audio-analyser/package.json
+++ b/demos/audio-analyser/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/backdrop-and-cables/package.json
+++ b/demos/backdrop-and-cables/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/baking-soft-shadows/package.json
+++ b/demos/baking-soft-shadows/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/basic-ballpit/package.json
+++ b/demos/basic-ballpit/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/basic-demo/package.json
+++ b/demos/basic-demo/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bestservedbold-christmas-baubles/package.json
+++ b/demos/bestservedbold-christmas-baubles/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bezier-curves-and-nodes/package.json
+++ b/demos/bezier-curves-and-nodes/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bloom-hdr-workflow-gltf/package.json
+++ b/demos/bloom-hdr-workflow-gltf/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bouncy-watch/package.json
+++ b/demos/bouncy-watch/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bounds-and-makedefault/package.json
+++ b/demos/bounds-and-makedefault/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bruno-simons-20k-challenge/package.json
+++ b/demos/bruno-simons-20k-challenge/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/building-dynamic-envmaps/package.json
+++ b/demos/building-dynamic-envmaps/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/building-live-envmaps/package.json
+++ b/demos/building-live-envmaps/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/bvh/package.json
+++ b/demos/bvh/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/camera-scroll/package.json
+++ b/demos/camera-scroll/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/camera-shake/package.json
+++ b/demos/camera-shake/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/canvas-text/package.json
+++ b/demos/canvas-text/package.json
@@ -11,9 +11,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/cards-with-border-radius/package.json
+++ b/demos/cards-with-border-radius/package.json
@@ -27,9 +27,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/cards/package.json
+++ b/demos/cards/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/caustics/package.json
+++ b/demos/caustics/package.json
@@ -26,9 +26,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/cell-fracture/package.json
+++ b/demos/cell-fracture/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/clones/package.json
+++ b/demos/clones/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/clouds/package.json
+++ b/demos/clouds/package.json
@@ -40,9 +40,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/color-grading/package.json
+++ b/demos/color-grading/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/confetti/package.json
+++ b/demos/confetti/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/csg-bunny-usegroups/package.json
+++ b/demos/csg-bunny-usegroups/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/csg-house/package.json
+++ b/demos/csg-house/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/csg-operations-rapier-physics/package.json
+++ b/demos/csg-operations-rapier-physics/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/dbismut-furniture/package.json
+++ b/demos/dbismut-furniture/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/diamond-refraction/package.json
+++ b/demos/diamond-refraction/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/diamond-ring/package.json
+++ b/demos/diamond-ring/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/drei-rendertexture/package.json
+++ b/demos/drei-rendertexture/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/ecctrl-fisheye/package.json
+++ b/demos/ecctrl-fisheye/package.json
@@ -28,9 +28,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/edgesgeometry/package.json
+++ b/demos/edgesgeometry/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/enter-portals/package.json
+++ b/demos/enter-portals/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/environment-blur-and-transitions/package.json
+++ b/demos/environment-blur-and-transitions/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/envmap-ground-projection/package.json
+++ b/demos/envmap-ground-projection/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/faucets-select-highlight/package.json
+++ b/demos/faucets-select-highlight/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/flexbox-yoga-in-webgl/package.json
+++ b/demos/flexbox-yoga-in-webgl/package.json
@@ -36,9 +36,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/floating-diamonds/package.json
+++ b/demos/floating-diamonds/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/floating-instanced-shoes/package.json
+++ b/demos/floating-instanced-shoes/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/floating-laptop/package.json
+++ b/demos/floating-laptop/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/flow-shield/package.json
+++ b/demos/flow-shield/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/flying-bananas/package.json
+++ b/demos/flying-bananas/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/frosted-glass/package.json
+++ b/demos/frosted-glass/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/gatsby-stars/package.json
+++ b/demos/gatsby-stars/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/glass-flower/package.json
+++ b/demos/glass-flower/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/gltf-animations-re-used/package.json
+++ b/demos/gltf-animations-re-used/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/gltf-animations-tied-to-scroll/package.json
+++ b/demos/gltf-animations-tied-to-scroll/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/gltf-animations/package.json
+++ b/demos/gltf-animations/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/gltfjsx-400kb-drone/package.json
+++ b/demos/gltfjsx-400kb-drone/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/gpgpu-curl-noise-dof/package.json
+++ b/demos/gpgpu-curl-noise-dof/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/grass-shader/package.json
+++ b/demos/grass-shader/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/ground-projected-envmaps-lamina/package.json
+++ b/demos/ground-projected-envmaps-lamina/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/ground-reflections-and-video-textures/package.json
+++ b/demos/ground-reflections-and-video-textures/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/hi-key-bubbles/package.json
+++ b/demos/hi-key-bubbles/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/horizontal-tiles/package.json
+++ b/demos/horizontal-tiles/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/html-annotations/package.json
+++ b/demos/html-annotations/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/html-input-fields/package.json
+++ b/demos/html-input-fields/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/html-markers/package.json
+++ b/demos/html-markers/package.json
@@ -10,9 +10,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "dependencies": {
     "@react-three/drei": "10.7.7",

--- a/demos/image-gallery/package.json
+++ b/demos/image-gallery/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/infinite-scroll/package.json
+++ b/demos/infinite-scroll/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/instanced-particles-effects/package.json
+++ b/demos/instanced-particles-effects/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/instanced-vertex-colors/package.json
+++ b/demos/instanced-vertex-colors/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/instances/package.json
+++ b/demos/instances/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/inter-epoxy-resin/package.json
+++ b/demos/inter-epoxy-resin/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/interactive-spline-scene-live-html/package.json
+++ b/demos/interactive-spline-scene-live-html/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/inverted-stencil-buffer/package.json
+++ b/demos/inverted-stencil-buffer/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/iridescent-decals/package.json
+++ b/demos/iridescent-decals/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/lamina-1x/package.json
+++ b/demos/lamina-1x/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/landing-page/package.json
+++ b/demos/landing-page/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/learn-with-jason/package.json
+++ b/demos/learn-with-jason/package.json
@@ -36,9 +36,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/lulaby-city/package.json
+++ b/demos/lulaby-city/package.json
@@ -37,10 +37,10 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "lint-staged": "^16.2.7",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "browserslist": {
     "production": [

--- a/demos/lusion-connectors/package.json
+++ b/demos/lusion-connectors/package.json
@@ -28,9 +28,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/magic-box/package.json
+++ b/demos/magic-box/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/merged-instance/package.json
+++ b/demos/merged-instance/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/minecraft/package.json
+++ b/demos/minecraft/package.json
@@ -39,9 +39,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/mixing-controls/package.json
+++ b/demos/mixing-controls/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/mixing-html-and-webgl-w-occlusion/package.json
+++ b/demos/mixing-html-and-webgl-w-occlusion/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/mixing-html-and-webgl/package.json
+++ b/demos/mixing-html-and-webgl/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/moksha/package.json
+++ b/demos/moksha/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/monitors/package.json
+++ b/demos/monitors/package.json
@@ -31,9 +31,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/motionpathcontrols/package.json
+++ b/demos/motionpathcontrols/package.json
@@ -28,9 +28,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/mount-transitions/package.json
+++ b/demos/mount-transitions/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/multiple-views-with-uniform-controls/package.json
+++ b/demos/multiple-views-with-uniform-controls/package.json
@@ -17,9 +17,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/nextjs-prism/package.json
+++ b/demos/nextjs-prism/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/night-train/package.json
+++ b/demos/night-train/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/object-clump/package.json
+++ b/demos/object-clump/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/pairing-threejs-to-ui/package.json
+++ b/demos/pairing-threejs-to-ui/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/pass-through-portals/package.json
+++ b/demos/pass-through-portals/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/physics-with-convex-polyhedrons/package.json
+++ b/demos/physics-with-convex-polyhedrons/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/pinball-in-70-lines/package.json
+++ b/demos/pinball-in-70-lines/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/pmndrs-vercel/package.json
+++ b/demos/pmndrs-vercel/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/portal-shapes/package.json
+++ b/demos/portal-shapes/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/portals/package.json
+++ b/demos/portals/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/progressive-loading-states-with-suspense/package.json
+++ b/demos/progressive-loading-states-with-suspense/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/racing-game/package.json
+++ b/demos/racing-game/package.json
@@ -20,9 +20,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/ragdoll-physics/package.json
+++ b/demos/ragdoll-physics/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/rapier-physics/package.json
+++ b/demos/rapier-physics/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/rapier-ping-pong/package.json
+++ b/demos/rapier-ping-pong/package.json
@@ -17,9 +17,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/raycast-cycling/package.json
+++ b/demos/raycast-cycling/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/re-using-geometry-and-level-of-detail/package.json
+++ b/demos/re-using-geometry-and-level-of-detail/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/re-using-gltfs/package.json
+++ b/demos/re-using-gltfs/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/react-ellipsecurve/package.json
+++ b/demos/react-ellipsecurve/package.json
@@ -33,9 +33,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/react-pp-outlines/package.json
+++ b/demos/react-pp-outlines/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/react-spring-animations/package.json
+++ b/demos/react-spring-animations/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/room-with-soft-shadows/package.json
+++ b/demos/room-with-soft-shadows/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/router-transitions/package.json
+++ b/demos/router-transitions/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/scrollcontrols-and-lens-refraction/package.json
+++ b/demos/scrollcontrols-and-lens-refraction/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/scrollcontrols-gltf/package.json
+++ b/demos/scrollcontrols-gltf/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/scrollcontrols-with-minimap/package.json
+++ b/demos/scrollcontrols-with-minimap/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/selective-outlines/package.json
+++ b/demos/selective-outlines/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/shader-fire/package.json
+++ b/demos/shader-fire/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/shader-hmr/package.json
+++ b/demos/shader-hmr/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/shadermaterials/package.json
+++ b/demos/shadermaterials/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/shoe-configurator/package.json
+++ b/demos/shoe-configurator/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/shopping/package.json
+++ b/demos/shopping/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/simple-audio-analyser/package.json
+++ b/demos/simple-audio-analyser/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/simple-physics-demo-with-debug-bounds/package.json
+++ b/demos/simple-physics-demo-with-debug-bounds/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/simple-physics-demo/package.json
+++ b/demos/simple-physics-demo/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/sky-dome-with-annotations/package.json
+++ b/demos/sky-dome-with-annotations/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/soft-shadows/package.json
+++ b/demos/soft-shadows/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/space-game/package.json
+++ b/demos/space-game/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/sparks-and-effects/package.json
+++ b/demos/sparks-and-effects/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/spline-glass-shapes/package.json
+++ b/demos/spline-glass-shapes/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/sport-hall/package.json
+++ b/demos/sport-hall/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/spotlight-shadows/package.json
+++ b/demos/spotlight-shadows/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/springy-boxes/package.json
+++ b/demos/springy-boxes/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/ssgi-spheres-with-rapier-physics/package.json
+++ b/demos/ssgi-spheres-with-rapier-physics/package.json
@@ -30,9 +30,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/ssr-test/package.json
+++ b/demos/ssr-test/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/stage-presets-gltfjsx/package.json
+++ b/demos/stage-presets-gltfjsx/package.json
@@ -16,9 +16,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/staging-and-camerashake/package.json
+++ b/demos/staging-and-camerashake/package.json
@@ -10,9 +10,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "dependencies": {
     "@react-three/drei": "10.7.7",

--- a/demos/starwars/package.json
+++ b/demos/starwars/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/stencil-mask/package.json
+++ b/demos/stencil-mask/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/svg-maps-with-html-annotations/package.json
+++ b/demos/svg-maps-with-html-annotations/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/svg-renderer/package.json
+++ b/demos/svg-renderer/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/t-shirt-configurator/package.json
+++ b/demos/t-shirt-configurator/package.json
@@ -17,9 +17,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/the-three-graces/package.json
+++ b/demos/the-three-graces/package.json
@@ -36,9 +36,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "type": "module",
   "repository": {

--- a/demos/threejs-journey-lv-1-fisheye/package.json
+++ b/demos/threejs-journey-lv-1-fisheye/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/threejs-journey-portal/package.json
+++ b/demos/threejs-journey-portal/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/thunder-clouds/package.json
+++ b/demos/thunder-clouds/package.json
@@ -41,9 +41,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/demos/trails/package.json
+++ b/demos/trails/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/transformcontrols-and-makedefault/package.json
+++ b/demos/transformcontrols-and-makedefault/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/transparent-aesop-bottles/package.json
+++ b/demos/transparent-aesop-bottles/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/trigger-meshes/package.json
+++ b/demos/trigger-meshes/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/tying-canvas-to-scroll-offset/package.json
+++ b/demos/tying-canvas-to-scroll-offset/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/useintersect-and-scrollcontrols/package.json
+++ b/demos/useintersect-and-scrollcontrols/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/video-cookies/package.json
+++ b/demos/video-cookies/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/video-textures/package.json
+++ b/demos/video-textures/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/view-tracking/package.json
+++ b/demos/view-tracking/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/viewcube/package.json
+++ b/demos/viewcube/package.json
@@ -14,9 +14,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/viking-ship/package.json
+++ b/demos/viking-ship/package.json
@@ -35,9 +35,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "type": "module",
   "repository": {

--- a/demos/volumetric-light-godray/package.json
+++ b/demos/volumetric-light-godray/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/volumetric-spotlight/package.json
+++ b/demos/volumetric-spotlight/package.json
@@ -12,9 +12,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/water-shader/package.json
+++ b/demos/water-shader/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/wireframes/package.json
+++ b/demos/wireframes/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/wobbling-sphere/package.json
+++ b/demos/wobbling-sphere/package.json
@@ -13,9 +13,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "dev": "vite --host",

--- a/demos/zustand-site/package.json
+++ b/demos/zustand-site/package.json
@@ -45,9 +45,9 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.165.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^5.4.0"
+    "vite": "^8.1.5"
   },
   "type": "module",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,14 +587,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/arkanoid:
     dependencies:
@@ -633,14 +633,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/arkanoid-under-60-loc:
     dependencies:
@@ -670,14 +670,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/audio-analyser:
     dependencies:
@@ -713,14 +713,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/backdrop-and-cables:
     dependencies:
@@ -750,14 +750,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/baking-soft-shadows:
     dependencies:
@@ -787,14 +787,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/basic-ballpit:
     dependencies:
@@ -827,14 +827,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/basic-demo:
     dependencies:
@@ -864,14 +864,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bestservedbold-christmas-baubles:
     dependencies:
@@ -907,14 +907,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bezier-curves-and-nodes:
     dependencies:
@@ -947,14 +947,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bloom-hdr-workflow-gltf:
     dependencies:
@@ -984,14 +984,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bouncy-watch:
     dependencies:
@@ -1021,14 +1021,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bounds-and-makedefault:
     dependencies:
@@ -1058,14 +1058,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bruno-simons-20k-challenge:
     dependencies:
@@ -1104,14 +1104,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/building-dynamic-envmaps:
     dependencies:
@@ -1147,14 +1147,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/building-live-envmaps:
     dependencies:
@@ -1190,14 +1190,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/bvh:
     dependencies:
@@ -1236,14 +1236,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/camera-scroll:
     dependencies:
@@ -1273,14 +1273,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/camera-shake:
     dependencies:
@@ -1310,14 +1310,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/canvas-text:
     dependencies:
@@ -1344,14 +1344,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/cards:
     dependencies:
@@ -1393,14 +1393,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/cards-with-border-radius:
     dependencies:
@@ -1433,14 +1433,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/caustics:
     dependencies:
@@ -1470,14 +1470,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/cell-fracture:
     dependencies:
@@ -1507,14 +1507,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/clones:
     dependencies:
@@ -1547,14 +1547,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/clouds:
     dependencies:
@@ -1587,14 +1587,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/color-grading:
     dependencies:
@@ -1624,14 +1624,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/confetti:
     dependencies:
@@ -1670,14 +1670,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/csg-bunny-usegroups:
     dependencies:
@@ -1710,14 +1710,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/csg-house:
     dependencies:
@@ -1750,14 +1750,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/csg-operations-rapier-physics:
     dependencies:
@@ -1799,14 +1799,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/dbismut-furniture:
     dependencies:
@@ -1839,14 +1839,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/diamond-refraction:
     dependencies:
@@ -1882,14 +1882,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/diamond-ring:
     dependencies:
@@ -1925,14 +1925,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/drei-rendertexture:
     dependencies:
@@ -1968,14 +1968,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/ecctrl-fisheye:
     dependencies:
@@ -2011,14 +2011,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/edgesgeometry:
     dependencies:
@@ -2048,14 +2048,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/enter-portals:
     dependencies:
@@ -2097,14 +2097,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/environment-blur-and-transitions:
     dependencies:
@@ -2140,14 +2140,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/envmap-ground-projection:
     dependencies:
@@ -2183,14 +2183,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/faucets-select-highlight:
     dependencies:
@@ -2223,14 +2223,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/flexbox-yoga-in-webgl:
     dependencies:
@@ -2263,14 +2263,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/floating-diamonds:
     dependencies:
@@ -2303,14 +2303,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/floating-instanced-shoes:
     dependencies:
@@ -2343,14 +2343,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/floating-laptop:
     dependencies:
@@ -2386,14 +2386,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/flow-shield:
     dependencies:
@@ -2432,14 +2432,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/flying-bananas:
     dependencies:
@@ -2475,14 +2475,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/frosted-glass:
     dependencies:
@@ -2521,14 +2521,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/gatsby-stars:
     dependencies:
@@ -2564,14 +2564,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/glass-flower:
     dependencies:
@@ -2604,14 +2604,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/gltf-animations:
     dependencies:
@@ -2641,14 +2641,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/gltf-animations-re-used:
     dependencies:
@@ -2681,14 +2681,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/gltf-animations-tied-to-scroll:
     dependencies:
@@ -2721,14 +2721,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/gltfjsx-400kb-drone:
     dependencies:
@@ -2767,14 +2767,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/gpgpu-curl-noise-dof:
     dependencies:
@@ -2807,14 +2807,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/grass-shader:
     dependencies:
@@ -2847,14 +2847,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/ground-projected-envmaps-lamina:
     dependencies:
@@ -2887,14 +2887,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/ground-reflections-and-video-textures:
     dependencies:
@@ -2927,14 +2927,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/hi-key-bubbles:
     dependencies:
@@ -2967,14 +2967,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/horizontal-tiles:
     dependencies:
@@ -3010,14 +3010,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/html-annotations:
     dependencies:
@@ -3047,14 +3047,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/html-input-fields:
     dependencies:
@@ -3087,14 +3087,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/html-markers:
     dependencies:
@@ -3127,14 +3127,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/image-gallery:
     dependencies:
@@ -3173,14 +3173,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/infinite-scroll:
     dependencies:
@@ -3213,14 +3213,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/instanced-particles-effects:
     dependencies:
@@ -3250,14 +3250,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/instanced-vertex-colors:
     dependencies:
@@ -3290,14 +3290,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/instances:
     dependencies:
@@ -3330,14 +3330,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/inter-epoxy-resin:
     dependencies:
@@ -3376,14 +3376,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/interactive-spline-scene-live-html:
     dependencies:
@@ -3425,14 +3425,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/inverted-stencil-buffer:
     dependencies:
@@ -3468,11 +3468,11 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/iridescent-decals:
     dependencies:
@@ -3502,14 +3502,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/lamina-1x:
     dependencies:
@@ -3545,14 +3545,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/landing-page:
     dependencies:
@@ -3585,14 +3585,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/learn-with-jason:
     dependencies:
@@ -3622,14 +3622,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/lulaby-city:
     dependencies:
@@ -3662,8 +3662,8 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       lint-staged:
         specifier: ^16.2.7
         version: 16.4.0
@@ -3671,8 +3671,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/lusion-connectors:
     dependencies:
@@ -3708,14 +3708,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/magic-box:
     dependencies:
@@ -3748,14 +3748,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/merged-instance:
     dependencies:
@@ -3785,14 +3785,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/minecraft:
     dependencies:
@@ -3831,14 +3831,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/mixing-controls:
     dependencies:
@@ -3874,14 +3874,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/mixing-html-and-webgl:
     dependencies:
@@ -3914,14 +3914,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/mixing-html-and-webgl-w-occlusion:
     dependencies:
@@ -3957,14 +3957,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/moksha:
     dependencies:
@@ -3997,14 +3997,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/monitors:
     dependencies:
@@ -4049,14 +4049,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/motionpathcontrols:
     dependencies:
@@ -4092,14 +4092,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/mount-transitions:
     dependencies:
@@ -4141,14 +4141,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/multiple-views-with-uniform-controls:
     dependencies:
@@ -4193,14 +4193,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/nextjs-prism:
     dependencies:
@@ -4233,14 +4233,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/night-train:
     dependencies:
@@ -4270,14 +4270,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/object-clump:
     dependencies:
@@ -4316,14 +4316,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/pairing-threejs-to-ui:
     dependencies:
@@ -4359,14 +4359,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/pass-through-portals:
     dependencies:
@@ -4405,14 +4405,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/physics-with-convex-polyhedrons:
     dependencies:
@@ -4448,14 +4448,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/pinball-in-70-lines:
     dependencies:
@@ -4488,14 +4488,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/pmndrs-vercel:
     dependencies:
@@ -4534,14 +4534,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/portal-shapes:
     dependencies:
@@ -4577,14 +4577,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/portals:
     dependencies:
@@ -4617,14 +4617,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/progressive-loading-states-with-suspense:
     dependencies:
@@ -4654,14 +4654,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/racing-game:
     dependencies:
@@ -4715,14 +4715,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/ragdoll-physics:
     dependencies:
@@ -4755,14 +4755,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/rapier-physics:
     dependencies:
@@ -4798,14 +4798,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/rapier-ping-pong:
     dependencies:
@@ -4850,14 +4850,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/raycast-cycling:
     dependencies:
@@ -4890,14 +4890,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/re-using-geometry-and-level-of-detail:
     dependencies:
@@ -4927,14 +4927,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/re-using-gltfs:
     dependencies:
@@ -4964,14 +4964,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/react-ellipsecurve:
     dependencies:
@@ -5004,14 +5004,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/react-pp-outlines:
     dependencies:
@@ -5047,14 +5047,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/react-spring-animations:
     dependencies:
@@ -5093,14 +5093,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/room-with-soft-shadows:
     dependencies:
@@ -5136,14 +5136,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/router-transitions:
     dependencies:
@@ -5185,14 +5185,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/scrollcontrols-and-lens-refraction:
     dependencies:
@@ -5228,14 +5228,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/scrollcontrols-gltf:
     dependencies:
@@ -5265,14 +5265,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/scrollcontrols-with-minimap:
     dependencies:
@@ -5305,14 +5305,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/selective-outlines:
     dependencies:
@@ -5345,14 +5345,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/shader-fire:
     dependencies:
@@ -5382,14 +5382,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/shader-hmr:
     dependencies:
@@ -5419,14 +5419,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/shadermaterials:
     dependencies:
@@ -5456,14 +5456,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/shoe-configurator:
     dependencies:
@@ -5499,14 +5499,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/shopping:
     dependencies:
@@ -5539,14 +5539,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/simple-audio-analyser:
     dependencies:
@@ -5579,14 +5579,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/simple-physics-demo:
     dependencies:
@@ -5616,14 +5616,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/simple-physics-demo-with-debug-bounds:
     dependencies:
@@ -5653,14 +5653,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/sky-dome-with-annotations:
     dependencies:
@@ -5693,14 +5693,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/soft-shadows:
     dependencies:
@@ -5736,14 +5736,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/space-game:
     dependencies:
@@ -5782,14 +5782,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/sparks-and-effects:
     dependencies:
@@ -5819,14 +5819,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/spline-glass-shapes:
     dependencies:
@@ -5865,14 +5865,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/sport-hall:
     dependencies:
@@ -5905,14 +5905,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/spotlight-shadows:
     dependencies:
@@ -5942,14 +5942,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/springy-boxes:
     dependencies:
@@ -5979,14 +5979,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/ssgi-spheres-with-rapier-physics:
     dependencies:
@@ -6028,14 +6028,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/ssr-test:
     dependencies:
@@ -6071,14 +6071,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/stage-presets-gltfjsx:
     dependencies:
@@ -6120,14 +6120,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/staging-and-camerashake:
     dependencies:
@@ -6157,14 +6157,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/starwars:
     dependencies:
@@ -6200,14 +6200,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/stencil-mask:
     dependencies:
@@ -6240,14 +6240,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/svg-maps-with-html-annotations:
     dependencies:
@@ -6280,14 +6280,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/svg-renderer:
     dependencies:
@@ -6317,14 +6317,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/t-shirt-configurator:
     dependencies:
@@ -6369,14 +6369,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/the-three-graces:
     dependencies:
@@ -6409,14 +6409,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/threejs-journey-lv-1-fisheye:
     dependencies:
@@ -6449,14 +6449,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/threejs-journey-portal:
     dependencies:
@@ -6486,14 +6486,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/thunder-clouds:
     dependencies:
@@ -6529,14 +6529,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/trails:
     dependencies:
@@ -6575,14 +6575,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/transformcontrols-and-makedefault:
     dependencies:
@@ -6615,14 +6615,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/transparent-aesop-bottles:
     dependencies:
@@ -6652,14 +6652,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/trigger-meshes:
     dependencies:
@@ -6692,14 +6692,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/tying-canvas-to-scroll-offset:
     dependencies:
@@ -6729,14 +6729,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/useintersect-and-scrollcontrols:
     dependencies:
@@ -6769,14 +6769,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/video-cookies:
     dependencies:
@@ -6809,14 +6809,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/video-textures:
     dependencies:
@@ -6846,14 +6846,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/view-tracking:
     dependencies:
@@ -6886,14 +6886,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/viewcube:
     dependencies:
@@ -6929,14 +6929,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/viking-ship:
     dependencies:
@@ -6966,14 +6966,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/volumetric-light-godray:
     dependencies:
@@ -7006,14 +7006,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/volumetric-spotlight:
     dependencies:
@@ -7043,14 +7043,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/water-shader:
     dependencies:
@@ -7083,14 +7083,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/wireframes:
     dependencies:
@@ -7129,14 +7129,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/wobbling-sphere:
     dependencies:
@@ -7169,14 +7169,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   demos/zustand-site:
     dependencies:
@@ -7212,14 +7212,14 @@ importers:
         specifier: ^0.165.0
         version: 0.165.0
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@20.19.39)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   packages/e2e:
     dependencies:
@@ -7315,10 +7315,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -7339,18 +7335,6 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -7375,14 +7359,23 @@ packages:
   '@dimforge/rapier3d-compat@0.19.2':
     resolution: {integrity: sha512-AZHL1jqUF55QJkJyU1yKeh4ImX2J93bVLIezT1+o0FZqTix6O06MOaqpKoJ4MmbDCsoZmwO+qc471/SDMDm2AA==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -7439,144 +7432,6 @@ packages:
 
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
-
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -7864,6 +7719,13 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.2.1':
+    resolution: {integrity: sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
   '@next/env@15.5.22':
     resolution: {integrity: sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==}
 
@@ -7937,6 +7799,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@playwright/test@1.62.0':
     resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
@@ -8528,146 +8393,103 @@ packages:
       react: ^19
       three: '>=0.159.0'
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
-
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -8759,23 +8581,11 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
@@ -9164,11 +8974,18 @@ packages:
       react:
         optional: true
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@vitejs/plugin-react@6.0.4':
+    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vue/compiler-core@3.5.32':
     resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
@@ -9690,11 +9507,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -10421,6 +10233,80 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -10561,6 +10447,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10718,6 +10609,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   playwright-core@1.62.0:
     resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
     engines: {node: '>=20'}
@@ -10744,6 +10639,10 @@ packages:
 
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -11078,10 +10977,6 @@ packages:
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
 
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
-
   react-textarea-autosize@8.3.4:
     resolution: {integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==}
     engines: {node: '>=10'}
@@ -11195,9 +11090,9 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rtl-css-js@1.16.1:
@@ -11588,6 +11483,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   to-readable-stream@1.0.0:
     resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==}
     engines: {node: '>=6'}
@@ -11761,25 +11660,33 @@ packages:
       react:
         optional: true
 
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true
-      less:
+      '@vitejs/devtools':
         optional: true
-      lightningcss:
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -11790,6 +11697,10 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   webgl-constants@1.1.1:
@@ -11992,7 +11903,8 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.29.0':
+    optional: true
 
   '@babel/core@7.29.0(supports-color@7.2.0)':
     dependencies:
@@ -12013,6 +11925,7 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -12029,6 +11942,7 @@ snapshots:
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
+    optional: true
 
   '@babel/helper-globals@7.28.0': {}
 
@@ -12047,33 +11961,24 @@ snapshots:
       '@babel/traverse': 7.29.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-plugin-utils@7.28.6': {}
+    optional: true
 
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  '@babel/helper-validator-option@7.27.1':
+    optional: true
 
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
+    optional: true
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0(supports-color@7.2.0))':
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0(supports-color@7.2.0))':
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
 
@@ -12104,9 +12009,20 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.19.2': {}
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -12116,6 +12032,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -12199,75 +12120,6 @@ snapshots:
   '@emotion/utils@1.4.2': {}
 
   '@emotion/weak-memoize@0.4.0': {}
-
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
-    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1(supports-color@7.2.0))':
     dependencies:
@@ -12467,6 +12319,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+    optional: true
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -12521,6 +12374,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@15.5.22': {}
 
   '@next/eslint-plugin-next@15.5.22':
@@ -12564,6 +12424,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@oxc-project/types@0.139.0': {}
 
   '@playwright/test@1.62.0':
     dependencies:
@@ -13247,82 +13109,56 @@ snapshots:
       three: 0.165.0
       three-stdlib: 2.36.1(three@0.165.0)
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
-
-  '@rollup/rollup-android-arm-eabi@4.60.1':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.1':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.1':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    optional: true
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -13393,30 +13229,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/babel__core@7.20.5':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.0
+      tslib: 2.8.1
+    optional: true
 
   '@types/draco3d@1.4.10': {}
-
-  '@types/estree@1.0.8': {}
 
   '@types/js-cookie@3.0.6': {}
 
@@ -13729,17 +13547,10 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
 
-  '@vitejs/plugin-react@4.7.0(supports-color@7.2.0)(vite@5.4.21(@types/node@20.19.39))':
+  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0(supports-color@7.2.0))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0(supports-color@7.2.0))
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 5.4.21(@types/node@20.19.39)
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@20.19.39)(yaml@2.9.0)
 
   '@vue/compiler-core@3.5.32':
     dependencies:
@@ -13977,7 +13788,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.16: {}
+  baseline-browser-mapping@2.10.16:
+    optional: true
 
   bidi-js@1.0.3:
     dependencies:
@@ -14007,6 +13819,7 @@ snapshots:
       electron-to-chromium: 1.5.332
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -14117,7 +13930,8 @@ snapshots:
 
   convert-source-map@1.9.0: {}
 
-  convert-source-map@2.0.0: {}
+  convert-source-map@2.0.0:
+    optional: true
 
   copy-to-clipboard@3.3.3:
     dependencies:
@@ -14260,8 +14074,7 @@ snapshots:
     dependencies:
       webgl-constants: 1.1.1
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -14300,7 +14113,8 @@ snapshots:
       - '@types/react'
       - immer
 
-  electron-to-chromium@1.5.332: {}
+  electron-to-chromium@1.5.332:
+    optional: true
 
   emoji-regex@10.6.0: {}
 
@@ -14425,32 +14239,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
 
   escalade@3.2.0: {}
 
@@ -14784,7 +14572,8 @@ snapshots:
 
   generator-function@2.0.1: {}
 
-  gensync@1.0.0-beta.2: {}
+  gensync@1.0.0-beta.2:
+    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -15281,6 +15070,55 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lines-and-columns@1.2.4: {}
 
   lint-staged@16.4.0:
@@ -15330,6 +15168,7 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+    optional: true
 
   maath@0.10.8(@types/three@0.165.0)(three@0.165.0):
     dependencies:
@@ -15430,6 +15269,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.16: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -15474,7 +15315,8 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.37:
+    optional: true
 
   normalize-url@4.5.1: {}
 
@@ -15588,6 +15430,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   playwright-core@1.62.0: {}
 
   playwright@1.62.0:
@@ -15613,6 +15457,12 @@ snapshots:
   postcss@8.4.49:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -16033,8 +15883,6 @@ snapshots:
 
   react-merge-refs@1.1.0: {}
 
-  react-refresh@0.17.0: {}
-
   react-textarea-autosize@8.3.4(@types/react@19.2.17)(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -16170,36 +16018,26 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup@4.60.1:
+  rolldown@1.1.5:
     dependencies:
-      '@types/estree': 1.0.8
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   rtl-css-js@1.16.1:
     dependencies:
@@ -16623,6 +16461,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   to-readable-stream@1.0.0: {}
 
   to-regex-range@5.0.1:
@@ -16783,6 +16626,7 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+    optional: true
 
   uri-js@4.4.1:
     dependencies:
@@ -16842,14 +16686,17 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.8
 
-  vite@5.4.21(@types/node@20.19.39):
+  vite@8.1.5(@types/node@20.19.39)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.8
-      rollup: 4.60.1
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.39
       fsevents: 2.3.3
+      yaml: 2.9.0
 
   webgl-constants@1.1.1: {}
 
@@ -16929,7 +16776,8 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yallist@3.1.1: {}
+  yallist@3.1.1:
+    optional: true
 
   yaml@1.10.3: {}
 


### PR DESCRIPTION
Bumps all 161 demos from `vite ^5.4.0` → `^8.1.5` and `@vitejs/plugin-react ^4.3.1` → `^6.0.4`.

## Why Dependabot never proposed this

Two reasons, both worth knowing:

1. **Peer-dep coupling.** `@vitejs/plugin-react` 4.x peers on `vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0` — vite 8 requires plugin-react 6.x (which peers on `vite: ^8.0.0`). Dependabot bumps one package at a time, and no `groups` is configured in `.github/dependabot.yml`, so a vite-only bump can never resolve and gets dropped silently.
2. **PR quota.** `open-pull-requests-limit` defaults to 5, and there are already 5 open Dependabot PRs (#119–#123), so nothing new is opened at all.

Fixing (1) means adding a `vite` + `@vitejs/*` group to `.github/dependabot.yml`; happy to do that in a follow-up.

## What changed

Manifests only — 161 `demos/*/package.json` + `pnpm-lock.yaml`. **No config changes were needed**: every demo config is a plain `defineConfig({ plugins: [react()] })`, and the two exceptions (an `alias`/`dedupe` block using `__dirname`, and `packages/e2e`'s custom `vite-plugin-monkey` transform) both work unchanged.

Vite 8 bundles with **Rolldown** rather than Rollup/esbuild, so build output differs (chunk hashes, minification). The extra `@vitejs/plugin-react` 6 peers (`@rolldown/plugin-babel`, `babel-plugin-react-compiler`) are optional and are not installed.

Versions are 8.1.5 / 6.0.4 rather than the very latest 8.2.0 / 6.0.5: those were published <24h ago and trip pnpm's `minimumReleaseAge` guard, which would have required committing a `minimumReleaseAgeExclude` bypass into `pnpm-workspace.yaml`. The carets will float up on their own.

## Verification

- `pnpm lint:versions` (syncpack) ✅ — the `sameRange` group covering `vite` + `@vitejs/plugin-react` is satisfied
- `pnpm lint:metadata` ✅ — 161 demos
- `turbo build2` ✅ — **158/158 demos build** (the e2e build path CI uses)
- `pnpm build` on the 2 TS demos (`racing-game`, `viking-ship`) ✅ — `tsc && vite build` both clean
- e2e pipeline smoke-tested on `aquarium`: vite 8 `preview` + Playwright render the scene correctly (screenshot verified by hand; the test itself only fails on a missing `-darwin` baseline, since baselines are `-linux`-only)
- vite 8 dev server smoke-tested on `trails`: react-refresh injected, deps pre-bundled, modules transformed

Snapshot tests are the real gate here and only run meaningfully in CI's Playwright container — worth watching this PR's run.

## Known non-blocker

`starwars`, `ssr-test` and `building-dynamic-envmaps` now **fail** `pnpm build`, with:

```
[MISSING_EXPORT] "SSR" is not exported by @react-three/postprocessing
```

This is pre-existing and unrelated to Vite: `@react-three/postprocessing` v3 dropped the `SSR` export, so those three demos are already broken at runtime — which is why their `build2` script is disabled (renamed `bbuild2`) and CI skips them. Rollup only warned about the missing export; Rolldown makes it a hard error, so Vite 8 merely surfaces a bug that was already there. CI is unaffected. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
