### PR TITLE
Fix router-transitions

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -59,7 +59,7 @@
       "dependencies": [
         "@react-three/drei"
       ],
-      "pinVersion": "10.7.7"
+      "pinVersion": "10.7.8"
     },
     {
       "label": "Update lamina to 1.2.2 for all examples.",

--- a/examples/aquarium/package.json
+++ b/examples/aquarium/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/arkanoid/package.json
+++ b/examples/arkanoid/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@react-spring/three": "^10.1.2",
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/audio-analyser/package.json
+++ b/examples/audio-analyser/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/backdrop-and-cables/package.json
+++ b/examples/backdrop-and-cables/package.json
@@ -2,7 +2,7 @@
   "name": "@example/backdrop-and-cables",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/baking-soft-shadows/package.json
+++ b/examples/baking-soft-shadows/package.json
@@ -2,7 +2,7 @@
   "name": "@example/baking-soft-shadows",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -2,7 +2,7 @@
   "name": "@example/basic-example",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/bestservedbold-christmas-baubles/package.json
+++ b/examples/bestservedbold-christmas-baubles/package.json
@@ -2,7 +2,7 @@
   "name": "@example/bestservedbold-christmas-baubles",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@react-three/rapier": "^2.2.0",

--- a/examples/bezier-curves-and-nodes/package.json
+++ b/examples/bezier-curves-and-nodes/package.json
@@ -2,7 +2,7 @@
   "name": "@example/bezier-curves-and-nodes",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@use-gesture/react": "^10.3.1",
     "react": "19.2.8",

--- a/examples/bloom-hdr-workflow-gltf/package.json
+++ b/examples/bloom-hdr-workflow-gltf/package.json
@@ -2,7 +2,7 @@
   "name": "@example/bloom-hdr-workflow-gltf",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/bouncy-watch/package.json
+++ b/examples/bouncy-watch/package.json
@@ -2,7 +2,7 @@
   "name": "@example/bouncy-watch",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/bounds-and-makedefault/package.json
+++ b/examples/bounds-and-makedefault/package.json
@@ -2,7 +2,7 @@
   "name": "@example/bounds-and-makedefault",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/bruno-simons-20k-challenge/package.json
+++ b/examples/bruno-simons-20k-challenge/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/csg": "^4.0.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@react-three/rapier": "^2.2.0",

--- a/examples/building-dynamic-envmaps/package.json
+++ b/examples/building-dynamic-envmaps/package.json
@@ -2,7 +2,7 @@
   "name": "@example/building-dynamic-envmaps",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/building-live-envmaps/package.json
+++ b/examples/building-live-envmaps/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "lamina": "1.2.2",
     "react": "19.2.8",

--- a/examples/bvh/package.json
+++ b/examples/bvh/package.json
@@ -2,7 +2,7 @@
   "name": "@example/bvh",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "r3f-perf": "^7.2.3",

--- a/examples/camera-scroll/package.json
+++ b/examples/camera-scroll/package.json
@@ -2,7 +2,7 @@
   "name": "@example/camera-scroll",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/camera-shake/package.json
+++ b/examples/camera-shake/package.json
@@ -2,7 +2,7 @@
   "name": "@example/camera-shake",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/cards-with-border-radius/package.json
+++ b/examples/cards-with-border-radius/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/cards/package.json
+++ b/examples/cards/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "random-words": "^2.0.1",
     "react": "19.2.8",

--- a/examples/caustics/package.json
+++ b/examples/caustics/package.json
@@ -2,7 +2,7 @@
   "name": "@example/caustics",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/cell-fracture/package.json
+++ b/examples/cell-fracture/package.json
@@ -2,7 +2,7 @@
   "name": "@example/cell-fracture",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/clones/package.json
+++ b/examples/clones/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/clouds/package.json
+++ b/examples/clouds/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/color-grading/package.json
+++ b/examples/color-grading/package.json
@@ -2,7 +2,7 @@
   "name": "@example/color-grading",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/csg-bunny-usegroups/package.json
+++ b/examples/csg-bunny-usegroups/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/csg": "^4.0.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/csg-house/package.json
+++ b/examples/csg-house/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/csg": "^4.0.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/csg-operations-rapier-physics/package.json
+++ b/examples/csg-operations-rapier-physics/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/csg": "^4.0.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "lamina": "1.2.2",

--- a/examples/dbismut-furniture/package.json
+++ b/examples/dbismut-furniture/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-spring/three": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/diamond-refraction/package.json
+++ b/examples/diamond-refraction/package.json
@@ -2,7 +2,7 @@
   "name": "@example/diamond-refraction",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/diamond-ring/package.json
+++ b/examples/diamond-ring/package.json
@@ -2,7 +2,7 @@
   "name": "@example/diamond-ring",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/drei-rendertexture/package.json
+++ b/examples/drei-rendertexture/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/ecctrl-fisheye/package.json
+++ b/examples/ecctrl-fisheye/package.json
@@ -2,7 +2,7 @@
   "name": "@example/ecctrl-fisheye",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "ecctrl": "1.0.88",

--- a/examples/edgesgeometry/package.json
+++ b/examples/edgesgeometry/package.json
@@ -2,7 +2,7 @@
   "name": "@example/edgesgeometry",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/enter-portals/package.json
+++ b/examples/enter-portals/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/environment-blur-and-transitions/package.json
+++ b/examples/environment-blur-and-transitions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/envmap-ground-projection/package.json
+++ b/examples/envmap-ground-projection/package.json
@@ -2,7 +2,7 @@
   "name": "@example/envmap-ground-projection",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "r3f-perf": "^7.2.3",

--- a/examples/faucets-select-highlight/package.json
+++ b/examples/faucets-select-highlight/package.json
@@ -2,7 +2,7 @@
   "name": "@example/faucets-select-highlight",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/flexbox-yoga-in-webgl/package.json
+++ b/examples/flexbox-yoga-in-webgl/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/flex": "^1.0.1",
     "@react-three/postprocessing": "^3.0.4",

--- a/examples/floating-diamonds/package.json
+++ b/examples/floating-diamonds/package.json
@@ -2,7 +2,7 @@
   "name": "@example/floating-diamonds",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/floating-instanced-shoes/package.json
+++ b/examples/floating-instanced-shoes/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/floating-laptop/package.json
+++ b/examples/floating-laptop/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@react-spring/three": "^10.1.2",
     "@react-spring/web": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/flow-shield/package.json
+++ b/examples/flow-shield/package.json
@@ -2,7 +2,7 @@
   "name": "@example/flow-shield",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/flying-bananas/package.json
+++ b/examples/flying-bananas/package.json
@@ -2,7 +2,7 @@
   "name": "@example/flying-bananas",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/frosted-glass/package.json
+++ b/examples/frosted-glass/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "framer-motion": "^10.18.0",
     "react": "19.2.8",

--- a/examples/gatsby-stars/package.json
+++ b/examples/gatsby-stars/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "maath": "^0.10.8",
     "react": "19.2.8",

--- a/examples/glass-flower/package.json
+++ b/examples/glass-flower/package.json
@@ -2,7 +2,7 @@
   "name": "@example/glass-flower",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/gltf-animations-re-used/package.json
+++ b/examples/gltf-animations-re-used/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-spring/three": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/gltf-animations-tied-to-scroll/package.json
+++ b/examples/gltf-animations-tied-to-scroll/package.json
@@ -2,7 +2,7 @@
   "name": "@example/gltf-animations-tied-to-scroll",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/gltf-animations/package.json
+++ b/examples/gltf-animations/package.json
@@ -2,7 +2,7 @@
   "name": "@example/gltf-animations",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/gltfjsx-400kb-drone/package.json
+++ b/examples/gltfjsx-400kb-drone/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "maath": "^0.10.8",

--- a/examples/gpgpu-curl-noise-dof/package.json
+++ b/examples/gpgpu-curl-noise-dof/package.json
@@ -2,7 +2,7 @@
   "name": "@example/gpgpu-curl-noise-dof",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/grass-shader/package.json
+++ b/examples/grass-shader/package.json
@@ -2,7 +2,7 @@
   "name": "@example/grass-shader",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/ground-projected-envmaps-lamina/package.json
+++ b/examples/ground-projected-envmaps-lamina/package.json
@@ -2,7 +2,7 @@
   "name": "@example/ground-projected-envmaps-lamina",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "lamina": "1.2.2",
     "react": "19.2.8",

--- a/examples/ground-reflections-and-video-textures/package.json
+++ b/examples/ground-reflections-and-video-textures/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/hi-key-bubbles/package.json
+++ b/examples/hi-key-bubbles/package.json
@@ -2,7 +2,7 @@
   "name": "@example/hi-key-bubbles",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/horizontal-tiles/package.json
+++ b/examples/horizontal-tiles/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/html-annotations/package.json
+++ b/examples/html-annotations/package.json
@@ -2,7 +2,7 @@
   "name": "@example/html-annotations",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/html-input-fields/package.json
+++ b/examples/html-input-fields/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/html-markers/package.json
+++ b/examples/html-markers/package.json
@@ -15,7 +15,7 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/image-gallery/package.json
+++ b/examples/image-gallery/package.json
@@ -2,7 +2,7 @@
   "name": "@example/image-gallery",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "maath": "^0.10.8",
     "react": "19.2.8",

--- a/examples/infinite-scroll/package.json
+++ b/examples/infinite-scroll/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/instanced-particles-effects/package.json
+++ b/examples/instanced-particles-effects/package.json
@@ -2,7 +2,7 @@
   "name": "@example/instanced-particles-effects",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/instances/package.json
+++ b/examples/instances/package.json
@@ -2,7 +2,7 @@
   "name": "@example/instances",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "nice-color-palettes": "^3.0.0",
     "react": "19.2.8",

--- a/examples/inter-epoxy-resin/package.json
+++ b/examples/inter-epoxy-resin/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/interactive-spline-scene-live-html/package.json
+++ b/examples/interactive-spline-scene-live-html/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.2.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@splinetool/loader": "0.9.153",
     "@splinetool/r3f-spline": "^1.0.2",

--- a/examples/inverted-stencil-buffer/package.json
+++ b/examples/inverted-stencil-buffer/package.json
@@ -2,7 +2,7 @@
   "name": "@example/inverted-stencil-buffer",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/iridescent-decals/package.json
+++ b/examples/iridescent-decals/package.json
@@ -2,7 +2,7 @@
   "name": "@example/iridescent-decals",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/lamina-1x/package.json
+++ b/examples/lamina-1x/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "lamina": "1.2.2",
     "react": "19.2.8",

--- a/examples/landing-page/package.json
+++ b/examples/landing-page/package.json
@@ -2,7 +2,7 @@
   "name": "@example/landing-page",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/learn-with-jason/package.json
+++ b/examples/learn-with-jason/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/lulaby-city/package.json
+++ b/examples/lulaby-city/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/lusion-connectors/package.json
+++ b/examples/lusion-connectors/package.json
@@ -2,7 +2,7 @@
   "name": "@example/lusion-connectors",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@react-three/rapier": "^2.2.0",

--- a/examples/magic-box/package.json
+++ b/examples/magic-box/package.json
@@ -2,7 +2,7 @@
   "name": "@example/magic-box",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/merged-instance/package.json
+++ b/examples/merged-instance/package.json
@@ -2,7 +2,7 @@
   "name": "@example/merged-instance",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/minecraft/package.json
+++ b/examples/minecraft/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "react": "19.2.8",

--- a/examples/mixing-controls/package.json
+++ b/examples/mixing-controls/package.json
@@ -2,7 +2,7 @@
   "name": "@example/mixing-controls",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/mixing-html-and-webgl-w-occlusion/package.json
+++ b/examples/mixing-html-and-webgl-w-occlusion/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.2.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/mixing-html-and-webgl/package.json
+++ b/examples/mixing-html-and-webgl/package.json
@@ -2,7 +2,7 @@
   "name": "@example/mixing-html-and-webgl",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "antd": "^5.20.1",
     "react": "19.2.8",

--- a/examples/moksha/package.json
+++ b/examples/moksha/package.json
@@ -2,7 +2,7 @@
   "name": "@example/moksha",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "lerp": "^1.0.3",
     "react": "19.2.8",

--- a/examples/monitors/package.json
+++ b/examples/monitors/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "maath": "^0.10.8",

--- a/examples/motionpathcontrols/package.json
+++ b/examples/motionpathcontrols/package.json
@@ -2,7 +2,7 @@
   "name": "@example/motionpathcontrols",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/mount-transitions/package.json
+++ b/examples/mount-transitions/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-spring/three": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/multiple-views-with-uniform-controls/package.json
+++ b/examples/multiple-views-with-uniform-controls/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@mantine/core": "^5.10.5",
     "@mantine/hooks": "^5.10.1",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@tabler/icons-react": "^3.36.0",
     "react": "19.2.8",

--- a/examples/nextjs-prism/package.json
+++ b/examples/nextjs-prism/package.json
@@ -2,7 +2,7 @@
   "name": "@example/nextjs-prism",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/night-train/package.json
+++ b/examples/night-train/package.json
@@ -2,7 +2,7 @@
   "name": "@example/night-train",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/object-clump/package.json
+++ b/examples/object-clump/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/pairing-threejs-to-ui/package.json
+++ b/examples/pairing-threejs-to-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@example/pairing-threejs-to-ui",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/pass-through-portals/package.json
+++ b/examples/pass-through-portals/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/physics-with-convex-polyhedrons/package.json
+++ b/examples/physics-with-convex-polyhedrons/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/pinball-in-70-lines/package.json
+++ b/examples/pinball-in-70-lines/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/pmndrs-vercel/package.json
+++ b/examples/pmndrs-vercel/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "lamina": "1.2.2",
     "react": "19.2.8",

--- a/examples/portal-shapes/package.json
+++ b/examples/portal-shapes/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "react": "19.2.8",

--- a/examples/portals/package.json
+++ b/examples/portals/package.json
@@ -2,7 +2,7 @@
   "name": "@example/portals",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/progressive-loading-states-with-suspense/package.json
+++ b/examples/progressive-loading-states-with-suspense/package.json
@@ -2,7 +2,7 @@
   "name": "@example/progressive-loading-states-with-suspense",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/racing-game/package.json
+++ b/examples/racing-game/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "inter-ui": "^3.19.3",
     "leva": "^0.10.1",

--- a/examples/ragdoll-physics/package.json
+++ b/examples/ragdoll-physics/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/rapier-physics/package.json
+++ b/examples/rapier-physics/package.json
@@ -2,7 +2,7 @@
   "name": "@example/rapier-physics",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "leva": "^0.10.1",

--- a/examples/rapier-ping-pong/package.json
+++ b/examples/rapier-ping-pong/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@react-three/rapier": "^2.2.0",

--- a/examples/raycast-cycling/package.json
+++ b/examples/raycast-cycling/package.json
@@ -2,7 +2,7 @@
   "name": "@example/raycast-cycling",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/re-using-geometry-and-level-of-detail/package.json
+++ b/examples/re-using-geometry-and-level-of-detail/package.json
@@ -2,7 +2,7 @@
   "name": "@example/re-using-geometry-and-level-of-detail",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/re-using-gltfs/package.json
+++ b/examples/re-using-gltfs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/react-ellipsecurve/package.json
+++ b/examples/react-ellipsecurve/package.json
@@ -2,7 +2,7 @@
   "name": "@example/react-ellipsecurve",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/react-pp-outlines/package.json
+++ b/examples/react-pp-outlines/package.json
@@ -2,7 +2,7 @@
   "name": "@example/react-pp-outlines",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/react-spring-animations/package.json
+++ b/examples/react-spring-animations/package.json
@@ -5,7 +5,7 @@
     "@react-spring/core": "^10.1.2",
     "@react-spring/three": "^10.1.2",
     "@react-spring/web": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/room-with-soft-shadows/package.json
+++ b/examples/room-with-soft-shadows/package.json
@@ -2,7 +2,7 @@
   "name": "@example/room-with-soft-shadows",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "r3f-perf": "^7.2.3",

--- a/examples/router-transitions/index.html
+++ b/examples/router-transitions/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/index.jsx"></script>
+    <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/examples/router-transitions/package.json
+++ b/examples/router-transitions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/router-transitions/src/App.tsx
+++ b/examples/router-transitions/src/App.tsx
@@ -1,21 +1,27 @@
-import { Canvas, useFrame } from "@react-three/fiber"
+import { Canvas, useFrame, type ThreeElements } from "@react-three/fiber"
+import type { ComponentProps } from "react"
+import type { Mesh } from "three"
 import { useGLTF, Float, Lightformer, Text, Html, ContactShadows, Environment, MeshTransmissionMaterial } from "@react-three/drei"
 import { EffectComposer, N8AO, TiltShift2 } from "@react-three/postprocessing"
-import { Route, Link, useLocation } from "wouter"
+import { Router, Route, Link, useLocation } from "wouter"
 import { suspend } from "suspend-react"
 import { easing } from "maath"
 
 import bombModel from "./bomb-gp.glb?url"
 
-const inter = import("@pmndrs/assets/fonts/inter_regular.woff")
+const inter = import("@pmndrs/assets/fonts/inter_regular.woff") as Promise<{ default: string }>
 useGLTF.preload(bombModel)
 
+const base = import.meta.env.BASE_URL.replace(/\/$/, "")
+
 export const App = () => (
-  <>
-    <Canvas eventSource={document.getElementById("root")} eventPrefix="client" shadows camera={{ position: [0, 0, 20], fov: 50 }}>
+  <Router base={base}>
+    <Canvas eventSource={document.getElementById("root")!} eventPrefix="client" shadows camera={{ position: [0, 0, 20], fov: 50 }}>
       <color attach="background" args={["#e0e0e0"]} />
       <spotLight position={[20, 20, 10]} intensity={Math.PI} decay={0} penumbra={1} castShadow angle={0.2} />
+      
       <Status position={[0, 0, -10]} />
+
       <Float floatIntensity={2}>
         <Route path="/">
           <Knot />
@@ -27,22 +33,27 @@ export const App = () => (
           <Bomb scale={0.7} />
         </Route>
       </Float>
+
       <ContactShadows scale={100} position={[0, -7.5, 0]} blur={1} far={100} opacity={0.85} />
+      
       <Environment preset="city">
         <Lightformer intensity={8} position={[10, 5, 0]} scale={[10, 50, 1]} onUpdate={(self) => self.lookAt(0, 0, 0)} />
       </Environment>
-      <EffectComposer disableNormalPass>
+
+      <EffectComposer>
         <N8AO aoRadius={1} intensity={2} />
         <TiltShift2 blur={0.2} />
       </EffectComposer>
+
       <Rig />
     </Canvas>
-    <div class="nav">
+
+    <div className="nav">
       <Link to="/">knot</Link>
       <Link to="/torus">torus</Link>
       <Link to="/bomb">bomb</Link>
     </div>
-  </>
+  </Router>
 )
 
 function Rig() {
@@ -55,36 +66,39 @@ function Rig() {
     )
     state.camera.lookAt(0, 0, 0)
   })
+
+  return null
 }
 
-const Torus = (props) => (
+const Torus = (props: ThreeElements["mesh"]) => (
   <mesh receiveShadow castShadow {...props}>
     <torusGeometry args={[4, 1.2, 128, 64]} />
     <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} />
   </mesh>
 )
 
-const Knot = (props) => (
+const Knot = (props: ThreeElements["mesh"]) => (
   <mesh receiveShadow castShadow {...props}>
     <torusKnotGeometry args={[3, 1, 256, 32]} />
     <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} />
   </mesh>
 )
 
-function Bomb(props) {
+function Bomb(props: ThreeElements["mesh"]) {
   const { nodes } = useGLTF(bombModel)
   return (
-    <mesh receiveShadow castShadow geometry={nodes.Little_Boy_Little_Boy_Material_0.geometry} {...props}>
+    <mesh receiveShadow castShadow geometry={(nodes.Little_Boy_Little_Boy_Material_0 as Mesh).geometry} {...props}>
       <MeshTransmissionMaterial backside backsideThickness={10} thickness={5} />
     </mesh>
   )
 }
 
-function Status(props) {
+function Status(props: Omit<ComponentProps<typeof Text>, "font" | "children">) {
   const [loc] = useLocation()
   const text = loc === "/" ? "/knot" : loc
+  
   return (
-    <Text fontSize={14} letterSpacing={-0.025} font={suspend(inter).default} color="black" {...props}>
+    <Text fontSize={14} letterSpacing={-0.025} font={(suspend(inter) as { default: string }).default} color="black" {...props}>
       {text}
       <Html style={{ color: "transparent", fontSize: "33.5em" }} transform>
         {text}

--- a/examples/router-transitions/src/index.tsx
+++ b/examples/router-transitions/src/index.tsx
@@ -2,4 +2,4 @@ import { createRoot } from "react-dom/client"
 import "./styles.css"
 import { App } from "./App"
 
-createRoot(document.getElementById("root")).render(<App />)
+createRoot(document.getElementById("root")!).render(<App />)

--- a/examples/scrollcontrols-and-lens-refraction/package.json
+++ b/examples/scrollcontrols-and-lens-refraction/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "maath": "^0.10.8",
     "react": "19.2.8",

--- a/examples/scrollcontrols-gltf/package.json
+++ b/examples/scrollcontrols-gltf/package.json
@@ -2,7 +2,7 @@
   "name": "@example/scrollcontrols-gltf",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/scrollcontrols-with-minimap/package.json
+++ b/examples/scrollcontrols-with-minimap/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/selective-outlines/package.json
+++ b/examples/selective-outlines/package.json
@@ -2,7 +2,7 @@
   "name": "@example/selective-outlines",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/shader-fire/package.json
+++ b/examples/shader-fire/package.json
@@ -2,7 +2,7 @@
   "name": "@example/shader-fire",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/shader-hmr/package.json
+++ b/examples/shader-hmr/package.json
@@ -2,7 +2,7 @@
   "name": "@example/shader-hmr",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/shadermaterials/package.json
+++ b/examples/shadermaterials/package.json
@@ -2,7 +2,7 @@
   "name": "@example/shadermaterials",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/shoe-configurator/package.json
+++ b/examples/shoe-configurator/package.json
@@ -2,7 +2,7 @@
   "name": "@example/shoe-configurator",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-colorful": "^5.6.1",

--- a/examples/shopping/package.json
+++ b/examples/shopping/package.json
@@ -2,7 +2,7 @@
   "name": "@example/shopping",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/sky-dome-with-annotations/package.json
+++ b/examples/sky-dome-with-annotations/package.json
@@ -2,7 +2,7 @@
   "name": "@example/sky-dome-with-annotations",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "antd": "^5.20.1",
     "react": "19.2.8",

--- a/examples/soft-shadows/package.json
+++ b/examples/soft-shadows/package.json
@@ -2,7 +2,7 @@
   "name": "@example/soft-shadows",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "r3f-perf": "^7.2.3",

--- a/examples/space-game/package.json
+++ b/examples/space-game/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/fiber": "9.6.1",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "styled-components": "^6.1.1",

--- a/examples/spline-glass-shapes/package.json
+++ b/examples/spline-glass-shapes/package.json
@@ -2,7 +2,7 @@
   "name": "@example/spline-glass-shapes",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@splinetool/loader": "0.9.153",
     "@splinetool/r3f-spline": "^1.0.2",

--- a/examples/sport-hall/package.json
+++ b/examples/sport-hall/package.json
@@ -2,7 +2,7 @@
   "name": "@example/sport-hall",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/spotlight-shadows/package.json
+++ b/examples/spotlight-shadows/package.json
@@ -2,7 +2,7 @@
   "name": "@example/spotlight-shadows",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/ssgi-spheres-with-rapier-physics/package.json
+++ b/examples/ssgi-spheres-with-rapier-physics/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@babel/runtime": "^7.25.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "maath": "^0.10.8",

--- a/examples/ssr-test/package.json
+++ b/examples/ssr-test/package.json
@@ -2,7 +2,7 @@
   "name": "@example/ssr-test",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/stage-presets-gltfjsx/package.json
+++ b/examples/stage-presets-gltfjsx/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@babel/runtime": "^7.25.0",
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "postprocessing": "6.36.6",

--- a/examples/staging-and-camerashake/package.json
+++ b/examples/staging-and-camerashake/package.json
@@ -15,7 +15,7 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/starwars/package.json
+++ b/examples/starwars/package.json
@@ -2,7 +2,7 @@
   "name": "@example/starwars",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "leva": "^0.10.1",

--- a/examples/stencil-mask/package.json
+++ b/examples/stencil-mask/package.json
@@ -2,7 +2,7 @@
   "name": "@example/stencil-mask",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "leva": "^0.10.1",
     "react": "19.2.8",

--- a/examples/svg-maps-with-html-annotations/package.json
+++ b/examples/svg-maps-with-html-annotations/package.json
@@ -2,7 +2,7 @@
   "name": "@example/svg-maps-with-html-annotations",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/t-shirt-configurator/package.json
+++ b/examples/t-shirt-configurator/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "framer-motion": "^10.18.0",
     "maath": "^0.10.8",

--- a/examples/the-three-graces/package.json
+++ b/examples/the-three-graces/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "maath": "^0.10.8",
     "react": "19.2.8",

--- a/examples/threejs-journey-lv-1-fisheye/package.json
+++ b/examples/threejs-journey-lv-1-fisheye/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-spring/three": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/threejs-journey-portal/package.json
+++ b/examples/threejs-journey-portal/package.json
@@ -2,7 +2,7 @@
   "name": "@example/threejs-journey-portal",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/thunder-clouds/package.json
+++ b/examples/thunder-clouds/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/rapier": "^2.2.0",
     "maath": "^0.10.8",

--- a/examples/trails/package.json
+++ b/examples/trails/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "lamina": "1.2.2",
     "react": "19.2.8",

--- a/examples/transformcontrols-and-makedefault/package.json
+++ b/examples/transformcontrols-and-makedefault/package.json
@@ -2,7 +2,7 @@
   "name": "@example/transformcontrols-and-makedefault",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/transparent-aesop-bottles/package.json
+++ b/examples/transparent-aesop-bottles/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/trigger-meshes/package.json
+++ b/examples/trigger-meshes/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/tying-canvas-to-scroll-offset/package.json
+++ b/examples/tying-canvas-to-scroll-offset/package.json
@@ -2,7 +2,7 @@
   "name": "@example/tying-canvas-to-scroll-offset",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/useintersect-and-scrollcontrols/package.json
+++ b/examples/useintersect-and-scrollcontrols/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/video-cookies/package.json
+++ b/examples/video-cookies/package.json
@@ -2,7 +2,7 @@
   "name": "@example/video-cookies",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/video-textures/package.json
+++ b/examples/video-textures/package.json
@@ -2,7 +2,7 @@
   "name": "@example/video-textures",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/view-tracking/package.json
+++ b/examples/view-tracking/package.json
@@ -2,7 +2,7 @@
   "name": "@example/view-tracking",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@studio-freight/lenis": "^1.0.42",
     "react": "19.2.8",

--- a/examples/viewcube/package.json
+++ b/examples/viewcube/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/assets": "^1.6.0",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/viking-ship/package.json
+++ b/examples/viking-ship/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/volumetric-light-godray/package.json
+++ b/examples/volumetric-light-godray/package.json
@@ -2,7 +2,7 @@
   "name": "@example/volumetric-light-godray",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "react": "19.2.8",

--- a/examples/volumetric-spotlight/package.json
+++ b/examples/volumetric-spotlight/package.json
@@ -2,7 +2,7 @@
   "name": "@example/volumetric-spotlight",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/water-shader/package.json
+++ b/examples/water-shader/package.json
@@ -2,7 +2,7 @@
   "name": "@example/water-shader",
   "version": "1.0.0",
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/wireframes/package.json
+++ b/examples/wireframes/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@pmndrs/branding": "^0.0.8",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "gl-noise": "^1.6.1",
     "leva": "^0.10.1",

--- a/examples/wobbling-sphere/package.json
+++ b/examples/wobbling-sphere/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@react-spring/three": "^10.1.2",
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/examples/zustand-site/package.json
+++ b/examples/zustand-site/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "10.7.7",
+    "@react-three/drei": "10.7.8",
     "@react-three/fiber": "9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "meshline": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "turbo lint",
     "lint:metadata": "node bin/validate-pmndrs-metadata.mjs",
     "lint:versions": "syncpack lint",
-    "fix:versions": "syncpack fix-mismatches",
+    "fix:versions": "syncpack fix",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "test": "turbo test"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,8 +595,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -638,8 +638,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -718,8 +718,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -758,8 +758,8 @@ importers:
   examples/backdrop-and-cables:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -795,8 +795,8 @@ importers:
   examples/baking-soft-shadows:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -872,8 +872,8 @@ importers:
   examples/basic-example:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -909,8 +909,8 @@ importers:
   examples/bestservedbold-christmas-baubles:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -952,8 +952,8 @@ importers:
   examples/bezier-curves-and-nodes:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -992,8 +992,8 @@ importers:
   examples/bloom-hdr-workflow-gltf:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1029,8 +1029,8 @@ importers:
   examples/bouncy-watch:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1066,8 +1066,8 @@ importers:
   examples/bounds-and-makedefault:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1106,8 +1106,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1149,8 +1149,8 @@ importers:
   examples/building-dynamic-envmaps:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1195,8 +1195,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1235,8 +1235,8 @@ importers:
   examples/bvh:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1281,8 +1281,8 @@ importers:
   examples/camera-scroll:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1318,8 +1318,8 @@ importers:
   examples/camera-shake:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1395,8 +1395,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1441,8 +1441,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1478,8 +1478,8 @@ importers:
   examples/caustics:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1515,8 +1515,8 @@ importers:
   examples/cell-fracture:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1555,8 +1555,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1592,8 +1592,8 @@ importers:
   examples/clouds:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1632,8 +1632,8 @@ importers:
   examples/color-grading:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1718,8 +1718,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1758,8 +1758,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1798,8 +1798,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1847,8 +1847,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1884,8 +1884,8 @@ importers:
   examples/diamond-refraction:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1927,8 +1927,8 @@ importers:
   examples/diamond-ring:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -1973,8 +1973,8 @@ importers:
         specifier: ^1.6.0
         version: 1.7.0
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2013,8 +2013,8 @@ importers:
   examples/ecctrl-fisheye:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2023,7 +2023,7 @@ importers:
         version: 2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       ecctrl:
         specifier: 1.0.88
-        version: 1.0.88(@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        version: 1.0.88(@react-three/drei@10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2056,8 +2056,8 @@ importers:
   examples/edgesgeometry:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2099,8 +2099,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2145,8 +2145,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2185,8 +2185,8 @@ importers:
   examples/envmap-ground-projection:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2228,8 +2228,8 @@ importers:
   examples/faucets-select-highlight:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2268,8 +2268,8 @@ importers:
   examples/flexbox-yoga-in-webgl:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2314,8 +2314,8 @@ importers:
   examples/floating-diamonds:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2354,8 +2354,8 @@ importers:
   examples/floating-instanced-shoes:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2400,8 +2400,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2437,8 +2437,8 @@ importers:
   examples/flow-shield:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2483,8 +2483,8 @@ importers:
   examples/flying-bananas:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2529,8 +2529,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2575,8 +2575,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2615,8 +2615,8 @@ importers:
   examples/glass-flower:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2655,8 +2655,8 @@ importers:
   examples/gltf-animations:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2695,8 +2695,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2732,8 +2732,8 @@ importers:
   examples/gltf-animations-tied-to-scroll:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2775,8 +2775,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2818,8 +2818,8 @@ importers:
   examples/gpgpu-curl-noise-dof:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2858,8 +2858,8 @@ importers:
   examples/grass-shader:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2898,8 +2898,8 @@ importers:
   examples/ground-projected-envmaps-lamina:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2941,8 +2941,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -2978,8 +2978,8 @@ importers:
   examples/hi-key-bubbles:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3021,8 +3021,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3061,8 +3061,8 @@ importers:
   examples/html-annotations:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3101,8 +3101,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3138,8 +3138,8 @@ importers:
   examples/html-markers:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3178,8 +3178,8 @@ importers:
   examples/image-gallery:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3227,8 +3227,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3264,8 +3264,8 @@ importers:
   examples/instanced-particles-effects:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3341,8 +3341,8 @@ importers:
   examples/instances:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3384,8 +3384,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3433,8 +3433,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3476,8 +3476,8 @@ importers:
   examples/inverted-stencil-buffer:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3516,8 +3516,8 @@ importers:
   examples/iridescent-decals:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3556,8 +3556,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3596,8 +3596,8 @@ importers:
   examples/landing-page:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3636,8 +3636,8 @@ importers:
   examples/learn-with-jason:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3676,8 +3676,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3716,8 +3716,8 @@ importers:
   examples/lusion-connectors:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3759,8 +3759,8 @@ importers:
   examples/magic-box:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3799,8 +3799,8 @@ importers:
   examples/merged-instance:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3839,8 +3839,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3882,8 +3882,8 @@ importers:
   examples/mixing-controls:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3925,8 +3925,8 @@ importers:
   examples/mixing-html-and-webgl:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -3971,8 +3971,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4008,8 +4008,8 @@ importers:
   examples/moksha:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4054,8 +4054,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4100,8 +4100,8 @@ importers:
   examples/motionpathcontrols:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4149,8 +4149,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4198,8 +4198,8 @@ importers:
         specifier: ^5.10.1
         version: 5.10.5(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4244,8 +4244,8 @@ importers:
   examples/nextjs-prism:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4284,8 +4284,8 @@ importers:
   examples/night-train:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4324,8 +4324,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4367,8 +4367,8 @@ importers:
   examples/pairing-threejs-to-ui:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4416,8 +4416,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4459,8 +4459,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4502,8 +4502,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4545,8 +4545,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4588,8 +4588,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4628,8 +4628,8 @@ importers:
   examples/portals:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4668,8 +4668,8 @@ importers:
   examples/progressive-loading-states-with-suspense:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4711,8 +4711,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4769,8 +4769,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4806,8 +4806,8 @@ importers:
   examples/rapier-physics:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4852,8 +4852,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4901,8 +4901,8 @@ importers:
   examples/raycast-cycling:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4941,8 +4941,8 @@ importers:
   examples/re-using-geometry-and-level-of-detail:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -4978,8 +4978,8 @@ importers:
   examples/re-using-gltfs:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5015,8 +5015,8 @@ importers:
   examples/react-ellipsecurve:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5055,8 +5055,8 @@ importers:
   examples/react-pp-outlines:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5107,8 +5107,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5144,8 +5144,8 @@ importers:
   examples/room-with-soft-shadows:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5190,8 +5190,8 @@ importers:
         specifier: ^1.6.0
         version: 1.7.0
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5239,8 +5239,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5279,8 +5279,8 @@ importers:
   examples/scrollcontrols-gltf:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5319,8 +5319,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5356,8 +5356,8 @@ importers:
   examples/selective-outlines:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5396,8 +5396,8 @@ importers:
   examples/shader-fire:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5433,8 +5433,8 @@ importers:
   examples/shader-hmr:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5470,8 +5470,8 @@ importers:
   examples/shadermaterials:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5507,8 +5507,8 @@ importers:
   examples/shoe-configurator:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5550,8 +5550,8 @@ importers:
   examples/shopping:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5704,8 +5704,8 @@ importers:
   examples/sky-dome-with-annotations:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5744,8 +5744,8 @@ importers:
   examples/soft-shadows:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5787,8 +5787,8 @@ importers:
   examples/space-game:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5876,8 +5876,8 @@ importers:
   examples/spline-glass-shapes:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5922,8 +5922,8 @@ importers:
   examples/sport-hall:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -5962,8 +5962,8 @@ importers:
   examples/spotlight-shadows:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6039,8 +6039,8 @@ importers:
         specifier: ^7.25.0
         version: 7.29.2
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6085,8 +6085,8 @@ importers:
   examples/ssr-test:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6134,8 +6134,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6177,8 +6177,8 @@ importers:
   examples/staging-and-camerashake:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6214,8 +6214,8 @@ importers:
   examples/starwars:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6257,8 +6257,8 @@ importers:
   examples/stencil-mask:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6297,8 +6297,8 @@ importers:
   examples/svg-maps-with-html-annotations:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6377,8 +6377,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6426,8 +6426,8 @@ importers:
   examples/the-three-graces:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6469,8 +6469,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6506,8 +6506,8 @@ importers:
   examples/threejs-journey-portal:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6543,8 +6543,8 @@ importers:
   examples/thunder-clouds:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6592,8 +6592,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6632,8 +6632,8 @@ importers:
   examples/transformcontrols-and-makedefault:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6672,8 +6672,8 @@ importers:
   examples/transparent-aesop-bottles:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6712,8 +6712,8 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)(typescript@7.0.2)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6749,8 +6749,8 @@ importers:
   examples/tying-canvas-to-scroll-offset:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6789,8 +6789,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6826,8 +6826,8 @@ importers:
   examples/video-cookies:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6866,8 +6866,8 @@ importers:
   examples/video-textures:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6903,8 +6903,8 @@ importers:
   examples/view-tracking:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6946,8 +6946,8 @@ importers:
         specifier: ^1.6.0
         version: 1.7.0
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -6986,8 +6986,8 @@ importers:
   examples/viking-ship:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -7023,8 +7023,8 @@ importers:
   examples/volumetric-light-godray:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -7063,8 +7063,8 @@ importers:
   examples/volumetric-spotlight:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -7100,8 +7100,8 @@ importers:
   examples/water-shader:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -7143,8 +7143,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -7189,8 +7189,8 @@ importers:
         specifier: ^10.1.2
         version: 10.1.2(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -7226,8 +7226,8 @@ importers:
   examples/zustand-site:
     dependencies:
       '@react-three/drei':
-        specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -9189,8 +9189,8 @@ packages:
   '@react-three/csg@4.0.0':
     resolution: {integrity: sha512-IMLKGINdyQEUfyg3CE1gYoH9lK5RDR90vhXG21vHyo2kVAuslTnsH9GTVat69YglvNqHoEIMExTGLdhzm5/ygQ==}
 
-  '@react-three/drei@10.7.7':
-    resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
+  '@react-three/drei@10.7.8':
+    resolution: {integrity: sha512-rJXyuzLm2Xq0kafHuR47ajDGbOe/pEhzIr4m8E8zwzQs0iNjloFDqBwRhrXmP/w+onLeYyN3EYPFW/cwWK/4yA==}
     peerDependencies:
       '@react-three/fiber': ^9.0.0
       react: ^19
@@ -14475,13 +14475,13 @@ snapshots:
 
   '@radix-ui/number@1.0.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   '@radix-ui/number@1.1.3': {}
 
   '@radix-ui/primitive@1.0.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -14619,7 +14619,7 @@ snapshots:
 
   '@radix-ui/react-compose-refs@1.0.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.8)':
@@ -14649,7 +14649,7 @@ snapshots:
 
   '@radix-ui/react-context@1.0.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@19.2.8)':
@@ -14689,7 +14689,7 @@ snapshots:
 
   '@radix-ui/react-direction@1.0.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@radix-ui/react-direction@1.1.4(@types/react@19.2.17)(react@19.2.8)':
@@ -15012,7 +15012,7 @@ snapshots:
 
   '@radix-ui/react-portal@1.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@radix-ui/react-primitive': 1.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -15049,7 +15049,7 @@ snapshots:
 
   '@radix-ui/react-presence@1.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@radix-ui/react-compose-refs': 1.0.0(react@19.2.8)
       '@radix-ui/react-use-layout-effect': 1.0.0(react@19.2.8)
       react: 19.2.8
@@ -15076,7 +15076,7 @@ snapshots:
 
   '@radix-ui/react-primitive@1.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@radix-ui/react-slot': 1.0.1(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -15371,7 +15371,7 @@ snapshots:
 
   '@radix-ui/react-tooltip@1.0.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@19.2.8)
       '@radix-ui/react-context': 1.0.0(react@19.2.8)
@@ -15432,7 +15432,7 @@ snapshots:
 
   '@radix-ui/react-use-callback-ref@1.0.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.17)(react@19.2.8)':
@@ -15512,7 +15512,7 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.0.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.8)':
@@ -15608,7 +15608,7 @@ snapshots:
 
   '@rc-component/async-validator@5.1.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   '@rc-component/color-picker@2.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -15621,14 +15621,14 @@ snapshots:
 
   '@rc-component/context@1.4.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       rc-util: 5.44.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
   '@rc-component/mini-decimal@1.1.3':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   '@rc-component/mutate-observer@1.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -15640,7 +15640,7 @@ snapshots:
 
   '@rc-component/portal@1.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
@@ -15771,9 +15771,9 @@ snapshots:
     transitivePeerDependencies:
       - three
 
-  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)':
+  '@react-three/drei@10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@mediapipe/tasks-vision': 0.10.17
       '@monogrid/gainmap-js': 3.4.0(three@0.165.0)
       '@react-three/fiber': 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
@@ -17082,10 +17082,10 @@ snapshots:
 
   duplexer3@0.1.5: {}
 
-  ecctrl@1.0.88(@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0):
+  ecctrl@1.0.88(@react-three/drei@10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0):
     dependencies:
       '@react-spring/three': 9.7.5(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
-      '@react-three/drei': 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
+      '@react-three/drei': 10.7.8(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(@types/react@19.2.17)(@types/three@0.165.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/fiber': 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@react-three/rapier': 2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0))(react@19.2.8)(three@0.165.0)
       leva: 0.9.36(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -19138,7 +19138,7 @@ snapshots:
 
   rc-overflow@1.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-resize-observer: 1.4.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       rc-util: 5.44.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -19315,7 +19315,7 @@ snapshots:
 
   rc-virtual-list@3.19.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-resize-observer: 1.4.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       rc-util: 5.44.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,4 @@ patchedDependencies:
 
 minimumReleaseAgeExclude:
   - material-theme-builder@3.0.0
+  - '@react-three/drei@10.7.8'


### PR DESCRIPTION
Fixes router-transitions, which had broken rendering of MeshTransmissionMaterial with react-pp. Also does a TS upgrade. A fix was updstreamed to Drei so we bump it here.