### PR TITLE
website: nav shell as shadcn Sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily 
 
 Two things to know before styling:
 
-- **The site's own components are not on Tailwind.** `Nav`, `Info`, `Social`, `Dev` and `ScaledDemoFrame` still style themselves with scoped CSS injected through `<Style>` (`@scope { … }`). That's deliberate, not a half-finished migration. Tailwind classes are for `components/ui/*` and new work; leave the `@scope` blocks alone unless you're converting a component wholesale. Inline `<style>` is unlayered, so those rules outrank Preflight and keep winning.
+- **Most of the site's own components are not on Tailwind.** `Info`, `Social`, `Dev` and `ScaledDemoFrame` still style themselves with scoped CSS injected through `<Style>` (`@scope { … }`). That's deliberate, not a half-finished migration. Tailwind classes are for `components/ui/*` and new work; leave the `@scope` blocks alone unless you're converting a component wholesale — `Nav` is the one that has been, and it now composes `Sidebar` with no `<Style>` of its own. Inline `<style>` is unlayered, so those rules outrank Preflight and keep winning.
 - **Sources are declared explicitly.** Tailwind's automatic source detection finds nothing in this app, so `app/globals.css` lists `@source` entries. Add one if you put components somewhere new.
 
 `demos/` is deliberately Tailwind-free; don't introduce it there.

--- a/apps/website/app/globals.css
+++ b/apps/website/app/globals.css
@@ -163,7 +163,15 @@
   --chart-3: var(--md-sys-color-tertiary-fixed);
   --chart-4: var(--md-sys-color-primary-fixed-dim);
   --chart-5: var(--md-sys-color-secondary-fixed-dim);
-  --sidebar: var(--md-sys-color-surface-container-low);
+  /* `surface`, not `surface-container-low`: the rail is meant to read as part
+     of the page rather than as a panel laid on it, and this is the token that
+     paints it -- `bg-sidebar` sits on the vendored component, where a
+     `className` override has no business going. Same value as `--background`,
+     so the rail is flush with the page, and `Nav` drops the component's
+     `border-r` so nothing draws a seam across it either. Keeping a role rather
+     than `transparent` also keeps the mobile sheet opaque, since it paints
+     from this token too. */
+  --sidebar: var(--md-sys-color-surface);
   --sidebar-foreground: var(--md-sys-color-on-surface);
   --sidebar-primary: var(--md-sys-color-primary);
   --sidebar-primary-foreground: var(--md-sys-color-on-primary);
@@ -183,4 +191,18 @@
   html {
     @apply font-sans;
   }
+}
+
+/* The nav's collapsed state lives in `localStorage`, and this site is a static
+   export -- so the only thing that knows it before first paint is the inline
+   script in `app/layout.tsx`, which marks <html>. React learns it an effect
+   later; without these two rules the rail would paint open and then swing shut
+   on every load. Unlayered on purpose: it has to outrank the sidebar's own
+   utilities, and all it does is restate what they already say when collapsed.
+   `Nav` drops the attribute as soon as it has rendered the real state. */
+html[data-nav-collapsed] [data-slot="sidebar-gap"] {
+  width: 0;
+}
+html[data-nav-collapsed] [data-slot="sidebar-container"][data-side="left"] {
+  left: calc(var(--sidebar-width) * -1);
 }

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -74,29 +74,19 @@ export default function RootLayout({
           css={`
             @scope {
               :scope {
+                /* Handed to the sidebar as --sidebar-width in Nav: the
+                   component sets that one inline, so a media query can only
+                   reach it through a variable it reads. */
                 --sidebar-w: 200px;
                 @media (min-width: 640px) {
                   --sidebar-w: 260px;
                 }
-                --motion-curve: linear(
-                  0.00, 0.00780, 0.0340, 0.0738, 0.116, 0.160, 0.203, 0.244,
-                  0.284, 0.322, 0.357, 0.391, 0.422, 0.453, 0.483, 0.510,
-                  0.536, 0.561, 0.583, 0.606, 0.627, 0.646, 0.665, 0.683,
-                  0.700, 0.716, 0.731, 0.745, 0.759, 0.771, 0.784, 0.795,
-                  0.806, 0.816, 0.826, 0.835, 0.844, 0.852, 0.859, 0.867,
-                  0.874, 0.881, 0.887, 0.893, 0.899, 0.904, 0.909, 0.914,
-                  0.919, 0.923, 0.927, 0.931, 0.935, 0.938, 0.941, 0.944,
-                  0.947, 0.950, 0.953, 0.955, 0.958, 0.960, 0.962, 0.964,
-                  0.966, 0.968, 0.969, 0.971, 0.973, 0.974, 0.975, 0.977,
-                  0.978, 0.979, 0.980, 0.981, 0.982, 0.983, 0.984, 0.985,
-                  0.986, 0.987, 0.987, 0.988, 0.989, 0.989, 0.990, 0.990,
-                  0.991, 0.991, 0.992, 0.992, 0.993, 0.993, 0.993, 0.994,
-                  0.994, 0.994, 0.995, 0.995, 0.995, 0.995, 0.996, 0.996,
-                  0.996, 0.996, 0.997, 0.997, 0.997, 0.997, 0.997, 0.997,
-                  0.998, 0.998, 0.998, 0.998, 0.998, 0.998, 0.998, 0.998,
-                  0.998, 0.998, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999,
-                  0.999, 0.999, 1.00
-                );
+
+                /* Read by Nav too: the rail and main are flush, so this
+                   padding is the whole of the clear space between the
+                   two, and the Show/Hide toggle puts its right edge
+                   halfway across it. */
+                --main-p: 1.5rem;
 
                 /* No background here on purpose: this block is unlayered, so
                    any value would outrank the bg-background/text-foreground
@@ -113,7 +103,7 @@ export default function RootLayout({
                 overflow: hidden;
                 display: grid;
                 place-items: center;
-                padding: 1.5rem;
+                padding: var(--main-p);
               }
             }
           `}

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   ComponentProps,
+  CSSProperties,
   ElementRef,
   useCallback,
   useEffect,
@@ -12,13 +13,19 @@ import {
   useState,
 } from "react";
 import { useParams } from "next/navigation";
-import { ListFilterIcon, SearchIcon, XIcon } from "lucide-react";
+import {
+  ChevronLeftIcon,
+  ListFilterIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react";
 
 import { getLibraryLabel, getLibraryPopularity } from "@/const/libraries";
 import type { Demo } from "@/lib/helper";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import {
   Empty,
   EmptyContent,
@@ -42,7 +49,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Style } from "./Style";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarProvider,
+  useSidebar,
+} from "@/components/ui/sidebar";
 
 const STORAGE_KEY = "nav-collapsed";
 const MAX_TAGS = 4;
@@ -50,18 +63,6 @@ const MAX_TAGS = 4;
    it reserves it for clearing the selection. The sentinel is what the option
    carries; the state stays "". */
 const ALL_LIBRARIES = "__all__";
-
-function getPreferredCollapsed() {
-  const nav = new URLSearchParams(window.location.search).get("nav");
-  if (nav === "closed") return true;
-  if (nav === "open") return false;
-
-  return localStorage.getItem(STORAGE_KEY) === "1";
-}
-
-function syncCollapsedAttr(collapsed: boolean) {
-  document.documentElement.toggleAttribute("data-nav-collapsed", collapsed);
-}
 
 function hasInteractiveFocus(element: Element | null) {
   return (
@@ -75,14 +76,96 @@ function hasInteractiveFocus(element: Element | null) {
   );
 }
 
+/**
+ * The rail's own handle, deliberately a sibling of `<Sidebar>` rather than a
+ * child: once the panel is off-canvas the only thing left on screen is this
+ * pill, so it has to live in the `<SidebarProvider>` wrapper and straddle the
+ * panel's edge from there.
+ */
+function NavToggle() {
+  const { open, openMobile, isMobile, toggleSidebar } = useSidebar();
+
+  /* Under `md` the panel is a sheet with its own open state, and `open` still
+     holds whatever the rail was left at. `toggleSidebar` already picks the
+     right one; the label has to agree with it. */
+  const shown = isMobile ? openMobile : open;
+
+  const [ready, setReady] = useState(false);
+  const [near, setNear] = useState(false);
+
+  useEffect(() => setReady(true), []);
+
+  /* Collapsed, the pill mostly tucks itself into the page edge; bringing the
+     pointer over there nudges it back out. */
+  useEffect(() => {
+    if (shown) {
+      setNear(false);
+      return;
+    }
+
+    const onMove = (event: MouseEvent) => setNear(event.clientX < 120);
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [shown]);
+
+  return (
+    <ButtonGroup
+      orientation="vertical"
+      className={cn(
+        /* The group is what the page positions now, and it carries the pill's
+           box: `inset-y-0` + `my-auto` centres it without a `-translate-y-1/2`
+           that would fight the button's own `active:translate-y-px`. Above the
+           panel's `z-10`, since the pill overlaps its edge. */
+        "absolute inset-y-0 right-0 z-20 my-auto h-22 w-11 transition-transform",
+        shown
+          ? /* Right edge halfway across the gutter between the rail and the
+               demo — which is `main`'s padding, since the two are flush. Half
+               its own width would put the edge at 22px, past the gutter's
+               midpoint and nearly onto the demo. The collapsed offsets below
+               are a different measure: there the wrapper has no width, so they
+               are just how much sliver is left against the page edge. */
+            "translate-x-[calc(var(--main-p)/2)]"
+          : near
+            ? "translate-x-3/4"
+            : "translate-x-1/4",
+      )}
+    >
+      <Button
+        variant="secondary"
+        size="xs"
+        onClick={toggleSidebar}
+        aria-label={shown ? "Hide demos" : "Show demos"}
+        aria-pressed={shown}
+        /* No `rounded-full` here: the group forces `rounded-b-4xl` on its last
+           child, and a browser scales *every* corner by the same factor once
+           one side overflows — 9999px on top against 26px below would collapse
+           the bottom pair to nothing. At 44px wide the stock 4xl is already
+           past the 22px cap, so it draws the very same pill. */
+        className="size-full flex-col gap-1.5 px-0 shadow-lg"
+      >
+        <ChevronLeftIcon
+          className={cn("transition-transform", !shown && "rotate-180")}
+        />
+        <span className="tracking-wider uppercase [writing-mode:vertical-rl]">
+          {/* Blank until mounted: the collapsed state comes out of
+              `localStorage`, so before then the word would be a coin flip. */}
+          {ready ? (shown ? "hide" : "show") : ""}
+        </span>
+      </Button>
+    </ButtonGroup>
+  );
+}
+
 export default function Nav({
   demos,
+  className,
+  style,
   ...props
-}: { demos: Demo[] } & ComponentProps<"nav">) {
+}: { demos: Demo[] } & ComponentProps<"div">) {
   const ulRef = useRef<ElementRef<"ul">>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const [collapsed, setCollapsed] = useState(false);
+  const [open, setOpenState] = useState(true);
   const [ready, setReady] = useState(false);
   const [library, setLibrary] = useState("");
   const [libraryOpen, setLibraryOpen] = useState(false);
@@ -90,6 +173,11 @@ export default function Nav({
   const [searchOpen, setSearchOpen] = useState(false);
 
   const searchVisible = searchOpen || search !== "";
+
+  const setOpen = useCallback((next: boolean) => {
+    setOpenState(next);
+    localStorage.setItem(STORAGE_KEY, next ? "0" : "1");
+  }, []);
 
   const libraryOptions = useMemo(() => {
     const popularityByLabel = new Map<string, number>();
@@ -157,11 +245,7 @@ export default function Nav({
 
   const focusSearch = useCallback(
     (select = false) => {
-      if (collapsed) {
-        setCollapsed(false);
-        localStorage.setItem(STORAGE_KEY, "0");
-      }
-
+      setOpen(true);
       setSearchOpen(true);
 
       requestAnimationFrame(() => {
@@ -169,7 +253,7 @@ export default function Nav({
         if (select) searchRef.current?.select();
       });
     },
-    [collapsed],
+    [setOpen],
   );
 
   const dismissSearch = useCallback(() => {
@@ -236,26 +320,23 @@ export default function Nav({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [dismissSearch, focusSearch, libraryOpen, search, searchVisible]);
 
-  const toggle = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
-      return next;
-    });
-  }, []);
-
   const { demoname } = useParams();
 
+  /* `data-nav-collapsed` is put on <html> before first paint by the inline
+     script in `app/layout.tsx` — the only way a statically exported page can
+     know about `localStorage` that early. React picks the state up here. */
   useEffect(() => {
-    const next = document.documentElement.hasAttribute("data-nav-collapsed");
-    setCollapsed(next);
+    setOpenState(!document.documentElement.hasAttribute("data-nav-collapsed"));
     setReady(true);
   }, []);
 
+  /* …and hands the attribute back once that state has rendered: from here on
+     the panel is React's, and a stale attribute would fight it (see the
+     pre-paint rule in `app/globals.css`). */
   useEffect(() => {
     if (!ready) return;
-    syncCollapsedAttr(collapsed);
-  }, [collapsed, ready]);
+    document.documentElement.removeAttribute("data-nav-collapsed");
+  }, [ready]);
 
   const firstRef = useRef(true);
   useEffect(() => {
@@ -273,260 +354,32 @@ export default function Nav({
     firstRef.current = false;
   }, [demoname, filteredDemos]);
 
-  const navRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!collapsed) {
-      navRef.current?.removeAttribute("data-near");
-      return;
-    }
-    const onMove = (e: MouseEvent) => {
-      if (e.clientX < 120) navRef.current?.setAttribute("data-near", "");
-      else navRef.current?.removeAttribute("data-near");
-    };
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, [collapsed]);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "[" && e.metaKey) toggle();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [toggle]);
-
   return (
-    <div ref={navRef} className="Nav" data-collapsed={collapsed || undefined}>
-      <Style
-        css={`
-          @scope {
-            :scope {
-              position: relative;
-              width: var(--sidebar-w);
-              flex-shrink: 0;
-              height: 100dvh;
-              overflow: visible;
-              z-index: 2;
-              margin-inline-start: 0;
-              transition: margin-inline-start 1078ms var(--motion-curve);
-              will-change: margin-inline-start;
-            }
-
-            :scope[data-collapsed] {
-              margin-inline-start: calc(-1 * var(--sidebar-w));
-            }
-
-            html[data-nav-collapsed] .Nav {
-              margin-inline-start: calc(-1 * var(--sidebar-w));
-            }
-
-            nav {
-              height: 100%;
-              overflow-y: auto;
-              overscroll-behavior: contain;
-              scrollbar-gutter: stable;
-              opacity: 1;
-              transition: opacity 0.15s linear;
-            }
-
-            :scope[data-collapsed] nav {
-              opacity: 0;
-              pointer-events: none;
-            }
-
-            html[data-nav-collapsed] .Nav nav {
-              opacity: 0;
-              pointer-events: none;
-            }
-
-            .filters {
-              position: sticky;
-              top: 0;
-              z-index: 2;
-              padding: 0.65rem 0.75rem 0.35rem 1rem;
-              /* This is the page background, fading out under the scrolling
-                 list — it has to follow --background. */
-              background: linear-gradient(var(--background) 75%, transparent);
-            }
-
-            .filterRow {
-              display: flex;
-              align-items: center;
-              gap: 0.4rem;
-            }
-
-            .filterRow[data-covered] {
-              visibility: hidden;
-            }
-
-            @keyframes search-in {
-              from {
-                opacity: 0;
-                translate: 0 -0.35rem;
-              }
-            }
-
-            /* The search field is a shadcn <InputGroup>; all this block may
-               hold is the geometry that lifts it over the filter row, plus the
-               width: auto that keeps the component's own w-full from fighting
-               the left/right insets. Anything else here is unlayered and would
-               outrank the component's utilities. */
-            .search {
-              position: absolute;
-              inset: 0.65rem 0.75rem auto 1rem;
-              z-index: 3;
-              width: auto;
-              animation: search-in 200ms ease;
-            }
-
-            .srOnly {
-              position: absolute;
-              width: 1px;
-              height: 1px;
-              padding: 0;
-              margin: -1px;
-              overflow: hidden;
-              clip: rect(0, 0, 0, 0);
-              white-space: nowrap;
-              border: 0;
-            }
-
-            .toggle {
-              position: absolute;
-              top: 50%;
-              right: 0;
-              translate: 50% -50%;
-              z-index: 10;
-
-              width: 2.75rem;
-              height: 5.5rem;
-              border-radius: 999px;
-              background: rgb(255 255 255 / 0.92);
-              border: 1px solid #d4d4d4;
-              cursor: pointer;
-              display: grid;
-              place-items: center;
-              color: #666;
-              transition:
-                background 0.15s ease,
-                color 0.15s ease,
-                box-shadow 0.15s ease,
-                translate 0.25s ease;
-              box-shadow: 0 10px 30px rgb(0 0 0 / 0.12);
-
-              &:hover {
-                background: #f5f5f5;
-                color: #222;
-                box-shadow: 0 14px 36px rgb(0 0 0 / 0.16);
-              }
-            }
-
-            .toggleInner {
-              display: grid;
-              gap: 0.35rem;
-              justify-items: center;
-            }
-
-            .toggleLabel {
-              font-size: 0.6rem;
-              line-height: 1;
-              letter-spacing: 0.08em;
-              text-transform: uppercase;
-              writing-mode: vertical-rl;
-              text-orientation: mixed;
-            }
-
-            .toggle svg {
-              width: 0.7rem;
-              height: 0.7rem;
-              transform: rotate(0deg);
-              transition: transform 1078ms var(--motion-curve);
-            }
-
-            :scope[data-collapsed] .toggle {
-              translate: 25% -50%;
-            }
-
-            html[data-nav-collapsed] .Nav .toggle {
-              translate: 25% -50%;
-            }
-
-            :scope[data-collapsed][data-near] .toggle {
-              translate: 75% -50%;
-            }
-
-            html[data-nav-collapsed] .Nav[data-near] .toggle {
-              translate: 75% -50%;
-            }
-
-            :scope[data-collapsed] .toggle svg {
-              transform: rotate(180deg);
-            }
-
-            html[data-nav-collapsed] .Nav .toggle svg {
-              transform: rotate(180deg);
-            }
-
-            ul {
-              padding-inline-start: unset;
-              list-style: none;
-              padding: 0.4rem 0.75rem 1rem 1rem;
-              display: flex;
-              flex-direction: column;
-              gap: 0.75rem;
-              margin: 0;
-            }
-
-            li {
-              padding-inline-start: unset;
-              transform: scale(1);
-              transition: transform 1078ms var(--motion-curve);
-            }
-
-            li:active {
-              transform: scale(0.97);
-            }
-
-            /* The demo cards are shadcn <Item>/<Badge>; they style themselves
-               with Tailwind. Nothing scoped here may target them — this block
-               is unlayered and would outrank every utility. */
-          }
-        `}
-      />
-
-      <button
-        className="toggle"
-        onClick={toggle}
-        aria-label={collapsed ? "Show demos" : "Hide demos"}
-        aria-pressed={!collapsed}
-      >
-        <span className="toggleInner">
-          <svg
-            viewBox="0 0 6 10"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 1L1 5L5 9"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span className="toggleLabel">
-            {ready ? (collapsed ? "show" : "hide") : ""}
-          </span>
-        </span>
-      </button>
-
-      <nav {...props}>
-        <div className="filters">
-          {searchVisible && (
-            /* Opaque: this floats over the filter row, and the sticky
-               `.filters` gradient behind it goes transparent at the bottom. */
-            <InputGroup className="search bg-background">
+    <SidebarProvider
+      open={open}
+      onOpenChange={setOpen}
+      /* The provider writes `--sidebar-width` inline, so the site's own
+         responsive rail width has to arrive the same way — a class would lose
+         to the inline style. `w-auto` undoes the provider's `w-full`, which
+         assumes it wraps the page; here it only wraps the rail and its
+         handle. */
+      style={
+        { "--sidebar-width": "var(--sidebar-w)", ...style } as CSSProperties
+      }
+      className={cn("relative w-auto shrink-0", className)}
+      {...props}
+    >
+      {/* The rail paints the same colour as the page, so the component's own
+          divider is the only thing left drawing a seam down the middle of a
+          flush surface. Same variant as the rule it cancels, so `cn`'s merge
+          drops that one outright rather than out-specifying it. */}
+      <Sidebar className="group-data-[side=left]:border-r-0">
+        {/* 16px down both edges, in place of the components' stock 8px. It has
+            to be set on the two children: `className` here lands on the fixed
+            container, and the panel's background is painted a level deeper. */}
+        <SidebarHeader className="px-4">
+          {searchVisible ? (
+            <InputGroup className="animate-in duration-200 fade-in slide-in-from-top-1">
               {/* Addons come after the control in the DOM — they focus it on
                   click and take their visual side from `align`. */}
               <InputGroupInput
@@ -557,133 +410,188 @@ export default function Nav({
                 </InputGroupButton>
               </InputGroupAddon>
             </InputGroup>
-          )}
-          <div className="filterRow" data-covered={searchVisible || undefined}>
-            <Select
-              open={libraryOpen}
-              onOpenChange={setLibraryOpen}
-              value={library || ALL_LIBRARIES}
-              onValueChange={(value) =>
-                setLibrary(value === ALL_LIBRARIES ? "" : value)
-              }
-            >
-              <SelectTrigger
-                className="min-w-0 flex-1"
-                aria-label="Filter examples by library"
+          ) : (
+            <div className="flex items-center gap-2">
+              <Select
+                open={libraryOpen}
+                onOpenChange={setLibraryOpen}
+                value={library || ALL_LIBRARIES}
+                onValueChange={(value) =>
+                  setLibrary(value === ALL_LIBRARIES ? "" : value)
+                }
               >
-                <ListFilterIcon className="text-muted-foreground" />
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value={ALL_LIBRARIES}>All libraries</SelectItem>
-                  {libraryOptions.map((option) => (
-                    <SelectItem key={option} value={option}>
-                      {option}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              onClick={() => focusSearch()}
-              aria-label="Search examples"
-              aria-keyshortcuts="Meta+F Control+F Meta+K Control+K"
-              title="Search examples (⌘F)"
-            >
-              <SearchIcon />
-            </Button>
-          </div>
-          <span id="search-results" className="srOnly" aria-live="polite">
-            {filteredDemos.length} examples
-          </span>
-        </div>
-        <ul ref={ulRef} id="demo-list">
-          {filteredDemos.map(({ name, title, thumb, isNew, tags }) => (
-            <li key={thumb} data-demo={name}>
-              <Item
-                asChild
-                variant="outline"
-                className={cn(
-                  "relative overflow-hidden bg-muted p-0",
-                  /* `accent` is the same value as `muted` under the neutral
-                     base colour, so the selected card reads through the
-                     paired `accent-foreground` ring. */
-                  demoname === name &&
-                    "bg-accent ring-2 ring-accent-foreground",
-                )}
-              >
-                <Link
-                  href={`/demos/${name}`}
-                  aria-current={demoname === name ? "page" : undefined}
-                  className="no-underline"
+                <SelectTrigger
+                  className="min-w-0 flex-1"
+                  aria-label="Filter examples by library"
                 >
-                  {/* Full-bleed: the media is the only thing in the box, so the
-                      card ends up with the thumbnail's aspect ratio. */}
-                  <ItemMedia
-                    variant="image"
-                    className="relative aspect-video size-auto w-full rounded-none"
-                  >
-                    <Image
-                      src={thumb}
-                      fill
-                      sizes="(min-width: 640px) 260px, 200px"
-                      alt={title}
-                    />
-                  </ItemMedia>
-                  {isNew && (
-                    <Badge
-                      variant="secondary"
-                      className="absolute top-1.5 right-1.5"
-                    >
-                      New
-                    </Badge>
-                  )}
-                  {tags.length > 0 && (
-                    <ItemFooter className="absolute inset-x-0 bottom-0">
-                      <ScrollArea className="w-full">
-                        {/* Padding sits inside the viewport so the scrollable
-                            strip itself runs edge to edge. */}
-                        <div className="flex w-max gap-1 p-1.5">
-                          {tags.slice(0, MAX_TAGS).map((tag) => (
-                            <Badge key={tag}>{tag}</Badge>
-                          ))}
-                        </div>
-                        <ScrollBar orientation="horizontal" />
-                      </ScrollArea>
-                    </ItemFooter>
-                  )}
-                </Link>
-              </Item>
-            </li>
-          ))}
-        </ul>
-        {filteredDemos.length === 0 && (
-          /* Stock padding is p-12, which leaves nothing to read in a rail this
-             narrow. */
-          <Empty className="p-6">
-            <EmptyHeader>
-              <EmptyTitle>No matching examples</EmptyTitle>
-            </EmptyHeader>
-            <EmptyContent>
+                  <ListFilterIcon className="text-muted-foreground" />
+                  <SelectValue />
+                </SelectTrigger>
+                {/* `item-aligned` — this registry's default, where Radix lays
+                    the menu over the trigger with the selected option on top
+                    of it — cannot do that for a trigger sitting 26px from the
+                    top of the window. It clamps the menu and makes up the
+                    difference by scrolling the viewport, here by the 4px of
+                    `SelectGroup` padding above the first option. That is a
+                    non-zero `scrollTop`, which is the whole of what mounts
+                    `SelectScrollUpButton`: an arrow offering to scroll back to
+                    an option already in view. `popper` anchors the menu below
+                    the trigger instead and never pre-scrolls, so the arrows
+                    are left to mean what they say. It also gives
+                    `--radix-select-content-available-height` a value, which
+                    the component's own `max-h-` reads and item-aligned never
+                    sets. */}
+                <SelectContent position="popper">
+                  <SelectGroup>
+                    <SelectItem value={ALL_LIBRARIES}>All libraries</SelectItem>
+                    {libraryOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
               <Button
                 type="button"
                 variant="outline"
-                size="sm"
-                onClick={() => {
-                  dismissSearch();
-                  setLibrary("");
-                }}
+                size="icon"
+                onClick={() => focusSearch()}
+                aria-label="Search examples"
+                aria-keyshortcuts="Meta+F Control+F Meta+K Control+K"
+                title="Search examples (⌘F)"
               >
-                Clear filters
+                <SearchIcon />
               </Button>
-            </EmptyContent>
-          </Empty>
-        )}
-      </nav>
-    </div>
+            </div>
+          )}
+          <span id="search-results" className="sr-only" aria-live="polite">
+            {filteredDemos.length} examples
+          </span>
+        </SidebarHeader>
+
+        {/* `scroll-fade` goes on the scroller, not on the header it softens:
+            the utility masks the element it sits on and reads that element's
+            own scroll position. It reveals each edge over the first 96px of
+            travel, so a list sitting at the top is not faded into its own
+            first card. Without scroll-driven-animation support the two fades
+            are simply always on. */}
+        <SidebarContent className="scroll-fade px-4">
+          <nav aria-label="Examples">
+            <ul
+              ref={ulRef}
+              id="demo-list"
+              /* The block padding is not decoration: the selected card's ring
+                 sits outside its border box, and the scroller would clip it on
+                 the first and last item without it. The inline half of it moved
+                 up to `SidebarContent`, so the header lines up with the list. */
+              className="flex flex-col gap-3 py-2"
+            >
+              {filteredDemos.map(({ name, title, thumb, isNew, tags }) => (
+                <li
+                  key={thumb}
+                  data-demo={name}
+                  className="transition-transform active:scale-97"
+                >
+                  <Item
+                    asChild
+                    variant="outline"
+                    className={cn(
+                      "relative overflow-hidden bg-muted p-0",
+                      /* `accent` is the same value as `muted` under the neutral
+                         base colour, so the selected card reads through the
+                         paired `accent-foreground` ring. */
+                      demoname === name &&
+                        "bg-accent ring-2 ring-accent-foreground",
+                    )}
+                  >
+                    <Link
+                      href={`/demos/${name}`}
+                      aria-current={demoname === name ? "page" : undefined}
+                      className="no-underline"
+                    >
+                      {/* Full-bleed: the media is the only thing in the box, so
+                          the card ends up with the thumbnail's aspect ratio. */}
+                      <ItemMedia
+                        variant="image"
+                        className="relative aspect-video size-auto w-full rounded-none"
+                      >
+                        {/* Thumbnails are served by each demo, not by this
+                            site, so in dev every card but the running one
+                            404s — and a built site can still meet a demo
+                            whose thumbnail was never generated. A broken
+                            `img` stops being a replaced element, which is
+                            exactly when its pseudo-elements start rendering:
+                            `after` covers the browser's glyph with the card's
+                            own colour and puts the alt text back as text. On
+                            an image that loads, nothing of this exists. */}
+                        <Image
+                          src={thumb}
+                          fill
+                          sizes="(min-width: 640px) 260px, 200px"
+                          alt={title}
+                          className="after:absolute after:inset-0 after:grid after:place-items-center after:bg-muted after:px-3 after:text-center after:text-xs after:text-muted-foreground after:content-[attr(alt)]"
+                        />
+                      </ItemMedia>
+                      {isNew && (
+                        <Badge
+                          variant="secondary"
+                          className="absolute top-1.5 right-1.5"
+                        >
+                          New
+                        </Badge>
+                      )}
+                      {tags.length > 0 && (
+                        <ItemFooter className="absolute inset-x-0 bottom-0">
+                          {/* Same fade as the demo list, on the other axis.
+                              It has to be aimed at the viewport: `ScrollArea`
+                              puts its `className` on the root, and the root is
+                              not what scrolls. */}
+                          <ScrollArea className="w-full [&>[data-slot=scroll-area-viewport]]:scroll-fade-x">
+                            {/* Padding sits inside the viewport so the
+                                scrollable strip itself runs edge to edge. */}
+                            <div className="flex w-max gap-1 p-1.5">
+                              {tags.slice(0, MAX_TAGS).map((tag) => (
+                                <Badge key={tag}>{tag}</Badge>
+                              ))}
+                            </div>
+                            <ScrollBar orientation="horizontal" />
+                          </ScrollArea>
+                        </ItemFooter>
+                      )}
+                    </Link>
+                  </Item>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          {filteredDemos.length === 0 && (
+            /* Stock padding is p-12, which leaves nothing to read in a rail
+               this narrow — and the inline half now comes from the scroller. */
+            <Empty className="py-6">
+              <EmptyHeader>
+                <EmptyTitle>No matching examples</EmptyTitle>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    dismissSearch();
+                    setLibrary("");
+                  }}
+                >
+                  Clear filters
+                </Button>
+              </EmptyContent>
+            </Empty>
+          )}
+        </SidebarContent>
+      </Sidebar>
+
+      <NavToggle />
+    </SidebarProvider>
   );
 }

--- a/apps/website/components/ui/button-group.tsx
+++ b/apps/website/components/ui/button-group.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { Separator } from "@/components/ui/separator";
+
+const buttonGroupVariants = cva(
+  "group/button-group flex w-fit items-stretch *:focus-visible:relative *:focus-visible:z-10 has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-4xl [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-4xl!",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-4xl!",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  },
+);
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "div";
+
+  return (
+    <Comp
+      className={cn(
+        "flex items-center gap-2 rounded-4xl border bg-muted px-2.5 text-sm font-medium [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+};

--- a/apps/website/components/ui/sheet.tsx
+++ b/apps/website/components/ui/sheet.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as SheetPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { XIcon } from "lucide-react";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left";
+  showCloseButton?: boolean;
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close data-slot="sheet-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-4 right-4"
+              size="icon-sm"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        "font-heading text-base font-medium text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/apps/website/components/ui/sidebar.tsx
+++ b/apps/website/components/ui/sidebar.tsx
@@ -1,0 +1,705 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PanelLeftIcon } from "lucide-react";
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed";
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  dir,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn(
+        "flex flex-col gap-2 p-2 [--radius:var(--radius-xl)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-3 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-lg px-3 py-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
+      },
+      size: {
+        default: "h-9 text-sm",
+        sm: "h-8 text-xs",
+        lg: "h-14 px-3 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot.Root : "button";
+  const { isMobile, state } = useSidebar();
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-2 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean;
+}) {
+  // Random width between 50 to 90%.
+  const [width] = React.useState(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  });
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+  size?: "sm" | "md";
+  isActive?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "a";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/apps/website/components/ui/skeleton.tsx
+++ b/apps/website/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-xl bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/website/components/ui/tooltip.tsx
+++ b/apps/website/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-2xl bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-4xl data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=left]:translate-x-[-1.5px] data-[side=right]:translate-x-[1.5px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/website/hooks/use-mobile.ts
+++ b/apps/website/hooks/use-mobile.ts
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    undefined,
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return !!isMobile;
+}


### PR DESCRIPTION
Stacked on #143.

The piece the previous commits in this stack kept deferring: the nav shell itself. `Nav` was a `.Nav` div wrapping a `<nav>`, with ~190 lines of `@scope` CSS doing the rail geometry, the collapse slide, the sticky filter strip, the search overlay's position, the list and the toggle. It is now `SidebarProvider` + `Sidebar` + `SidebarHeader` + `SidebarContent`, added with `pnpm dlx shadcn@latest add sidebar`, plus `button-group`.

### `Nav` renders no `<Style>` at all now

That block was unlayered, so every rule in it outranked the utilities the components emit. What it used to do:

- the rail's width, the negative margin that slid it off-screen, and the `100dvh` / `overflow-y: auto` split → `Sidebar collapsible="offcanvas"` and `SidebarContent`
- `.filters`' `position: sticky` → **nothing**. `SidebarHeader` is a flex sibling of the scroller, so it stays put without being stuck to anything
- its `linear-gradient(--background 75%, transparent)`, which faded the list out under the filter row → [`scroll-fade`](https://ui.shadcn.com/docs/utils/scroll-fade) on `SidebarContent`. The utility goes on the scroller rather than on the header it softens: it masks the element it sits on and reads that element's own scroll offset. So unlike the gradient it also handles the bottom edge, and neither edge is faded until there is something scrolled past it. Each card's tag strip gets the same treatment on the other axis (`scroll-fade-x`), aimed at the viewport since `ScrollArea` puts its `className` on the root and the root is not what scrolls
- `.search`'s absolute overlay and `.filterRow[data-covered]` → the header swaps one for the other. Both rows are `h-9`, so nothing moves; the entrance keyframes become `animate-in` from tw-animate-css
- `.srOnly` → `sr-only`, `ul` / `li` → utilities

### The Show/Hide pill

It is a shadcn `Button` inside a vertical `ButtonGroup`, and a **sibling of `Sidebar`** rather than a child — off-canvas it is the only thing left on screen, so it lives in the `SidebarProvider` wrapper and straddles the panel's edge from there. One button in the group for now; it is there so a second one can land next to it without the pill having to be rebuilt. The group carries the position and the box, the button fills it.

It keeps its behaviour: an 11px sliver when collapsed, nudged back out when the pointer comes within 120px. It loses its colours — it was pinned to `rgb(255 255 255 / .92)` / `#d4d4d4` / `#666` and read light in both schemes, and is now `variant="secondary"`, i.e. on the Material roles the rest of this stack wired up. Centred with `inset-y-0 my-auto` rather than `-translate-y-1/2`, so `Button`'s own `active:translate-y-px` press still reads as a press.

Open, its right edge lands halfway across the gutter between the rail and the demo. The rail and `main` are flush, so that gutter is exactly `main`'s padding — which moves to a `--main-p` custom property in `layout.tsx`, next to `--sidebar-w` and read the same way, rather than being hardcoded in two places. The old half-its-own-width overhang put the edge 10px further out, past the midpoint and nearly onto the demo. The collapsed offsets stay proportional: there the wrapper has no width, so they are just how much sliver is left against the page edge.

No `rounded-full` on it, deliberately: `ButtonGroup` forces `rounded-b-4xl` on its last child, and a browser scales *every* corner by the same factor once one side overflows — a 9999px top against a 26px bottom collapses the bottom pair to square. At 44px wide the stock 4xl is already past the 22px cap, so it draws the very same pill.

### No-flash restore survives

The collapsed state is in `localStorage` and the site is a static export, so `cookies()` + `defaultOpen` — what shadcn documents — is not available. The inline script in `layout.tsx` still marks `<html>` before first paint, and two unlayered rules in `globals.css` restate the collapsed geometry for the frames before hydration. `Nav` now *drops* the attribute once it has rendered the real state, rather than keeping it in sync forever: past mount, the panel is React's.

`--sidebar-width` is handed the site's responsive `--sidebar-w` through `style`, since `SidebarProvider` sets that variable inline and a class would lose to it.

### The rail reads as part of the page, not as a panel laid on it

`--sidebar` is remapped from `surface-container-low` to `surface` — the same value as `--background`, so the panel is flush — and `Sidebar` is handed `group-data-[side=left]:border-r-0`, so nothing draws a seam down the middle of that flush surface either.

The colour goes through `globals.css` rather than a `bg-transparent` at the call site: `bg-sidebar` sits on the vendored component, and the token is the sanctioned way in. Staying on an m3 role rather than the `transparent` keyword also keeps the mobile sheet opaque, since it paints from the same token. The border is geometry, so it is a `className` — spelled with the variant it cancels, which is what lets `cn`'s merge drop the original outright instead of out-specifying it.

### 16px down both edges

On `SidebarHeader` and `SidebarContent`, in place of the components' stock 8px — not on `Sidebar`, whose `className` lands on the fixed container, a level above the div that paints the background, so padding there would inset the panel's own colour. The list keeps the block half of its padding: the selected card's ring sits outside its border box, and the scroller would clip it on the first and last item.

### The library dropdown opens below its trigger

On `position="popper"`, rather than this registry's `item-aligned` default. Item-aligned lays the menu over the trigger with the selected option on top of it, and cannot do that for a trigger sitting 26px from the top of the window: it clamps the menu and makes up the difference by scrolling the viewport — here by the 4px of `SelectGroup` padding above the first option.

That is a non-zero `scrollTop`, which is the whole of what mounts `SelectScrollUpButton`. So the menu showed an arrow offering to scroll back up to an option already in view, on every open. Popper anchors below the trigger and never pre-scrolls, so the arrows are left to mean what they say — and it gives `--radix-select-content-available-height` a value, which the component's own `max-h-` reads and item-aligned never sets.

### Behaviour that changes — all of it the component's own

- **Collapse is ⌘B, not ⌘[.** `SidebarProvider` brings the shortcut and calls `preventDefault`; the old handler did not, so ⌘[ also navigated back.
- **Below `md` the rail is a `Sheet`** instead of a 200px column next to the demo.
- **The slide is 200ms ease-linear**, not the 1078ms `--motion-curve` spring. Re-timing it means reaching into two `data-slot`s from a parent `className`, which is exactly the coupling `--overwrite` should not have to survive. That was the token's last consumer, so the `linear()` literal goes with it. Say the word and it comes back.
- **`SidebarContent` hides its scrollbar** (`no-scrollbar`), where the old `<nav>` reserved a `scrollbar-gutter: stable`.

### A missing thumbnail no longer draws the browser's broken-image glyph

Thumbnails are served by each demo rather than by this site, so in dev every card but the running one 404s — and a built site can still meet a demo whose thumbnail was never generated.

A broken `img` stops being a replaced element, which is exactly when its pseudo-elements begin to render. So `after:` covers the glyph with the card's own colour and puts the alt text back as centred text, via `content: attr(alt)`. On an image that loads, none of it exists. No state, no `onError`, no second element — eight utilities on the `Image`. Checked in Chrome both ways round.

### Also

`Sidebar` renders divs, so the list gets a `<nav aria-label="Examples">` to keep the landmark. `getPreferredCollapsed` was already dead code and is removed. `AGENTS.md` no longer lists `Nav` among the `@scope` components.

### Checks

`tsc --noEmit`, `next lint` and `next build` (163 pages, static export) are clean. Checked in the browser: collapse and restore across reloads, the proximity nudge, ⌘F / typeahead / Escape, the library dropdown, the empty state, and the mobile sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
