### PR TITLE
website: demo top bar as shadcn ButtonGroup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily 
 
 Two things to know before styling:
 
-- **Most of the site's own components are not on Tailwind.** `Info`, `Social`, `Dev` and `ScaledDemoFrame` still style themselves with scoped CSS injected through `<Style>` (`@scope { … }`). That's deliberate, not a half-finished migration. Tailwind classes are for `components/ui/*` and new work; leave the `@scope` blocks alone unless you're converting a component wholesale — `Nav` is the one that has been, and it now composes `Sidebar` with no `<Style>` of its own. Inline `<style>` is unlayered, so those rules outrank Preflight and keep winning.
+- **Most of the site's own components are not on Tailwind.** `Dev` and `ScaledDemoFrame` still style themselves with scoped CSS injected through `<Style>` (`@scope { … }`). That's deliberate, not a half-finished migration. Tailwind classes are for `components/ui/*` and new work; leave the `@scope` blocks alone unless you're converting a component wholesale — `Nav` composes `Sidebar`, and `Info`/`Social` compose `ButtonGroup`, none of them with a `<Style>` of their own. Inline `<style>` is unlayered, so those rules outrank Preflight and keep winning.
 - **Sources are declared explicitly.** Tailwind's automatic source detection finds nothing in this app, so `app/globals.css` lists `@source` entries. Add one if you put components somewhere new.
 
 `demos/` is deliberately Tailwind-free; don't introduce it there.

--- a/apps/website/app/demos/[demoname]/Info.tsx
+++ b/apps/website/app/demos/[demoname]/Info.tsx
@@ -7,6 +7,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from "@/components/ui/item";
+import {
   Popover,
   PopoverContent,
   PopoverDescription,
@@ -130,53 +137,61 @@ export function Info({ demo }: { demo: Demo }) {
 
         {demo.assets.length > 0 && (
           <Section title="Assets">
-            <ul className="flex flex-col gap-2.5 text-xs">
+            {/* The one part of the panel that is a list of *things* rather than
+                a value: each asset has a name, someone it is by, and terms it
+                comes under. `ItemGroup` carries the `role="list"` the `<ul>`
+                used to. `muted` rather than `outline` — the panel is already a
+                surface, and a border inside it would read as a second one. */}
+            <ItemGroup>
               {demo.assets.map((asset) => (
-                <li key={asset.name}>
-                  {asset.source ? (
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={asset.source}
-                    >
-                      {asset.name}
-                    </a>
-                  ) : (
-                    asset.name
-                  )}
-                  {asset.creator && (
-                    <span className="text-muted-foreground">
-                      {" "}
-                      by {asset.creator}
-                    </span>
-                  )}
-                  {asset.license && (
-                    <span className="text-muted-foreground">
-                      {" — "}
-                      {asset.licenseUrl ? (
+                <Item key={asset.name} variant="muted" size="xs">
+                  <ItemContent>
+                    <ItemTitle>
+                      {asset.source ? (
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href={asset.licenseUrl}
+                          href={asset.source}
                         >
-                          {asset.license}
+                          {asset.name}
                         </a>
                       ) : (
-                        asset.license
+                        asset.name
                       )}
-                    </span>
-                  )}
-                  {asset.modified && (
-                    <span className="text-muted-foreground"> (modified)</span>
-                  )}
-                  {asset.notes && (
-                    <span className="block text-muted-foreground">
-                      {asset.notes}
-                    </span>
-                  )}
-                </li>
+                      {asset.modified && (
+                        <Badge variant="outline">edited</Badge>
+                      )}
+                    </ItemTitle>
+                    {(asset.creator || asset.license) && (
+                      <ItemDescription>
+                        {asset.creator && <>by {asset.creator}</>}
+                        {asset.creator && asset.license && " — "}
+                        {asset.license &&
+                          (asset.licenseUrl ? (
+                            <a
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              href={asset.licenseUrl}
+                            >
+                              {asset.license}
+                            </a>
+                          ) : (
+                            asset.license
+                          ))}
+                      </ItemDescription>
+                    )}
+                    {/* Notes are the only free text here, and the stock
+                        two-line clamp is measured for a row in a list, not for
+                        a panel the reader opened to read. */}
+                    {asset.notes && (
+                      <ItemDescription className="line-clamp-none text-xs">
+                        {asset.notes}
+                      </ItemDescription>
+                    )}
+                  </ItemContent>
+                </Item>
               ))}
-            </ul>
+            </ItemGroup>
           </Section>
         )}
       </PopoverContent>

--- a/apps/website/app/demos/[demoname]/Info.tsx
+++ b/apps/website/app/demos/[demoname]/Info.tsx
@@ -1,11 +1,24 @@
-"use client";
+import { ReactNode } from "react";
+import { RxInfoCircled } from "react-icons/rx";
 
-import { useEffect, useRef, useState } from "react";
-import { RxCross2, RxInfoCircled } from "react-icons/rx";
-
-import { Style } from "@/components/Style";
 import { getLibraryLabel } from "@/const/libraries";
 import type { Demo } from "@/lib/helper";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function formatDate(date: string) {
   return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-US", {
@@ -16,344 +29,108 @@ function formatDate(date: string) {
   });
 }
 
+/** The panel is a stack of these — a small caps label over its content. */
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="flex flex-col gap-1.5">
+      <h3 className="text-xs font-bold tracking-wider text-muted-foreground uppercase">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
 export function Info({ demo }: { demo: Demo }) {
-  const [open, setOpen] = useState(false);
-  const popoverRef = useRef<HTMLDivElement>(null);
   const libraryLabels = Array.from(
     new Set(demo.libraries.map(getLibraryLabel)),
   );
 
-  useEffect(() => {
-    const popover = popoverRef.current;
-    if (!popover) return;
-
-    const onToggle = (event: ToggleEvent) => {
-      setOpen(event.newState === "open");
-    };
-
-    popover.addEventListener("toggle", onToggle);
-    return () => popover.removeEventListener("toggle", onToggle);
-  }, []);
-
   return (
-    <div className="Info">
-      <Style
-        css={`
-          @scope {
-            :scope {
-              position: relative;
-            }
+    <Popover>
+      {/* One button, so the group's `rounded-4xl` ends meet and it draws a
+          disc. It is a group of one on purpose: a second control can land
+          beside it without the pill having to be rebuilt. */}
+      <ButtonGroup className="rounded-4xl shadow-lg">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                variant="secondary"
+                size="icon"
+                aria-label="Show demo info"
+                /* `secondary` reads the same open or shut; the panel is
+                   anchored to this button, so it should look pressed while the
+                   panel is up. */
+                className="aria-expanded:bg-primary aria-expanded:text-primary-foreground"
+              >
+                <RxInfoCircled />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">info</TooltipContent>
+        </Tooltip>
+      </ButtonGroup>
 
-            .trigger {
-              position: relative;
-              display: grid;
-              place-items: center;
-              width: 2.4rem;
-              height: 2.4rem;
-              padding: 0;
-              border: none;
-              border-radius: 999px;
-              background: rgb(255 255 255 / 0.82);
-              backdrop-filter: blur(10px);
-              box-shadow: 0 1px 6px rgb(0 0 0 / 0.1);
-              color: #555;
-              cursor: pointer;
-              transition:
-                background 0.15s ease,
-                color 0.15s ease;
-            }
-
-            .trigger:hover {
-              color: #111;
-            }
-
-            .trigger[aria-expanded="true"] {
-              background: #222;
-              color: white;
-            }
-
-            .trigger svg {
-              width: 1.05rem;
-              height: 1.05rem;
-            }
-
-            .trigger > span {
-              position: absolute;
-              top: 100%;
-              left: 50%;
-              translate: -50% 0;
-              margin-top: 0.45rem;
-              padding: 0.25em 0.5em;
-              border-radius: 4px;
-              background: #222;
-              color: white;
-              font-size: 0.65rem;
-              white-space: nowrap;
-              pointer-events: none;
-              opacity: 0;
-              transition: opacity 0.15s ease;
-            }
-
-            .trigger:hover > span {
-              opacity: 1;
-            }
-
-            .trigger[aria-expanded="true"] > span {
-              opacity: 0;
-            }
-
-            .panel {
-              position: fixed;
-              inset: 3.75rem max(0.75rem, env(safe-area-inset-right)) auto auto;
-              box-sizing: border-box;
-              width: min(24rem, calc(100dvw - 1.5rem));
-              max-height: min(calc(100dvh - 4.5rem), 34rem);
-              overflow-y: auto;
-              overscroll-behavior: contain;
-              margin: 0;
-              padding: 1.1rem 1.2rem 1.2rem;
-              border: 1px solid #d4d4d4;
-              border-radius: 12px;
-              background: rgb(255 255 255 / 0.92);
-              backdrop-filter: blur(10px);
-              box-shadow: 0 10px 30px rgb(0 0 0 / 0.12);
-              animation: info-in 0.2s ease both;
-            }
-
-            .panel::backdrop {
-              background: transparent;
-            }
-
-            @keyframes info-in {
-              from {
-                opacity: 0;
-                translate: 0 -0.35rem;
-              }
-              to {
-                opacity: 1;
-                translate: 0 0;
-              }
-            }
-
-            header {
-              display: flex;
-              align-items: baseline;
-              justify-content: space-between;
-              gap: 0.75rem;
-            }
-
-            h2 {
-              margin: 0;
-              font-size: 1rem;
-              font-weight: 700;
-              color: #111;
-            }
-
-            .close {
-              flex-shrink: 0;
-              display: grid;
-              place-items: center;
-              width: 1.6rem;
-              height: 1.6rem;
-              padding: 0;
-              border: none;
-              border-radius: 50%;
-              background: none;
-              color: #555;
-              cursor: pointer;
-              transition:
-                background 0.15s ease,
-                color 0.15s ease;
-            }
-
-            .close:hover {
-              background: rgb(0 0 0 / 0.06);
-              color: #111;
-            }
-
-            .close svg {
-              width: 0.85rem;
-              height: 0.85rem;
-            }
-
-            .description {
-              margin: 0.5rem 0 0;
-              font-size: 0.8rem;
-              line-height: 1.5;
-              color: #333;
-            }
-
-            section {
-              margin-top: 0.9rem;
-            }
-
-            h3 {
-              margin: 0 0 0.4rem;
-              color: #555;
-              font-size: 0.65rem;
-              font-weight: 700;
-              letter-spacing: 0.06em;
-              text-transform: uppercase;
-            }
-
-            .pills {
-              display: flex;
-              flex-wrap: wrap;
-              gap: 0.3rem;
-              margin: 0;
-              padding: 0;
-              list-style: none;
-            }
-
-            .pills li {
-              padding: 2px 8px;
-              border-radius: 999px;
-              background: rgb(0 0 0 / 0.06);
-              color: #333;
-              font-size: 0.65rem;
-              line-height: 1.5;
-            }
-
-            .text {
-              margin: 0;
-              font-size: 0.8rem;
-              line-height: 1.5;
-              color: #333;
-            }
-
-            .assets {
-              display: grid;
-              gap: 0.6rem;
-              margin: 0;
-              padding: 0;
-              list-style: none;
-            }
-
-            .assets li {
-              font-size: 0.75rem;
-              line-height: 1.45;
-              color: #333;
-            }
-
-            .assets .meta {
-              color: #666;
-            }
-
-            .assets .notes {
-              display: block;
-              color: #666;
-              font-size: 0.7rem;
-            }
-
-            @media (max-width: 40rem), (max-height: 32rem) {
-              .panel {
-                inset: auto max(0.5rem, env(safe-area-inset-right))
-                  max(0.5rem, env(safe-area-inset-bottom))
-                  max(0.5rem, env(safe-area-inset-left));
-                width: auto;
-                max-width: none;
-                max-height: calc(
-                  100dvh -
-                    1rem - env(safe-area-inset-top) - env(
-                      safe-area-inset-bottom
-                    )
-                );
-                padding: 1rem;
-                border-radius: 16px;
-              }
-
-              .panel::backdrop {
-                background: rgb(0 0 0 / 0.18);
-              }
-
-              .trigger > span {
-                display: none;
-              }
-            }
-
-            @media (prefers-reduced-motion: reduce) {
-              .panel {
-                animation: none;
-              }
-            }
-          }
-        `}
-      />
-
-      <button
-        popoverTarget="demo-info-panel"
-        popoverTargetAction="toggle"
-        className="trigger"
-        aria-expanded={open}
-        aria-controls="demo-info-panel"
-        aria-haspopup="dialog"
-        aria-label={open ? "Hide demo info" : "Show demo info"}
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        /* 12px of clearance, the same margin the bar itself keeps — the panel
+           is as wide as the viewport allows on a phone, so without it Radix
+           would park it flush against the edge. */
+        collisionPadding={12}
+        /* Radix measures the room left under the trigger and publishes it as
+           `--radix-popover-content-available-height`, which is what the old
+           `max-height: min(100dvh - 4.5rem, 34rem)` was approximating by
+           hand. */
+        className="max-h-(--radix-popover-content-available-height) w-[min(24rem,calc(100dvw-1.5rem))] overflow-y-auto overscroll-contain"
       >
-        <RxInfoCircled />
-        <span>info</span>
-      </button>
-
-      <div
-        popover="auto"
-        ref={popoverRef}
-        id="demo-info-panel"
-        className="panel"
-        role="dialog"
-        aria-labelledby="demo-info-title"
-      >
-        <header>
-          <h2 id="demo-info-title">{demo.title}</h2>
-          <button
-            className="close"
-            onClick={() => popoverRef.current?.hidePopover()}
-            aria-label="Dismiss demo info"
-          >
-            <RxCross2 />
-          </button>
-        </header>
-
-        {demo.description && <p className="description">{demo.description}</p>}
+        <PopoverHeader>
+          <PopoverTitle>{demo.title}</PopoverTitle>
+          {demo.description && (
+            <PopoverDescription>{demo.description}</PopoverDescription>
+          )}
+        </PopoverHeader>
 
         {demo.authors.length > 0 && (
-          <section>
-            <h3>{demo.authors.length > 1 ? "Authors" : "Author"}</h3>
-            <p className="text">{demo.authors.join(", ")}</p>
-          </section>
+          <Section title={demo.authors.length > 1 ? "Authors" : "Author"}>
+            <p>{demo.authors.join(", ")}</p>
+          </Section>
         )}
 
         {demo.publishedAt && (
-          <section>
-            <h3>Published</h3>
-            <p className="text">{formatDate(demo.publishedAt)}</p>
-          </section>
+          <Section title="Published">
+            <p>{formatDate(demo.publishedAt)}</p>
+          </Section>
         )}
 
         {demo.tags.length > 0 && (
-          <section>
-            <h3>Tags</h3>
-            <ul className="pills">
+          <Section title="Tags">
+            <ul className="flex flex-wrap gap-1">
               {demo.tags.map((tag) => (
-                <li key={tag}>{tag}</li>
+                <Badge key={tag} variant="secondary" asChild>
+                  <li>{tag}</li>
+                </Badge>
               ))}
             </ul>
-          </section>
+          </Section>
         )}
 
         {libraryLabels.length > 0 && (
-          <section>
-            <h3>Libraries</h3>
-            <ul className="pills">
+          <Section title="Libraries">
+            <ul className="flex flex-wrap gap-1">
               {libraryLabels.map((library) => (
-                <li key={library}>{library}</li>
+                <Badge key={library} variant="secondary" asChild>
+                  <li>{library}</li>
+                </Badge>
               ))}
             </ul>
-          </section>
+          </Section>
         )}
 
         {demo.assets.length > 0 && (
-          <section>
-            <h3>Assets</h3>
-            <ul className="assets">
+          <Section title="Assets">
+            <ul className="flex flex-col gap-2.5 text-xs">
               {demo.assets.map((asset) => (
                 <li key={asset.name}>
                   {asset.source ? (
@@ -368,10 +145,13 @@ export function Info({ demo }: { demo: Demo }) {
                     asset.name
                   )}
                   {asset.creator && (
-                    <span className="meta"> by {asset.creator}</span>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      by {asset.creator}
+                    </span>
                   )}
                   {asset.license && (
-                    <span className="meta">
+                    <span className="text-muted-foreground">
                       {" — "}
                       {asset.licenseUrl ? (
                         <a
@@ -386,14 +166,20 @@ export function Info({ demo }: { demo: Demo }) {
                       )}
                     </span>
                   )}
-                  {asset.modified && <span className="meta"> (modified)</span>}
-                  {asset.notes && <span className="notes">{asset.notes}</span>}
+                  {asset.modified && (
+                    <span className="text-muted-foreground"> (modified)</span>
+                  )}
+                  {asset.notes && (
+                    <span className="block text-muted-foreground">
+                      {asset.notes}
+                    </span>
+                  )}
                 </li>
               ))}
             </ul>
-          </section>
+          </Section>
         )}
-      </div>
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/website/app/demos/[demoname]/Social.tsx
+++ b/apps/website/app/demos/[demoname]/Social.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { Style } from "@/components/Style";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode } from "react";
 import { toast } from "sonner";
 import { GoCommandPalette } from "react-icons/go";
-import { RxChevronDown, RxOpenInNewWindow } from "react-icons/rx";
+import { RxOpenInNewWindow } from "react-icons/rx";
 import { SiCodesandbox, SiGithub, SiStackblitz } from "react-icons/si";
+
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function Social({
   demoname,
@@ -14,9 +21,6 @@ export function Social({
   demoname: string;
   embed_url: string;
 }) {
-  const [moreOpen, setMoreOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
   const command = `npx -y degit pmndrs/examples/demos/${demoname} ${demoname} && cd ${demoname} && npm i && npm run dev`;
 
   const handleClick = async () => {
@@ -38,18 +42,8 @@ export function Social({
     });
   };
 
-  useEffect(() => {
-    const menu = menuRef.current;
-    if (!menu) return;
-
-    const onToggle = (event: ToggleEvent) => {
-      setMoreOpen(event.newState === "open");
-    };
-
-    menu.addEventListener("toggle", onToggle);
-    return () => menu.removeEventListener("toggle", onToggle);
-  }, []);
-
+  /* `degit` is the odd one out: it copies rather than navigates, so it is the
+     entry with no `href` and the only real `<button>` in the group. */
   const actions: { label: string; icon: ReactNode; href?: string }[] = [
     { label: "fullpage", icon: <RxOpenInNewWindow />, href: embed_url },
     {
@@ -71,231 +65,54 @@ export function Social({
   ];
 
   return (
-    <>
-      <nav className="Social">
-        <Style
-          css={`
-            @scope {
-              & {
-                display: flex;
-                gap: 0.1rem;
-                padding: 0.3rem;
-                border-radius: 999px;
-                background: rgb(255 255 255 / 0.82);
-                backdrop-filter: blur(10px);
-                box-shadow: 0 1px 6px rgb(0 0 0 / 0.1);
-              }
+    /* `ButtonGroup` is a div, so the landmark has to come from somewhere: four
+       of the five entries leave the page. */
+    <nav aria-label="Demo links">
+      {/* The group draws no box of its own — the buttons, sitting flush, are
+          the pill. It only needs the matching radius so the shadow traces that
+          pill rather than the rectangle around it.
 
-              :scope > a,
-              .more {
-                position: relative;
-                display: grid;
-                place-items: center;
-                width: 1.8rem;
-                height: 1.8rem;
-                border-radius: 50%;
-                color: #555;
-                transition:
-                  background 0.15s ease,
-                  color 0.15s ease;
-              }
-
-              .more {
-                display: none;
-                padding: 0;
-                border: 0;
-                background: none;
-                cursor: pointer;
-              }
-
-              :scope > a:hover,
-              .more:hover,
-              .more[aria-expanded="true"] {
-                background: rgb(0 0 0 / 0.06);
-                color: #111;
-              }
-
-              :scope > a svg,
-              .more svg {
-                width: 0.95rem;
-                height: 0.95rem;
-              }
-
-              .more svg {
-                transition: rotate 0.2s ease;
-              }
-
-              .more[aria-expanded="true"] svg {
-                rotate: 180deg;
-              }
-
-              :scope > a > span {
-                position: absolute;
-                top: 100%;
-                left: 50%;
-                translate: -50% 0;
-                margin-top: 0.45rem;
-                padding: 0.25em 0.5em;
-                border-radius: 4px;
-                background: #222;
-                color: white;
-                font-size: 0.65rem;
-                white-space: nowrap;
-                pointer-events: none;
-                opacity: 0;
-                transition: opacity 0.15s ease;
-              }
-
-              :scope > a:hover > span {
-                opacity: 1;
-              }
-
-              .menu {
-                position: fixed;
-                inset: 3.75rem max(0.75rem, env(safe-area-inset-right)) auto
-                  auto;
-                margin: 0;
-                padding: 0.4rem;
-                border: 1px solid #d4d4d4;
-                border-radius: 12px;
-                background: rgb(255 255 255 / 0.92);
-                backdrop-filter: blur(10px);
-                box-shadow: 0 10px 30px rgb(0 0 0 / 0.12);
-                animation: social-menu-in 0.2s ease both;
-              }
-
-              .menu:popover-open {
-                display: grid;
-                gap: 0.1rem;
-              }
-
-              @keyframes social-menu-in {
-                from {
-                  opacity: 0;
-                  translate: 0 -0.35rem;
-                }
-                to {
-                  opacity: 1;
-                  translate: 0 0;
-                }
-              }
-
-              .item {
-                display: flex;
-                align-items: center;
-                gap: 0.6rem;
-                padding: 0.5rem 1rem 0.5rem 0.7rem;
-                border: 0;
-                border-radius: 8px;
-                background: none;
-                color: #333;
-                cursor: pointer;
-                font: inherit;
-                font-size: 0.75rem;
-                font-weight: 600;
-                text-align: left;
-                transition:
-                  background 0.15s ease,
-                  color 0.15s ease;
-              }
-
-              .item:hover {
-                background: rgb(0 0 0 / 0.06);
-                color: #111;
-              }
-
-              .item svg {
-                width: 0.95rem;
-                height: 0.95rem;
-                flex-shrink: 0;
-                color: #555;
-              }
-
-              @media (max-width: 40rem) {
-                :scope > a {
-                  display: none;
-                }
-
-                .more {
-                  display: grid;
-                }
-              }
-
-              @media (prefers-reduced-motion: reduce) {
-                .menu {
-                  animation: none;
-                }
-              }
-            }
-          `}
-        />
-
-        {actions.map(({ label, icon, href }) =>
-          href ? (
-            <a
-              key={label}
-              target="_blank"
-              rel="noopener noreferrer"
-              href={href}
-            >
-              {icon}
-              <span>{label}</span>
-            </a>
-          ) : (
-            <a key={label} href="javascript:void(0);" onClick={handleClick}>
-              {icon}
-              <span>{label}</span>
-            </a>
-          ),
-        )}
-
-        <button
-          popoverTarget="social-more-menu"
-          popoverTargetAction="toggle"
-          className="more"
-          aria-expanded={moreOpen}
-          aria-controls="social-more-menu"
-          aria-label={moreOpen ? "Hide demo links" : "Show demo links"}
-        >
-          <RxChevronDown />
-        </button>
-
-        <div
-          popover="auto"
-          ref={menuRef}
-          id="social-more-menu"
-          className="menu"
-        >
-          {actions.map(({ label, icon, href }) =>
-            href ? (
-              <a
-                key={label}
-                className="item"
-                target="_blank"
-                rel="noopener noreferrer"
-                href={href}
-                onClick={() => menuRef.current?.hidePopover()}
-              >
-                {icon}
-                {label}
-              </a>
-            ) : (
-              <button
-                key={label}
-                className="item"
-                type="button"
-                onClick={() => {
-                  menuRef.current?.hidePopover();
-                  handleClick();
-                }}
-              >
-                {icon}
-                {label}
-              </button>
-            ),
-          )}
-        </div>
-      </nav>
-    </>
+          No divider between the buttons, and that takes saying so: the group
+          drops each button's *left* border, but every button keeps a 1px
+          transparent one on its right and paints `bg-clip-padding`, so the
+          page shows through the join as a hairline. Dropping the right border
+          too on everything but the last button closes it — the outer edge is
+          left alone, where the same 1px is what keeps the shadow off the
+          background colour. */}
+      <ButtonGroup className="rounded-4xl shadow-lg [&>*:not(:last-child)]:border-r-0">
+        {actions.map(({ label, icon, href }) => (
+          <Tooltip key={label}>
+            <TooltipTrigger asChild>
+              {href ? (
+                <Button asChild variant="secondary" size="icon">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={href}
+                    aria-label={label}
+                    /* Prose links are underlined site-wide from `@layer base`;
+                       an icon-only button is not prose. */
+                    className="no-underline"
+                  >
+                    {icon}
+                  </a>
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="icon"
+                  onClick={handleClick}
+                  aria-label={label}
+                >
+                  {icon}
+                </Button>
+              )}
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </ButtonGroup>
+    </nav>
   );
 }

--- a/apps/website/app/demos/[demoname]/page.tsx
+++ b/apps/website/app/demos/[demoname]/page.tsx
@@ -79,8 +79,18 @@ export default async function Page(props: Props) {
         css={`
           @scope {
             .Dev {
+              /* Never takes effect: 'Dev' sets its own 'min(100%, 46rem)' from
+                 a scope rooted on the element itself, and in '@scope' the
+                 nearer root wins whatever the specificity. Kept as the
+                 fallback for a 'Dev' that stops sizing itself. */
               width: 100%;
               height: 100%;
+              /* ...which is why this is needed: an explicitly sized item
+                 stretches to nothing and is parked at the start of the track,
+                 so past 46rem of room the panel sat against the left edge.
+                 'main' centres its own only grid item, and that one is the
+                 route layout's div, which fills. */
+              justify-self: center;
               display: grid;
               place-items: center;
               padding: 1rem;

--- a/apps/website/app/demos/[demoname]/page.tsx
+++ b/apps/website/app/demos/[demoname]/page.tsx
@@ -4,6 +4,7 @@ import { ScaledDemoFrame } from "@/components/ScaledDemoFrame";
 import { getDemos } from "@/lib/helper";
 import { Dev } from "./Dev";
 import { Style } from "@/components/Style";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 import { Social } from "./Social";
 import { Info } from "./Info";
@@ -90,15 +91,6 @@ export default async function Page(props: Props) {
               min-width: 0;
               min-height: 0;
             }
-            .TopBar {
-              position: fixed;
-              top: 0.75rem;
-              right: 0.75rem;
-              z-index: 3;
-              display: flex;
-              align-items: flex-start;
-              gap: 0.5rem;
-            }
           }
         `}
       />
@@ -111,10 +103,15 @@ export default async function Page(props: Props) {
             <ScaledDemoFrame src={embed_url} title={demo.title} />
           </div>
 
-          <div className="TopBar">
-            <Info key={demoname} demo={demo} />
-            <Social demoname={demoname} embed_url={embed_url} />
-          </div>
+          {/* Both pills label themselves through `Tooltip`, which needs a
+              provider above it. The one the sidebar brings is scoped to the
+              nav, and this bar is nowhere near it. */}
+          <TooltipProvider>
+            <div className="fixed top-3 right-3 z-3 flex items-start gap-2">
+              <Info key={demoname} demo={demo} />
+              <Social demoname={demoname} embed_url={embed_url} />
+            </div>
+          </TooltipProvider>
         </>
       )}
     </>

--- a/apps/website/components/ui/popover.tsx
+++ b/apps/website/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-4 rounded-2xl bg-popover p-4 text-sm text-popover-foreground shadow-2xl ring-1 ring-foreground/5 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("text-base font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+};


### PR DESCRIPTION
Stacked on #144.

The demo page's two floating pills — the info disc and the row of links out to the demo — were the last hand-rolled chrome on that page: ~190 lines of `@scope` CSS across `Info` and `Social` drawing the pill boxes, the round buttons, the hover labels and the panels they open. Both are now a shadcn **`ButtonGroup`**, added with `pnpm dlx shadcn@latest add popover` for the one component this needed that wasn't already vendored.

### Two groups, no `<Style>` left in either component

**`Social`** is one horizontal `ButtonGroup` of five `Button size="icon" variant="secondary"` — four `asChild` anchors and, for `degit`, the one real `<button>`. The group draws no box of its own: the buttons sit flush and *are* the pill. It only carries `rounded-4xl shadow-lg`, so the shadow traces that pill instead of the rectangle around it.

**`Info`** is a `ButtonGroup` of one. A single child is both first and last, so it keeps `Button`'s own `rounded-4xl` on all four corners — 26px against a 36px box, which a browser clamps to a disc. It is a group of one on purpose: a second control can land beside it later without the pill having to be rebuilt.

### No divider between the buttons, and that takes saying so

`ButtonGroup` drops each button's *left* border, but every `Button` keeps a 1px **transparent** one on its right and paints `bg-clip-padding` — so the page shows through each join as a hairline, and five buttons read as five buttons. `[&>*:not(:last-child)]:border-r-0` closes them into one continuous surface. The outer edge keeps its 1px, where it is what holds the shadow off the background colour.

No `ButtonGroupSeparator` either, though the docs suggest one for non-`outline` variants: the icons are distinct enough, and the bar is meant to read as a single object.

### The hover labels are a `Tooltip`

`Social` painted them by hand — an absolutely positioned `> span` per link, faded in on `:hover`. They are `Tooltip`s now, which also means they answer to focus, so the labels are reachable from the keyboard for the first time. The provider goes on the top bar in `page.tsx`: the only other one on the site comes with `SidebarProvider` and is scoped to the nav.

### `Info`'s panel is a `Popover`

It was a native `popover="auto"` div pinned to the viewport with `inset: 3.75rem max(0.75rem, env(safe-area-inset-right)) auto auto` and a second copy of those insets behind a `(max-width: 40rem), (max-height: 32rem)` query. Radix positions it against the trigger instead, so all of that goes:

- the hand-computed `max-height: min(100dvh - 4.5rem, 34rem)` → `--radix-popover-content-available-height`, which is the measured room under the trigger
- the mobile insets → `collisionPadding={12}`, the same 12px the bar itself keeps off the edge
- the `info-in` keyframes and the `prefers-reduced-motion` opt-out → the component's own `data-open:animate-in`

Inside, the header is `PopoverHeader` / `PopoverTitle` / `PopoverDescription` and the five repeated `<h3>` + content blocks became a local `Section`. No `Card` around any of it: `PopoverContent` already *is* the surface, and a card inside it would be a second one.

The `.pills` are `Badge variant="secondary"`, for both **Tags** and **Libraries** — `asChild`, so each one still renders the `<li>` it replaces.

**Assets** are `Item`s. It is the one part of the panel that lists *things* rather than values: a name, someone it is by, terms it comes under. `ItemGroup` carries the `role="list"` the `<ul>` had, `ItemTitle` takes the name and `ItemDescription` the attribution, and `modified` becomes a `Badge variant="outline"` on the title instead of a trailing `(modified)`. `variant="muted"` rather than `outline`, again because the panel is already a surface. The notes line drops the stock two-line clamp — it is measured for a row in a list, not for a panel someone opened in order to read it.

The trigger is `variant="secondary"`, which reads the same open or shut, so it takes `aria-expanded:bg-primary` at the call site — the panel is anchored to that button and it should look pressed while the panel is up.

### Behaviour that changes

- **The panel is anchored to the info button**, not to the viewport's top-right corner. It lands under the button that opened it, and collision handling replaces the two hand-written placements.
- **Its close `×` is gone.** Radix light-dismisses on outside click and on Escape, and the trigger toggles — the button was a third way to do what two already did.
- **`Social` no longer collapses below `40rem`.** The chevron and its popover menu existed because five hand-sized buttons had no responsive story; at `size="icon"` the row is 180px, and the whole bar clears 236px from the right edge — it fits a 320px phone with room to spare. That removes the `moreOpen` state, the `toggle` listener and the duplicate list of links.
- **`Info` is a server component again** — nothing in it holds state any more.

### Also

`ButtonGroup` renders a `div`, so `Social` keeps a `<nav aria-label="Demo links">` around it — four of the five entries leave the page. `.TopBar` was the last rule in `page.tsx`'s `@scope` block that styled something on this page rather than a child component, so it moves to the div as utilities. `AGENTS.md` now lists only `Dev` and `ScaledDemoFrame` as the `@scope` holdouts.

### One thing fixed in passing

**The `Dev` panel is centred again.** `main` centres its only grid item, but that item is the route layout's div, which fills — and inside it `Dev` is explicitly sized (`min(100%, 46rem)`, from a scope rooted on the element itself, which beats `page.tsx`'s `width: 100%` on `@scope` proximity whatever the specificity). An explicitly sized stretch item is parked at the start of the track. Under 46rem of room `min()` returned `100%` and it looked centred; past that it sat against the left edge. `justify-self: center` on the same `.Dev` rule this PR already touches.

Not a regression from this stack — `main` renders it identically; the threshold is just easy to cross on a wide window.

### Checks

`tsc --noEmit`, `next lint` and `next build` (163 pages, static export) are clean. Checked in the browser at 1280px, 900px and 375px, in both schemes: the seamless pill, the tooltips, the panel opening, Escape and outside-click, and the pressed trigger. The `degit` toast could not be exercised — the automated browser denies clipboard writes — but `handleClick` is unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
