### PR TITLE
Fix invalid DOM property warnings on popover triggers

### DIFF
--- a/apps/website/app/demos/[demoname]/Info.tsx
+++ b/apps/website/app/demos/[demoname]/Info.tsx
@@ -281,10 +281,8 @@ export function Info({ demo }: { demo: Demo }) {
       />
 
       <button
-        {...({
-          popovertarget: "demo-info-panel",
-          popovertargetaction: "toggle",
-        } as const)}
+        popoverTarget="demo-info-panel"
+        popoverTargetAction="toggle"
         className="trigger"
         aria-expanded={open}
         aria-controls="demo-info-panel"
@@ -296,7 +294,7 @@ export function Info({ demo }: { demo: Demo }) {
       </button>
 
       <div
-        {...({ popover: "auto" } as const)}
+        popover="auto"
         ref={popoverRef}
         id="demo-info-panel"
         className="panel"

--- a/apps/website/app/demos/[demoname]/Social.tsx
+++ b/apps/website/app/demos/[demoname]/Social.tsx
@@ -232,10 +232,8 @@ export function Social({
         )}
 
         <button
-          {...({
-            popovertarget: "social-more-menu",
-            popovertargetaction: "toggle",
-          } as const)}
+          popoverTarget="social-more-menu"
+          popoverTargetAction="toggle"
           className="more"
           aria-expanded={moreOpen}
           aria-controls="social-more-menu"
@@ -245,7 +243,7 @@ export function Social({
         </button>
 
         <div
-          {...({ popover: "auto" } as const)}
+          popover="auto"
           ref={menuRef}
           id="social-more-menu"
           className="menu"


### PR DESCRIPTION
## What

Replace the lowercase Popover API invoker attributes in `Info.tsx` and `Social.tsx` with React 19's first-class camelCase props:

```diff
-{...({ popovertarget: "demo-info-panel", popovertargetaction: "toggle" } as const)}
+popoverTarget="demo-info-panel"
+popoverTargetAction="toggle"
```

Also drops the now-unnecessary `as const` spread around `popover="auto"` on the panel/menu elements.

## Why

Leftover from the React 19 conversion (12543a20). The `as const` spread was a workaround for React 18 not typing these attributes. React 19 doesn't recognize them in lowercase, so it dropped them from the DOM and logged two console errors on **every** `/demos/<name>` page:

```
Invalid DOM property `popovertarget`. Did you mean `popoverTarget`?
Invalid DOM property `popovertargetaction`. Did you mean `popoverTargetAction`?
```

## Reviewer notes

- **This was a functional bug, not just console noise.** Neither trigger has an `onClick` — both relied solely on the native popover invoker. With the attributes stripped, the ⓘ info button and the mobile "more" chevron did nothing when clicked. (The `hidePopover()` handlers that do exist are on the close ⓧ and the menu items, so closing worked but opening never did.)
- `popover="auto"` stays lowercase — that one genuinely is lowercase in React — but it no longer needs the `as const` spread, since React 19 types `popover` on `HTMLAttributes`. Confirmed by `tsc`.

## Verification

Ran `website` dev alongside `pnpm --filter @demo/aquarium dev3` so the real Info/Social render (not the Dev fallback), on `/demos/aquarium`:

- Console clean on load — both errors gone, zero errors.
- Native invoker wiring now attaches: `button.popoverTargetElement.id === "demo-info-panel"`, `popoverTargetAction === "toggle"`.
- Info panel: trusted click → `toggle` fires `closed->open`, `aria-expanded="true"`; second click → `open->closed`.
- Mobile "more" menu at 375px: same open/close toggle, `aria-expanded` tracking correctly.

Checks: `pnpm --filter website exec tsc --noEmit` clean. `pnpm --filter website lint` clean apart from a pre-existing `react-hooks/exhaustive-deps` warning in `components/Toast.tsx:36` (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)