### PR TITLE
website: nav demo cards as shadcn Item + Badge

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -67,7 +67,9 @@ export default function RootLayout({
                   0.999, 0.999, 1.00
                 );
 
-                background: #eee;
+                /* No background here on purpose: this block is unlayered, so
+                   any value would outrank the bg-background/text-foreground
+                   that globals.css puts on body in @layer base. */
                 display: flex;
                 height: 100dvh;
                 overflow: hidden;

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -12,10 +12,13 @@ import {
   useState,
 } from "react";
 import { useParams } from "next/navigation";
-import clsx from "clsx";
 
 import { getLibraryLabel, getLibraryPopularity } from "@/const/libraries";
 import type { Demo } from "@/lib/helper";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Item, ItemFooter, ItemMedia } from "@/components/ui/item";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Style } from "./Style";
 
 const STORAGE_KEY = "nav-collapsed";
@@ -626,81 +629,9 @@ export default function Nav({
               transform: scale(0.97);
             }
 
-            a {
-              display: block;
-              background: white;
-              border-radius: 6px;
-              overflow: hidden;
-              outline: 2px solid transparent;
-              outline-offset: 2px;
-              transition:
-                outline-color 0.2s ease,
-                box-shadow 0.2s ease;
-            }
-
-            a:hover {
-              box-shadow: 0 2px 12px rgb(0 0 0 / 0.1);
-            }
-
-            a.active {
-              outline-color: black;
-            }
-
-            .thumb {
-              position: relative;
-              aspect-ratio: 16/9;
-              width: 100%;
-              overflow: hidden;
-            }
-
-            .pill {
-              position: absolute;
-              top: 6px;
-              right: 6px;
-              padding: 2px 7px;
-              font-size: 0.55rem;
-              font-weight: 700;
-              letter-spacing: 0.06em;
-              text-transform: uppercase;
-              line-height: 1.5;
-              color: white;
-              background: #e8756a;
-              border-radius: 999px;
-              z-index: 1;
-            }
-
-            a img {
-              object-fit: cover;
-              width: 100%;
-              height: 100%;
-              display: block;
-              color: inherit !important;
-              font-size: 0.7rem;
-              background: none;
-            }
-
-            .tags {
-              position: absolute;
-              inset: auto 0 0 0;
-              z-index: 1;
-              display: flex;
-              flex-wrap: nowrap;
-              gap: 3px;
-              padding: 5px;
-              /* whatever runs past the right edge is simply clipped */
-              overflow: hidden;
-            }
-
-            .tag {
-              flex-shrink: 0;
-              padding: 1px 6px;
-              border-radius: 999px;
-              background: #222;
-              color: white;
-              font-size: 0.5rem;
-              line-height: 1.7;
-              white-space: nowrap;
-            }
+            /* The demo cards are shadcn <Item>/<Badge>; they style themselves
+               with Tailwind. Nothing scoped here may target them — this block
+               is unlayered and would outrank every utility. */
           }
         `}
       />
@@ -858,24 +789,56 @@ export default function Nav({
         <ul ref={ulRef} id="demo-list">
           {filteredDemos.map(({ name, title, thumb, isNew, tags }) => (
             <li key={thumb} data-demo={name}>
-              <Link
-                href={`/demos/${name}`}
-                className={clsx({ active: demoname === name })}
+              <Item
+                asChild
+                variant="outline"
+                className="relative overflow-hidden p-0"
               >
-                <div className="thumb">
-                  {isNew && <span className="pill">New</span>}
-                  <Image src={thumb} fill sizes="227px" alt={title} />
-                  {tags.length > 0 && (
-                    <div className="tags">
-                      {tags.slice(0, MAX_TAGS).map((tag) => (
-                        <span key={tag} className="tag">
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
+                <Link
+                  href={`/demos/${name}`}
+                  aria-current={demoname === name ? "page" : undefined}
+                  className={cn(
+                    "no-underline",
+                    demoname === name && "ring-2 ring-foreground",
                   )}
-                </div>
-              </Link>
+                >
+                  {/* Full-bleed: the media is the only thing in the box, so the
+                      card ends up with the thumbnail's aspect ratio. */}
+                  <ItemMedia
+                    variant="image"
+                    className="relative aspect-video size-auto w-full rounded-none"
+                  >
+                    <Image
+                      src={thumb}
+                      fill
+                      sizes="(min-width: 640px) 260px, 200px"
+                      alt={title}
+                    />
+                  </ItemMedia>
+                  {isNew && (
+                    <Badge
+                      variant="secondary"
+                      className="absolute top-1.5 right-1.5"
+                    >
+                      New
+                    </Badge>
+                  )}
+                  {tags.length > 0 && (
+                    <ItemFooter className="absolute inset-x-0 bottom-0">
+                      <ScrollArea className="w-full">
+                        {/* Padding sits inside the viewport so the scrollable
+                            strip itself runs edge to edge. */}
+                        <div className="flex w-max gap-1 p-1.5">
+                          {tags.slice(0, MAX_TAGS).map((tag) => (
+                            <Badge key={tag}>{tag}</Badge>
+                          ))}
+                        </div>
+                        <ScrollBar orientation="horizontal" />
+                      </ScrollArea>
+                    </ItemFooter>
+                  )}
+                </Link>
+              </Item>
             </li>
           ))}
         </ul>

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -312,7 +312,9 @@ export default function Nav({
               top: 0;
               z-index: 2;
               padding: 0.65rem 0.75rem 0.35rem 1rem;
-              background: linear-gradient(#eee 75%, rgb(238 238 238 / 0));
+              /* This is the page background, fading out under the scrolling
+                 list — it has to follow --background. */
+              background: linear-gradient(var(--background) 75%, transparent);
             }
 
             .filterRow {
@@ -792,15 +794,19 @@ export default function Nav({
               <Item
                 asChild
                 variant="outline"
-                className="relative overflow-hidden p-0"
+                className={cn(
+                  "relative overflow-hidden bg-muted p-0",
+                  /* `accent` is the same value as `muted` under the neutral
+                     base colour, so the selected card reads through the
+                     paired `accent-foreground` ring. */
+                  demoname === name &&
+                    "bg-accent ring-2 ring-accent-foreground",
+                )}
               >
                 <Link
                   href={`/demos/${name}`}
                   aria-current={demoname === name ? "page" : undefined}
-                  className={cn(
-                    "no-underline",
-                    demoname === name && "ring-2 ring-foreground",
-                  )}
+                  className="no-underline"
                 >
                   {/* Full-bleed: the media is the only thing in the box, so the
                       card ends up with the thumbnail's aspect ratio. */}

--- a/apps/website/components/ui/badge.tsx
+++ b/apps/website/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border bg-input/30 text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/website/components/ui/item.tsx
+++ b/apps/website/components/ui/item.tsx
@@ -1,0 +1,196 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { Separator } from "@/components/ui/separator";
+
+function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      role="list"
+      data-slot="item-group"
+      className={cn(
+        "group/item-group flex w-full flex-col gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      className={cn("my-2", className)}
+      {...props}
+    />
+  );
+}
+
+const itemVariants = cva(
+  "group/item flex w-full flex-wrap items-center rounded-2xl border text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-muted",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent",
+        outline: "border-border",
+        muted: "border-transparent bg-muted/50",
+      },
+      size: {
+        default: "gap-3.5 px-4 py-3.5",
+        sm: "gap-3.5 px-3.5 py-3",
+        xs: "gap-2.5 px-3 py-2.5 in-data-[slot=dropdown-menu-content]:p-0",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Item({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof itemVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div";
+  return (
+    <Comp
+      data-slot="item"
+      data-variant={variant}
+      data-size={size}
+      className={cn(itemVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start [&_svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "[&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 overflow-hidden rounded-lg group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 group-data-[size=xs]/item:rounded-md [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function ItemMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemMediaVariants>) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-content"
+      className={cn(
+        "flex flex-1 flex-col gap-1 group-data-[size=xs]/item:gap-0.5 [&+[data-slot=item-content]]:flex-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-title"
+      className={cn(
+        "line-clamp-1 flex w-fit items-center gap-2 text-sm leading-snug font-medium underline-offset-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="item-description"
+      className={cn(
+        "line-clamp-2 text-left text-sm font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-actions"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-header"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-footer"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemActions,
+  ItemGroup,
+  ItemSeparator,
+  ItemTitle,
+  ItemDescription,
+  ItemHeader,
+  ItemFooter,
+};

--- a/apps/website/components/ui/scroll-area.tsx
+++ b/apps/website/components/ui/scroll-area.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/apps/website/components/ui/separator.tsx
+++ b/apps/website/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import { Separator as SeparatorPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };


### PR DESCRIPTION
Stacked on #136, which is what puts Tailwind + shadcn/ui in `apps/website` in the first place.

The nav list rendered a hand-rolled card — a `<div class="thumb">` holding `<span class="tag">` pills and a `<span class="pill">New</span>`, all styled from Nav's `@scope` block. It is now [`Item`](https://ui.shadcn.com/docs/components/radix/item), [`Badge`](https://ui.shadcn.com/docs/components/radix/badge) and [`ScrollArea`](https://ui.shadcn.com/docs/components/radix/scroll-area), added with the CLI as `AGENTS.md` asks.

## The card

`ItemMedia variant="image"` is the only thing in the box, so the `Item` still takes the thumbnail's 16:9 ratio and the image stays full-bleed. No title is introduced — there wasn't one before.

The tag strip is the one behavioural change. It was `overflow: hidden`, so anything past the right edge was simply cut off; it is now a `ScrollArea` whose padding lives *inside* the viewport, so the scrollable strip itself runs edge to edge and the overflowing tags are reachable. Verified in the browser: the viewport spans the card minus its 1px borders, `scrollWidth` (237) exceeds `clientWidth` (230), and the horizontal scrollbar mounts on hover pinned to the strip's bottom edge rather than scrolling away with the content.

`MAX_TAGS` is left at 4. Dropping the cap now that overflow is reachable is a one-word change if you want it, but it wasn't part of the ask.

## Two things this drags along

**The `@scope` rules for the card had to go, not just be left behind.** That block is unlayered, so `a`, `.thumb`, `.pill`, `.tags` and `.tag` would have outranked every Tailwind utility the components emit. Everything else in `Nav` — the filter row, search, toggle, empty state — still styles itself the old way, per `AGENTS.md`.

**Colours are theme tokens now.** The base colour is `neutral`, which has no accent, so the `New` pill loses its `#e8756a`: it is `variant="secondary"`, a light pill that reads against the dark tags below it. The tags were `#222` on white and land on `variant="default"`, which is the same thing expressed in tokens.

Tags are deliberately *not* `variant="secondary"` — `secondary` and the `muted` the card hovers to are the same value in this theme, so they vanished under the cursor. Caught on hover, fixed with `outline`… then `default` once the tags moved back over the image.

The active link now carries `aria-current="page"` and takes its ring from that, replacing the `.active` class the deleted CSS keyed on.

## Note on `base`

The linked docs are the Base UI flavour, but #136 pins `--base radix` (for sonner), so the CLI added the Radix variants. For `Badge`, `Item` and `ScrollArea` the difference is only `asChild` vs `render`; `Item asChild` wrapping the `<Link>` is the Radix form.

## Not fixed here: dark mode

On a dark-preferring browser the demo cards now render dark on the site's hardcoded `#eee` chrome. This is **pre-existing on #136**, not introduced here — `globals.css` applies `text-foreground` to `body`, so `Dev.tsx`'s "Start this demo with :" is already near-white on light grey before this branch. The cards using semantic tokens is correct behaviour; what's missing is a decision about the site's theme story (the chrome is hardcoded light and `ThemeProvider` is on `system`). That belongs in #136 or its own PR, not in a component swap.

## Verification

`tsc --noEmit`, `next lint` and `next build` (163 pages exported) are clean. Rendered and inspected in a browser at both sidebar widths: full-bleed thumbnails, the `New` badge, the active ring, hover, and the scrolling tag strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
