### PR TITLE
Keep the list back until the filter has been applied

### DIFF
--- a/apps/website/app/globals.css
+++ b/apps/website/app/globals.css
@@ -350,3 +350,40 @@
     margin-inline-start: calc(var(--sidebar-width) * -1);
   }
 }
+
+/* Same story for `?q=` and `?library=`, one step earlier: a static export
+   ships the list rendered whole, so all ~160 cards paint while the JS that
+   will narrow them down is still loading, and the filter lands as a visible
+   jump. `bootNav` marks a filtered arrival, and these hold the list back
+   behind a handful of skeletons until React has applied it -- only for those
+   arrivals; everyone else gets the prerendered list painted as it always was
+   and never renders the skeletons at all.
+
+   `visibility`, not `display`: the cards have to keep their boxes, both
+   because the list windowing measures them on that very commit -- collapsed
+   to nothing, every card reads as on-screen and all ~160 thumbnails mount at
+   once -- and because it is what lets the skeletons sit over the list rather
+   than push it down. */
+#example-skeletons,
+#nav-filters-skeleton {
+  display: none;
+}
+
+html[data-nav-filtering] #example-skeletons {
+  display: flex;
+}
+
+html[data-nav-filtering] #nav-filters-skeleton {
+  display: block;
+}
+
+html[data-nav-filtering] #example-list {
+  visibility: hidden;
+}
+
+/* The filter row is the same story in miniature: whichever of its two forms
+   the HTML was built with is the wrong one here -- the dropdown where the
+   search field belongs, or the dropdown with nothing selected. */
+html[data-nav-filtering] #nav-filters {
+  display: none;
+}

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -13,6 +13,50 @@ const inter = Inter({ subsets: ["latin"] });
 const examples = getExamples();
 
 /**
+ * Two things only the client knows, both needed before the first paint, so the
+ * blocking script below runs this and leaves the verdict on <html>: whether the
+ * rail starts collapsed, and whether this is a filtered arrival — `?q=`
+ * /`?library=`, whose list must not paint whole while the JS that will narrow
+ * it is still loading. `globals.css` acts on both marks and `Nav` takes them
+ * over, then drops them. A filter beats a stored collapse: a shared link has to
+ * be able to show what it filtered down to.
+ *
+ * A function rather than a template string, so it is typed, formatted and
+ * linted like everything else — `String(bootNav)` is what ends up in the page.
+ * The catch that comes with that: it has to stay hermetic. No imports, no
+ * module-level constants, nothing but its arguments, or the bundler leaves a
+ * dangling reference in the string. Hence the storage key coming in as one —
+ * `Nav` owns the other half of that contract.
+ */
+function bootNav(storageKey: string) {
+  const params = new URLSearchParams(window.location.search);
+  const filtering = !!(params.get("q") || params.get("library"));
+
+  const isCollapsed = () => {
+    const parts = window.location.pathname.split("/").filter(Boolean);
+    const examplesIndex = parts.indexOf("examples");
+    const onAnExample = examplesIndex !== -1 && !!parts[examplesIndex + 1];
+
+    /* Two cases where the rail stays out whatever this visitor last left it
+       at: the index, where there is nothing to look at beside it, and a
+       shared filter link, which has to show what it filtered down to. */
+    if (!onAnExample || filtering) return false;
+
+    /* Then `?nav=`, a link saying how it wants to arrive… */
+    const nav = params.get("nav");
+    if (nav === "closed") return true;
+    if (nav === "open") return false;
+
+    /* …and failing that, wherever this visitor left it. */
+    return localStorage.getItem(storageKey) === "1";
+  };
+
+  const root = document.documentElement;
+  root.toggleAttribute("data-nav-collapsed", isCollapsed());
+  root.toggleAttribute("data-nav-filtering", filtering);
+}
+
+/**
  * The one hex the whole palette hangs off -- poimandres' signature mint.
  * Material Color Utilities derives every `--md-sys-color-*` role from it, and
  * `globals.css` hands those on to shadcn's tokens. `scheme`, `contrast`, core
@@ -81,21 +125,10 @@ export default function RootLayout({
           precedence="high"
           dangerouslySetInnerHTML={{ __html: mcuCss }}
         />
+        {/* Blocking on purpose: `bootNav` settles what the rail looks like
+            before anything paints. */}
         <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              (() => {
-                const storageKey = "nav-collapsed";
-                const parts = window.location.pathname.split("/").filter(Boolean);
-                const examplesIndex = parts.indexOf("examples");
-                const hasExampleSelected = examplesIndex !== -1 && !!parts[examplesIndex + 1];
-                const nav = new URLSearchParams(window.location.search).get("nav");
-                const collapsed =
-                  !hasExampleSelected ? false : nav === "closed" ? true : nav === "open" ? false : localStorage.getItem(storageKey) === "1";
-                document.documentElement.toggleAttribute("data-nav-collapsed", collapsed);
-              })();
-            `,
-          }}
+          dangerouslySetInnerHTML={{ __html: `(${bootNav})("nav-collapsed")` }}
         />
         <ThemeProvider
           attribute="class"

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/input-group";
 import { Item, ItemFooter, ItemMedia } from "@/components/ui/item";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
   SelectContent,
@@ -62,9 +63,24 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 
+/* Where the rail's collapsed preference lives. `bootNav` in `app/layout.tsx`
+   reads it before first paint; this is the end that writes it. */
 const STORAGE_KEY = "nav-collapsed";
 const MAX_TAGS = 4;
 const INITIAL_THUMBNAILS = 6;
+/* Tag-strip widths for the placeholder cards a filtered arrival waits in
+   front of — one row per card, the same handful the list mounts eagerly.
+   Written out rather than drawn at random: the markup has to come out the
+   same on both sides of hydration, and real strips are two or three pills of
+   uneven length. */
+const SKELETON_TAGS = [
+  [56, 88],
+  [72],
+  [64, 104, 48],
+  [96, 60],
+  [52, 76],
+  [80, 44, 92],
+];
 /* `library` is "" for no filter, but Radix rejects an empty SelectItem value —
    it reserves it for clearing the selection. The sentinel is what the option
    carries; the state stays "". */
@@ -87,9 +103,9 @@ const filterParsers = {
    survives the client navigation into an example. */
 const serializeFilters = createSerializer(filterParsers);
 
-/* `data-nav-collapsed` is put on <html> before first paint by the inline
-   script in `app/layout.tsx` — the only way a statically exported page can
-   weigh `localStorage`, the `?nav=` override and the current route that early.
+/* `data-nav-collapsed` is put on <html> before first paint by `bootNav`
+   (`app/layout.tsx`) — the only way a statically exported page can weigh
+   `localStorage`, the `?nav=` override and the current route that early.
    React reads the verdict back through `useSyncExternalStore` rather than from
    a mount effect: the value is already there at hydration, and the server
    snapshot is what keeps the first render agreeing with the prerendered HTML.
@@ -229,7 +245,6 @@ function NavToggle() {
      right one; the label has to agree with it. */
   const shown = isMobile ? openMobile : open;
 
-  const ready = useIsClient();
   const [near, setNear] = useState(false);
 
   useEffect(() => {
@@ -276,10 +291,13 @@ function NavToggle() {
           !shown && "rotate-180",
         )}
       />
+      {/* Written out from the first client render, not once mounted: `shown`
+          reaches back to the pre-paint mark through `useSyncExternalStore`, so
+          the word is already right where a `localStorage` read would have made
+          it a coin flip — and the pill no longer reflows around a label that
+          turns up late. */}
       <span className="tracking-wider uppercase [writing-mode:vertical-rl]">
-        {/* Blank until mounted: the collapsed state comes out of
-              `localStorage`, so before then the word would be a coin flip. */}
-        {ready ? (shown ? "hide" : "show") : ""}
+        {shown ? "hide" : "show"}
       </span>
     </Button>
   );
@@ -520,12 +538,16 @@ export default function Nav({
 
   const { examplename } = useParams();
 
-  /* React hands the pre-paint attribute back once it has rendered a panel of
-     its own: from here on the state above is the truth, and a stale attribute
-     would fight it (see the pre-paint rule in `app/globals.css`). */
+  /* React hands the pre-paint marks back once it has rendered a panel and a
+     list of its own: from here on the state above is the truth, and a stale
+     attribute would fight it (see the pre-paint rules in `app/globals.css`).
+     By this render `q` and `library` have reached the client — the adapter
+     reads them through `useSyncExternalStore`, which settles during the
+     hydration commit, before this effect. */
   useEffect(() => {
     if (!ready) return;
     document.documentElement.removeAttribute("data-nav-collapsed");
+    document.documentElement.removeAttribute("data-nav-filtering");
   }, [ready]);
 
   const firstRef = useRef(true);
@@ -580,56 +602,63 @@ export default function Nav({
             to be set on the two children: `className` here lands on the fixed
             container, and the panel's background is painted a level deeper. */}
         <SidebarHeader className="px-4">
-          {searchVisible ? (
-            <InputGroup className="animate-in border-border bg-input shadow-lg duration-200 fade-in slide-in-from-top-1">
-              {/* Addons come after the control in the DOM — they focus it on
+          {/* Both branches read the URL, so on a filtered arrival both are
+              wrong until React knows it: the row would paint the library
+              filter unset, or paint the dropdown where the search field
+              belongs. `display: contents` so standing in front of them
+              changes nothing about how they lay out. */}
+          <Skeleton id="nav-filters-skeleton" className="h-9 rounded-full" />
+          <div id="nav-filters" className="contents">
+            {searchVisible ? (
+              <InputGroup className="animate-in border-border bg-input shadow-lg duration-200 fade-in slide-in-from-top-1">
+                {/* Addons come after the control in the DOM — they focus it on
                   click and take their visual side from `align`. */}
-              <InputGroupInput
-                ref={searchRef}
-                type="search"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                onFocus={() => setSearchOpen(true)}
-                placeholder="Search examples"
-                aria-label="Search examples"
-                aria-controls="example-list"
-                aria-describedby="search-results"
-                className="[&::-webkit-search-cancel-button]:hidden"
-              />
-              <InputGroupAddon>
-                <SearchIcon />
-              </InputGroupAddon>
-              <InputGroupAddon align="inline-end">
-                <InputGroupText className="text-xs tabular-nums">
-                  {filteredExamples.length}
-                </InputGroupText>
-                <InputGroupButton
-                  size="icon-xs"
-                  onClick={dismissSearch}
-                  aria-label="Close search"
+                <InputGroupInput
+                  ref={searchRef}
+                  type="search"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  onFocus={() => setSearchOpen(true)}
+                  placeholder="Search examples"
+                  aria-label="Search examples"
+                  aria-controls="example-list"
+                  aria-describedby="search-results"
+                  className="[&::-webkit-search-cancel-button]:hidden"
+                />
+                <InputGroupAddon>
+                  <SearchIcon />
+                </InputGroupAddon>
+                <InputGroupAddon align="inline-end">
+                  <InputGroupText className="text-xs tabular-nums">
+                    {filteredExamples.length}
+                  </InputGroupText>
+                  <InputGroupButton
+                    size="icon-xs"
+                    onClick={dismissSearch}
+                    aria-label="Close search"
+                  >
+                    <XIcon />
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Select
+                  open={libraryOpen}
+                  onOpenChange={setLibraryOpen}
+                  value={library || ALL_LIBRARIES}
+                  onValueChange={(value) =>
+                    setLibrary(value === ALL_LIBRARIES ? "" : value)
+                  }
                 >
-                  <XIcon />
-                </InputGroupButton>
-              </InputGroupAddon>
-            </InputGroup>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Select
-                open={libraryOpen}
-                onOpenChange={setLibraryOpen}
-                value={library || ALL_LIBRARIES}
-                onValueChange={(value) =>
-                  setLibrary(value === ALL_LIBRARIES ? "" : value)
-                }
-              >
-                <SelectTrigger
-                  className="min-w-0 flex-1 border-border bg-input shadow-lg"
-                  aria-label="Filter examples by library"
-                >
-                  <ListFilterIcon className="text-muted-foreground" />
-                  <SelectValue />
-                </SelectTrigger>
-                {/* `item-aligned` — this registry's default, where Radix lays
+                  <SelectTrigger
+                    className="min-w-0 flex-1 border-border bg-input shadow-lg"
+                    aria-label="Filter examples by library"
+                  >
+                    <ListFilterIcon className="text-muted-foreground" />
+                    <SelectValue />
+                  </SelectTrigger>
+                  {/* `item-aligned` — this registry's default, where Radix lays
                     the menu over the trigger with the selected option on top
                     of it — cannot do that for a trigger sitting 26px from the
                     top of the window. It clamps the menu and makes up the
@@ -643,31 +672,34 @@ export default function Nav({
                     `--radix-select-content-available-height` a value, which
                     the component's own `max-h-` reads and item-aligned never
                     sets. */}
-                <SelectContent position="popper" className="backdrop-blur-sm">
-                  <SelectGroup>
-                    <SelectItem value={ALL_LIBRARIES}>All libraries</SelectItem>
-                    {libraryOptions.map((option) => (
-                      <SelectItem key={option} value={option}>
-                        {option}
+                  <SelectContent position="popper" className="backdrop-blur-sm">
+                    <SelectGroup>
+                      <SelectItem value={ALL_LIBRARIES}>
+                        All libraries
                       </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                onClick={() => focusSearch()}
-                aria-label="Search examples"
-                aria-keyshortcuts="Meta+F Control+F Meta+K Control+K"
-                title="Search examples (⌘F)"
-                className="bg-input shadow-lg"
-              >
-                <SearchIcon />
-              </Button>
-            </div>
-          )}
+                      {libraryOptions.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => focusSearch()}
+                  aria-label="Search examples"
+                  aria-keyshortcuts="Meta+F Control+F Meta+K Control+K"
+                  title="Search examples (⌘F)"
+                  className="bg-input shadow-lg"
+                >
+                  <SearchIcon />
+                </Button>
+              </div>
+            )}
+          </div>
           <span id="search-results" className="sr-only" aria-live="polite">
             {filteredExamples.length} examples
           </span>
@@ -679,7 +711,39 @@ export default function Nav({
             travel, so a list sitting at the top is not faded into its own
             first card. Without scroll-driven-animation support the two fades
             are simply always on. */}
-        <SidebarContent className="scroll-fade px-4">
+        <SidebarContent className="relative scroll-fade px-4">
+          {/* What a filtered arrival looks at while the JS that will narrow
+              the list is still loading — the pre-paint rules in
+              `app/globals.css` swap the two, and the effect above drops the
+              mark once React has rendered the real thing. Laid over the list
+              rather than above it, because the list keeps its box (see those
+              rules); inert, because the list underneath is the real content
+              and is what gets announced. */}
+          <ul
+            id="example-skeletons"
+            aria-hidden
+            className="absolute inset-x-4 top-2 flex flex-col gap-3"
+          >
+            {SKELETON_TAGS.map((widths, index) => (
+              <li key={index} className="relative">
+                <Skeleton className="aspect-video w-full rounded-md" />
+                {/* Same corner as the real strip, so the shape the eye is
+                    waiting for is already there when the cards land. Darker
+                    than the card it sits on, the way the real pills are —
+                    at the card's own tone they read as holes in it. */}
+                <div className="absolute inset-x-0 bottom-0 flex gap-1 p-1.5">
+                  {widths.map((width, tag) => (
+                    <Skeleton
+                      key={tag}
+                      style={{ width }}
+                      className="h-5 rounded-full bg-foreground/10"
+                    />
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
+
           <nav aria-label="Examples">
             <ul
               ref={setListRef}


### PR DESCRIPTION
Re-targets #161, which was opened against `fix/set-state-in-effect` to stack on #160 — but #160 was squashed into `main` two minutes earlier, so merging #161 landed it on a branch `main` no longer tracks. Same content, cherry-picked onto `main`: the three touched files were byte-identical between `main` and #161's base, so this is the merged commit unchanged.

---

Arriving on `?q=` or `?library=` meant watching all ~160 cards paint and then jump to the handful that match.

### Why not `<Suspense>`

The site is `output: "export"`: the list ships **rendered whole in the HTML** and paints before any JS runs, so nothing React does afterwards can help — a boundary that never suspends changes nothing.

Next *does* have a native answer: a `<Suspense>` around a `useSearchParams` consumer (i.e. `nuqs/adapters/next/app`) makes the prerender emit the fallback instead of the subtree. But that is decided **at build time**, not per visitor — it would cost the prerendered list, all ~160 links, for *everyone*, to spare the flash for the few who arrive with a filter.

### What this does instead

`bootNav` already reads the URL (for `?nav=`), so it also marks a filtered arrival on `<html>`; `globals.css` holds the list back behind skeletons until `Nav` takes the mark over, in the same handoff as `data-nav-collapsed`. Only filtered arrivals pay anything; everyone else keeps the prerendered list painting exactly as before.

`visibility`, not `display`: the cards have to keep their boxes, both because the list windowing measures them on that very commit — collapsed to nothing, every card reads as on-screen and all ~160 thumbnails mount at once — and because it is what lets the skeletons sit over the list rather than push it down.

The skeletons carry the tag strip the real cards do, and the filter row gets one too: whichever of its two forms the HTML was built with is the wrong one on a filtered arrival — the dropdown standing where the search field belongs on `?q=`, or the dropdown with nothing selected on `?library=`.

### Along the way

- **The boot script is a real function.** `String(bootNav)` is what lands in the page, so the logic is typed, formatted and linted like the rest of `layout.tsx` instead of living in a template literal. It has to stay hermetic to survive stringification — hence the storage key as an argument. (It cannot live in `Nav.tsx`: that is a `"use client"` module, so a server component importing from it gets a client reference, not the function.)
- **The pill's `hide`/`show` no longer arrives late.** It was held back until mounted because the collapsed state came from `localStorage`; it now reaches the pre-paint mark through `useSyncExternalStore`, so the word is right on the first client render and the pill stops reflowing around it.
- A filter beats a stored collapse in the script too, matching what `Nav` already did on the client.

### Known

`hide` then reload on a filtered URL reopens the rail — the "a shared filter link has to be visible" rule, inherited from the one-shot effect that predates this work, acting in both `bootNav` and `Nav`. Left as-is deliberately: the two cases it conflates (arriving on someone else's filter link, vs. having just collapsed it yourself on that URL) are indistinguishable from `localStorage` alone.

### Verified

`pnpm lint` / `tsc --noEmit` / `next build` clean; the minified inline script in the built HTML is self-contained. In the browser: `?q=` and `?library=` never show the unfiltered list, the mark is gone once React owns it, an unfiltered load is untouched (158 cards, list visible, collapse restored), and `?nav=` still outranks the stored preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9J9K5TobdJo49EU4Z1Fp4
