### PR TITLE
Fix Stage/CameraControls conflict and GodRays clearing in postprocessing examples

### DIFF
--- a/examples/chromatic-aberration/src/App.tsx
+++ b/examples/chromatic-aberration/src/App.tsx
@@ -16,7 +16,12 @@ export default function App() {
   return (
     <Canvas shadows dpr={[1, 2]} camera={{ fov: 50 }}>
       <Suspense fallback={null}>
-        <Stage preset="rembrandt" intensity={Math.PI} environment="city">
+        <Stage
+          preset="rembrandt"
+          intensity={Math.PI}
+          environment="city"
+          adjustCamera={false}
+        >
           <Model />
         </Stage>
         <EffectComposer>

--- a/examples/dot-screen/src/App.tsx
+++ b/examples/dot-screen/src/App.tsx
@@ -15,7 +15,12 @@ export default function App() {
   return (
     <Canvas shadows dpr={[1, 2]} camera={{ fov: 50 }}>
       <Suspense fallback={null}>
-        <Stage preset="rembrandt" intensity={Math.PI} environment="city">
+        <Stage
+          preset="rembrandt"
+          intensity={Math.PI}
+          environment="city"
+          adjustCamera={false}
+        >
           <Model />
         </Stage>
         <EffectComposer>

--- a/examples/grid/src/App.tsx
+++ b/examples/grid/src/App.tsx
@@ -13,7 +13,12 @@ export default function App() {
   return (
     <Canvas shadows dpr={[1, 2]} camera={{ fov: 50 }}>
       <Suspense fallback={null}>
-        <Stage preset="rembrandt" intensity={Math.PI} environment="city">
+        <Stage
+          preset="rembrandt"
+          intensity={Math.PI}
+          environment="city"
+          adjustCamera={false}
+        >
           <Model />
         </Stage>
         <EffectComposer>

--- a/examples/pixelation/src/App.tsx
+++ b/examples/pixelation/src/App.tsx
@@ -16,7 +16,12 @@ export default function App() {
         <EffectComposer>
           <Pixelation granularity={granularity} />
         </EffectComposer>
-        <Stage preset="rembrandt" intensity={Math.PI} environment="city">
+        <Stage
+          preset="rembrandt"
+          intensity={Math.PI}
+          environment="city"
+          adjustCamera={false}
+        >
           <Model />
         </Stage>
       </Suspense>

--- a/examples/scanline/src/App.tsx
+++ b/examples/scanline/src/App.tsx
@@ -13,7 +13,12 @@ export default function App() {
   return (
     <Canvas shadows dpr={[1, 2]} camera={{ fov: 50 }}>
       <Suspense fallback={null}>
-        <Stage preset="rembrandt" intensity={Math.PI} environment="city">
+        <Stage
+          preset="rembrandt"
+          intensity={Math.PI}
+          environment="city"
+          adjustCamera={false}
+        >
           <Model />
         </Stage>
         <EffectComposer>

--- a/examples/sepia/src/App.tsx
+++ b/examples/sepia/src/App.tsx
@@ -1,8 +1,8 @@
-import { Suspense } from "react";
-import { Canvas } from "@react-three/fiber";
 import { CameraControls, Stage } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
 import { EffectComposer, Sepia } from "@react-three/postprocessing";
 import { useControls } from "leva";
+import { Suspense } from "react";
 import Model from "./Model";
 
 export default function App() {
@@ -13,7 +13,12 @@ export default function App() {
   return (
     <Canvas shadows dpr={[1, 2]} camera={{ fov: 50 }}>
       <Suspense fallback={null}>
-        <Stage preset="rembrandt" intensity={Math.PI} environment="city">
+        <Stage
+          preset="rembrandt"
+          intensity={Math.PI}
+          environment="city"
+          adjustCamera={false}
+        >
           <Model />
         </Stage>
         <EffectComposer>

--- a/examples/take-control/src/Effects.tsx
+++ b/examples/take-control/src/Effects.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import type { Mesh } from "three";
-import { BlendFunction } from "postprocessing";
+import { Circle } from "@react-three/drei";
 import {
   EffectComposer,
   GodRays,
@@ -8,8 +6,10 @@ import {
   Noise,
   Vignette,
 } from "@react-three/postprocessing";
-import { Circle } from "@react-three/drei";
 import { useControls } from "leva";
+import { BlendFunction } from "postprocessing";
+import { useState } from "react";
+import type { Mesh } from "three";
 
 function Sun({ onReady }: { onReady: (sun: Mesh) => void }) {
   const { sunColor } = useControls({
@@ -27,15 +27,15 @@ export default function Effects() {
   const [sun, setSun] = useState<Mesh | null>(null);
 
   const { hue, saturation } = useControls("Postprocessing - HueSaturation", {
-    hue: { value: 3.11, min: 0, max: Math.PI * 2 },
-    saturation: { value: 2.05, min: 0, max: Math.PI * 2 },
+    hue: { value: 0, min: -1, max: 1 },
+    saturation: { value: 0, min: -1, max: 1 },
   });
   const { noiseOpacity } = useControls("Postprocessing - Noise", {
-    noiseOpacity: { value: 0.47, min: 0, max: 1, label: "Opacity" },
+    noiseOpacity: { value: 0.5, min: 0, max: 1, label: "Opacity" },
   });
   const { exposure, decay, blur } = useControls("Postprocessing - GodRays", {
     exposure: { value: 0.34, min: 0, max: 1 },
-    decay: { value: 0.9, min: 0, max: 1, step: 0.1 },
+    decay: { value: 0.9, min: 0, max: 1 },
     blur: { value: false },
   });
 
@@ -44,13 +44,13 @@ export default function Effects() {
       <Sun onReady={setSun} />
       {sun && (
         <EffectComposer multisampling={0} autoClear={false}>
+          <HueSaturation hue={hue} saturation={saturation} />
           <GodRays sun={sun} exposure={exposure} decay={decay} blur={blur} />
           <Noise
             opacity={noiseOpacity}
             premultiply
             blendFunction={BlendFunction.ADD}
           />
-          <HueSaturation hue={hue} saturation={saturation} />
           <Vignette />
         </EffectComposer>
       )}

--- a/examples/take-control/src/Effects.tsx
+++ b/examples/take-control/src/Effects.tsx
@@ -43,7 +43,7 @@ export default function Effects() {
     <>
       <Sun onReady={setSun} />
       {sun && (
-        <EffectComposer multisampling={0}>
+        <EffectComposer multisampling={0} autoClear={false}>
           <GodRays sun={sun} exposure={exposure} decay={decay} blur={blur} />
           <Noise
             opacity={noiseOpacity}

--- a/examples/take-control/src/Lights.tsx
+++ b/examples/take-control/src/Lights.tsx
@@ -14,19 +14,16 @@ export default function Lights() {
         color={color}
         position={[0, 0, -10]}
         intensity={4 * Math.PI}
-        decay={0}
       />
       <pointLight
         color={color}
         position={[0, 1, -10]}
         intensity={0.3 * 4 * Math.PI}
-        decay={0}
       />
       <spotLight
         position={[0, 1, 3]}
         intensity={0.4 * 4 * Math.PI}
         distance={10}
-        decay={0}
         color="blue"
       />
       <directionalLight position={[0, 0, 0]} intensity={0.1 * Math.PI} />


### PR DESCRIPTION
Stage's own camera-fitting logic fights CameraControls: it throws a recurring console error and makes the camera jump on every Leva change. adjustCamera={false} on Stage stops Stage from touching the camera at all.

GodRaysEffect in current postprocessing versions relies on renderer.autoClear staying false throughout the composer's render pass (newer versions skip an explicit clear before drawing the light source, expecting prior buffer content - like depth data copied a moment earlier - to survive). The EffectComposer wrapper flips gl.autoClear to its own autoClear prop (true by default) for the whole frame, which stomps that assumption and produces a blob instead of rays. autoClear={false} leaves gl.autoClear alone.