### PR TITLE
Upload the CI build to Vercel as a per-PR preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,16 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  deployments: write
 
 jobs:
   build-job:
     runs-on: ubuntu-latest
     env:
       TURBO_TELEMETRY_DISABLED: 1
+      # No token, no preview: that is a fork's pull request, which cannot read
+      # the repo secrets, or a checkout of this repo that never set them.
+      PREVIEW: ${{ github.event_name == 'pull_request' && secrets.VERCEL_TOKEN != '' }}
 
     # Cancel multiple runs when pushing to main
     concurrency:
@@ -89,6 +93,51 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && !inputs.update_snapshots }}
         with:
           path: ./out${{ steps.configurepages.outputs.base_path }}
+
+      #
+      # Preview (only for pull requests)
+      #
+      # The same build with no base path -- a preview is served from its own
+      # domain root -- uploaded as-is: Vercel hosts `out`, it never rebuilds it.
+      - run: pnpm build
+        if: ${{ env.PREVIEW == 'true' }}
+      - id: preview
+        if: ${{ env.PREVIEW == 'true' }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          mkdir -p .vercel/output
+          mv out .vercel/output/static
+          # `cleanUrls`: the website exports flat `<name>.html` pages and links
+          # to them without the extension
+          echo '{"version":3,"cleanUrls":true}' > .vercel/output/config.json
+          # `--archive`: one tarball, not 2.4k file uploads
+          url=$(pnpm dlx vercel@latest deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      # The pull request's "View deployment" box, which Vercel's git integration
+      # would have filled had we let it deploy
+      - uses: actions/github-script@v9
+        if: ${{ env.PREVIEW == 'true' }}
+        env:
+          URL: ${{ steps.preview.outputs.url }}
+        with:
+          script: |
+            const { data } = await github.rest.repos.createDeployment({
+              ...context.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: "preview",
+              transient_environment: true, // superseded by the next one
+              auto_merge: false, // deploy that ref, not a merge of the base into it
+              required_contexts: [], // the checks that would gate it are the ones running this
+            });
+            await github.rest.repos.createDeploymentStatus({
+              ...context.repo,
+              deployment_id: data.id,
+              state: "success",
+              environment_url: process.env.URL,
+            });
 
   deploy-job:
     # only for pushes on main

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ This will:
 
 </details>
 
+# deploy
+
+`.github/workflows/ci.yml` publishes `main` to GitHub Pages, and uploads the same
+`out` folder to Vercel for each pull request, as a preview — Vercel only hosts
+it, the build always happens in the CI. Needs `VERCEL_TOKEN`, `VERCEL_ORG_ID` and
+`VERCEL_PROJECT_ID` as repo secrets; a pull request from a fork cannot read them,
+and gets no preview.
+
 # test
 
 ```sh


### PR DESCRIPTION
GitHub Pages serves `main`, and nothing serves a pull request — a change to an example has to be described rather than clicked. This gives each PR a preview URL.

**Vercel hosts the build, it never runs one.** `vercel deploy --prebuilt` uploads a `.vercel/output` assembled from the `out` the CI just produced. So: no `vercel.json`, no workspace install on their side, no second build pipeline to keep in sync, and no way for what reviewers click to diverge from what CI tested.

The URL is published as a **GitHub deployment** (`transient`, environment `preview`), so the PR grows its "View deployment" box and the environment is listed with the others — the surface Vercel's own Git integration would have filled, ours to fill since we deploy from the workflow. No PR comment.

## Proven on this PR

Run [31376871029](https://github.com/pmndrs/examples/actions/runs/31376871029) → https://examples-67rn8tmum-pmndrs.vercel.app

| Step | |
| --- | --- |
| `pnpm build` (preview, after `test`) | **11 s** — turbo cache hit on every example |
| assemble + `vercel deploy --prebuilt` | **52 s**, CLI 58.9.0 on Node 24 |
| GitHub deployment | 2 s |
| whole job | 4 min 05 |

## Details worth a look

- **`BASE_PATH`/`BASE_URL` unset** for the preview build — served from its own domain root, demos land at `/<name>/` and website pages at `/examples/<name>`, exactly what `out.sh` writes. Pages keeps its base path.
- **`cleanUrls`** in `.vercel/output/config.json` — the website exports flat `<name>.html` pages and links to them without the extension.
- **`--archive=tgz`** — one 226 MB tarball instead of 2 412 individual uploads, which also keeps us clear of the 15 000-file cap on CLI deployments regardless of how many examples land later.
- **No third-party action** — Vercel publishes none, and the marketplace one that fits (`BetaHuhn/deploy-to-vercel-action`) last shipped in May 2024 on the node20 runtime. What it adds over the CLI is the GitHub deployment, which is 15 lines here and does not involve handing `VERCEL_TOKEN` to a vendored bundle.
- **No token, no preview** — a fork's PR cannot read the secrets, so the step is skipped rather than failed. The build still runs for them.

## Setup, for the record

Repo secrets `VERCEL_TOKEN` (scoped to the team, not a personal account), `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, against a bare Vercel project — no Git connection, since nothing is built there.

Preview Deployment Protection is on by default on Pro; leave it on and reviewers hit a login wall.

## Test plan

- [x] `pnpm check` passes; workflow YAML parses and the `github-script` body is valid JS
- [x] Packaging step run locally: build with no base path → `.vercel/output/{config.json,static}`, 2 412 files, 226 MB tarball
- [x] Green run on this PR, deployment visible in the timeline and under Environments