### PR TITLE
Manage the shareable filter params with nuqs

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { NuqsAdapter } from "nuqs/adapters/react";
 import "./globals.css";
 import Nav from "@/components/Nav";
 import { getExamples } from "@/lib/helper";
@@ -103,7 +104,20 @@ export default function RootLayout({
           enableSystem={false}
           disableTransitionOnChange
         >
-          <Nav examples={examples} />
+          {/* `Nav` is the only nuqs consumer, so the adapter wraps it alone.
+
+              The plain-React adapter, not `nuqs/adapters/next/app`: this site
+              is `output: "export"`, so there is no server for the Next adapter
+              to talk to — and its provider calls `useSearchParams`, which on a
+              prerendered route drops everything up to the nearest `<Suspense>`
+              out of the static HTML. That is the whole rail, all ~160 example
+              links included. This adapter reads `location.search` through
+              `useSyncExternalStore` with an empty server snapshot, so the rail
+              still ships prerendered and picks the params up on hydration —
+              which is exactly what the hand-rolled version did. */}
+          <NuqsAdapter>
+            <Nav examples={examples} />
+          </NuqsAdapter>
           <main className="grid h-dvh min-w-0 flex-1 place-items-center overflow-hidden p-(--main-p)">
             {children}
           </main>

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -13,7 +13,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { useParams, usePathname } from "next/navigation";
+import { useParams } from "next/navigation";
+import { createSerializer, parseAsString, useQueryStates } from "nuqs";
 import {
   ChevronLeftIcon,
   ListFilterIcon,
@@ -65,6 +66,23 @@ const INITIAL_THUMBNAILS = 6;
    it reserves it for clearing the selection. The sentinel is what the option
    carries; the state stays "". */
 const ALL_LIBRARIES = "__all__";
+
+/* Filters are shareable: `?q=` carries the search text, `?library=` the
+   library filter. nuqs owns the round trip — the URL *is* the state, so the
+   defaults below double as the "no filter" values and `clearOnDefault` (on by
+   default) drops the empty param rather than leaving `?q=` behind.
+
+   Its defaults also cover what the hand-rolled version had to spell out: a
+   shallow `history.replaceState` instead of a router navigation per keystroke,
+   throttled to stay under Safari's History API rate limit. */
+const filterParsers = {
+  q: parseAsString.withDefault(""),
+  library: parseAsString.withDefault(""),
+};
+
+/* Same parsers, used to hang the active filter off every card link so it
+   survives the client navigation into an example. */
+const serializeFilters = createSerializer(filterParsers);
 
 /**
  * Keep the list itself complete for links, roving focus and stable scroll
@@ -270,10 +288,21 @@ export default function Nav({
 
   const [open, setOpenState] = useState(true);
   const [ready, setReady] = useState(false);
-  const [library, setLibrary] = useState("");
   const [libraryOpen, setLibraryOpen] = useState(false);
-  const [search, setSearch] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+
+  const [{ q: search, library }, setFilters] = useQueryStates(filterParsers);
+  const setSearch = useCallback(
+    (value: string | ((current: string) => string)) =>
+      setFilters((current) => ({
+        q: typeof value === "function" ? value(current.q) : value,
+      })),
+    [setFilters],
+  );
+  const setLibrary = useCallback(
+    (value: string) => setFilters({ library: value }),
+    [setFilters],
+  );
 
   const searchVisible = searchOpen || search !== "";
 
@@ -447,52 +476,24 @@ export default function Nav({
     document.documentElement.removeAttribute("data-nav-collapsed");
   }, [ready]);
 
-  /* Filters are shareable: `?q=` carries the search text, `?library=` the
-     library filter. Read once on mount — declared after the collapse
-     restore above so a shared link can win over a collapsed rail. Written
-     with `history.replaceState` rather than the router: per-keystroke
-     navigations are pointless work, and Safari rate-limits the History API
-     anyway, hence the debounce. */
-  const pathname = usePathname();
-  const urlReadRef = useRef(false);
+  /* A shared filter link has to be visible when it lands, which the search
+     field handles on its own (`searchVisible` reads the state) but the rail
+     does not — hence this, declared after the collapse restore above so the
+     link wins over a collapsed rail. It fires once, on the first non-empty
+     filter, which covers both a link opened cold and one whose params only
+     reach the client after hydration.
+
+     Plain state, not `setOpen`: following someone's filter link should not
+     overwrite this visitor's stored collapse preference. */
+  const filtersRevealed = useRef(false);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const q = params.get("q");
-    const lib = params.get("library");
+    if (filtersRevealed.current || (!search && !library)) return;
+    filtersRevealed.current = true;
 
-    if (q) {
-      setSearch(q);
-      setSearchOpen(true);
-      /* Plain state, not `setOpen`: following someone's filter link should
-         not overwrite this visitor's stored collapse preference. */
-      setOpenState(true);
-    }
-    if (lib) setLibrary(lib);
-
-    urlReadRef.current = true;
-  }, []);
-
-  /* `pathname` is a dependency so the params survive client navigation:
-     clicking a card pushes a bare `/examples/<name>`, and this puts the
-     active filter back into the address bar. */
-  useEffect(() => {
-    if (!urlReadRef.current) return;
-
-    const id = setTimeout(() => {
-      const url = new URL(window.location.href);
-
-      if (search) url.searchParams.set("q", search);
-      else url.searchParams.delete("q");
-      if (library) url.searchParams.set("library", library);
-      else url.searchParams.delete("library");
-
-      if (url.href !== window.location.href)
-        history.replaceState(history.state, "", url);
-    }, 150);
-
-    return () => clearTimeout(id);
-  }, [search, library, pathname]);
+    if (search) setSearchOpen(true);
+    setOpenState(true);
+  }, [search, library]);
 
   const firstRef = useRef(true);
   useEffect(() => {
@@ -682,7 +683,13 @@ export default function Nav({
                         )}
                       >
                         <Link
-                          href={`/examples/${name}`}
+                          /* The filter rides along: the rail stays mounted
+                             across this navigation, but the URL is the state
+                             now, so a bare `/examples/<name>` would clear it. */
+                          href={serializeFilters(`/examples/${name}`, {
+                            q: search,
+                            library,
+                          })}
                           aria-label={title}
                           aria-current={
                             examplename === name ? "page" : undefined

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -175,6 +175,7 @@
     "material-theme-builder": "^3.0.0",
     "next": "16.3.0",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.9.5",
     "radix-ui": "^1.6.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      nuqs:
+        specifier: ^2.9.5
+        version: 2.9.5(next@16.3.0(@babel/core@7.29.0(supports-color@7.2.0))(@playwright/test@1.62.0)(@types/node@20.19.39)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       radix-ui:
         specifier: ^1.6.7
         version: 1.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -9407,6 +9410,9 @@ packages:
       '@react-three/fiber': '>=7.0.0'
       '@splinetool/loader': '>=0.9.19'
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stitches/react@1.2.8':
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
     peerDependencies:
@@ -11979,6 +11985,27 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nuqs@2.9.5:
+    resolution: {integrity: sha512-Ec+vVwUKKng7E6ya5zZowt3QqDRGqqB1E40Rp2QAyZXGgYekDzmVo7V7jwbLAMkdbiZTH285fOIUyZGrS5zsCg==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7 || ^8
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -15957,6 +15984,8 @@ snapshots:
       '@react-three/fiber': 9.6.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.165.0)
       '@splinetool/loader': 0.9.153(patch_hash=87d1c8725410c81bfa246825dab2fc7b9f3fc6ab7ef0ab3e28137e5ebbada172)(three@0.165.0)
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stitches/react@1.2.8(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -18580,6 +18609,13 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  nuqs@2.9.5(next@16.3.0(@babel/core@7.29.0(supports-color@7.2.0))(@playwright/test@1.62.0)(@types/node@20.19.39)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      react: 19.2.8
+    optionalDependencies:
+      next: 16.3.0(@babel/core@7.29.0(supports-color@7.2.0))(@playwright/test@1.62.0)(@types/node@20.19.39)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
Replaces the hand-rolled URL round trip from #156: the read-once-on-mount effect and the debounced `history.replaceState` writer both go, and `?q=` / `?library=` become `useQueryStates` over two string parsers.

The nuqs defaults are what that code was spelling out by hand — shallow `replaceState` rather than a router navigation per keystroke, throttled under Safari's History API rate limit, and `clearOnDefault` so an emptied field leaves no `?q=` behind. Net −50 lines in `Nav.tsx`.

## Why `nuqs/adapters/react` and not `nuqs/adapters/next/app`

The site is `output: "export"`, so there is no server for the Next adapter to talk to, and its provider calls `useSearchParams` — which fails the build outright (`missing-suspense-with-csr-bailout`), and with a `<Suspense>` around the rail drops the whole thing and its ~160 example links out of the prerendered HTML. Measured on `out/examples/aquarium.html`: **158 → 0** occurrences of `href="/examples/…"`.

The React adapter reads `location.search` through `useSyncExternalStore` with an empty server snapshot, so the rail still ships prerendered and picks the params up on hydration — which is exactly what the hand-rolled version did.

Nothing is given up for it. `shallow: false` (RSC refetch) is a dead option without a server; `basePath` resolves identically since both adapters build the URL from `location`; and the only internal `<Link>`s are Nav's own cards, which now carry the params themselves. `enableHistorySync()` is there if a third-party `pushState` ever needs picking up.

`experimental.missingSuspenseWithCSRBailout: false` is not an option — it no longer exists in Next 16.

## Behaviour changes

Two fall out of the URL now being the state rather than a mirror of it:

- Card links carry the active filter (`createSerializer`) instead of an effect putting it back *after* a bare `/examples/<name>` has already cleared it.
- A `?library=` link opens the rail the way a `?q=` link always did, rather than filtering silently behind a collapsed one.

## Verification

- `tsc --noEmit` and `next build` clean; 158 nav links still in the prerendered HTML; lint unchanged (5 pre-existing warnings).
- In Chrome: `?q=cloud` lands with rail + search field open (3 results) · clicking a card → `/examples/clouds?q=cloud` · typing updates the URL · the close button removes `q` · the select writes `library=Rapier` · an unrelated `nav=open` survives every update · console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9GcQrfLJ6Cpzd5NPtsYEY
