### PR TITLE
Stop linting the build output

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,14 +8,27 @@ import tseslint from "typescript-eslint";
  * copy-pasteable into a sandbox without lint scaffolding of its own.
  *
  * Only `{ts,tsx}` is matched, which is every example since #164 -- and is why
- * nothing ignores the build output or the vendored draco decoders: both are
- * plain `.js`, so they are never picked up in the first place.
+ * the vendored draco decoders need no ignore entry: they are plain `.js`, so
+ * they are never picked up in the first place. The build output was assumed to
+ * be in the same case and is not, hence the `dist` entry below.
  *
  * @type {import('eslint').Linter.Config[]}
  */
 export default [
   /* Vendored, and pre-annotated for someone else's config. */
   { ignores: ["**/realism-effects/"] },
+  /*
+   * Build output. Almost all of it is bundled `.js` this config never matches,
+   * which is how it went unnoticed that `infinite-scroll` serves a `.tsx` from
+   * `public/` -- vite copies that directory verbatim, so the file lands in
+   * `dist/` as a second, lintable copy of itself.
+   *
+   * It made the warning count depend on whether you happened to have built:
+   * 81 on a fresh clone, 83 once `dist/` existed. The CI lints before it
+   * builds and so never saw it; every local `pnpm build` broke the pre-commit
+   * and pre-push hooks until the next `git clean`.
+   */
+  { ignores: ["examples/*/dist/"] },
   {
     files: ["examples/**/*.{ts,tsx}"],
     plugins: {


### PR DESCRIPTION
`pnpm lint:examples` passed on a fresh clone and failed on a working copy that had been built — 81 warnings against a ceiling of 81, then 83. Both hooks run it, so a local `pnpm build` left the repo uncommittable and unpushable until the next `git clean`. The CI never saw it: it lints before it builds.

The config assumed the build output could not be linted — it is bundled `.js`, and only `{ts,tsx}` is matched. That holds everywhere except `infinite-scroll`, which serves a `.tsx` from `public/`. Vite copies that directory verbatim, so the file lands in `dist/` as a second, lintable copy of itself, and its two warnings are counted twice:

    examples/infinite-scroll/public/ScrollControls.tsx  ->  2 warnings
    examples/infinite-scroll/dist/ScrollControls.tsx    ->  the same 2

Ignore `examples/*/dist/`, and correct the comment that said this could not happen.

Verified: 81 warnings with a built tree, `pnpm check` green, and this commit went in through the pre-commit and pre-push hooks rather than around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
