### PR TITLE
Freeze the page clock, remount in our order, and recover all 35 drifters

### DIFF
--- a/bin/e2e-exceptions.mjs
+++ b/bin/e2e-exceptions.mjs
@@ -98,10 +98,18 @@ export const EXCEPTIONS = {
 //
 // Measured under that harness over repeated passes of three cold shots each,
 // on every former drifter plus three always-stable controls, until two
-// consecutive passes caught nothing:
-//
-//   pass 1   38 examples   0 caught
-//   pass 2   38 survivors   0 caught
+// consecutive passes caught nothing. The first protocol run came back clean
+// at six shots per example -- and doubling it under full-machine load caught
+// three more, each flipping once in ten to fifteen shots and only under
+// load. That is the measurement lesson next to "warm is not cold" and
+// "three shots settle nothing": an idle machine hides flakers, so the
+// certifying run keeps the machine busy on purpose. All three were
+// diagnosed to a proven mechanism (an async Worker reply landing mid-shot,
+// networkidle saying "arrived" when Draco had not finished decoding, and a
+// texture() sampled where GLSL leaves derivatives undefined), fixed, and
+// re-measured 9/9 under load each. The final certification -- all 38 under
+// sustained load, plus a parallel sweep hammering the six heaviest with
+// ~135 extra shots -- caught nothing, twice over.
 //
 // It is still sampling -- the nightly, which shoots five times on the runner
 // that actually takes the picture, is what keeps the claim honest over time,

--- a/bin/e2e-exceptions.mjs
+++ b/bin/e2e-exceptions.mjs
@@ -80,90 +80,39 @@ export const EXCEPTIONS = {
 // -- and one example crying wolf is enough for nobody to read the report.
 //
 // `e2e-flaky` is what decides, never a reading of the source: `useFrame` tells
-// you nothing either way. Each line carries the hashes that disagreed and how
+// you nothing either way. An entry carries the hashes that disagreed and how
 // many shots it took to catch them, so the claim can be checked rather than
 // believed.
 //
-// Measured over five independent passes of three cold shots, run until two
-// consecutive passes caught nothing new. Each pass only re-shot what the last
-// one still called stable, because UNSTABLE is proof and needs no repeat while
-// "stable" is only an absence of one:
+// The list is empty, and that emptiness was bought, not assumed. Thirty-five
+// examples used to live here -- every one measured drifting, some flipping
+// between three canvases within three shots. Understanding why emptied it:
+// the page keeping its own clock (react-spring's rafz never goes through
+// `useFrame`), wall-clock timers, the media clock, mount order following
+// asset-arrival order, three's draw sorts keying on ids that are dealt in
+// Draco-worker completion order, CSS animations on the compositor's timeline,
+// and one MSAA sample resolved inside the driver. Each mechanism is documented
+// where it is closed, in `packages/e2e/src/deterministic.js` and
+// `CheesyCanvas.jsx`; two examples also stopped scheduling real timers
+// (`clones`, `springy-boxes`).
 //
-//   pass 1   162 examples   28 caught
-//   pass 2   134 survivors   7 caught
-//   pass 3   127 survivors   2 caught
-//   pass 4   124 survivors   0
-//   pass 5   124 survivors   0
+// Measured under that harness over repeated passes of three cold shots each,
+// on every former drifter plus three always-stable controls, until two
+// consecutive passes caught nothing:
 //
-// The middle rows are why this was not stopped at three. Seven examples that
-// three shots called stable were not, and two more survived six -- so three
-// settles nothing, and a list built on three would have published nine drifting
-// examples with a measurement stamped on them.
+//   pass 1   38 examples   0 caught
+//   pass 2   38 survivors   0 caught
 //
-// The last two rows are why it stops here. Everything published has now held
-// the same canvas across fifteen cold shots, and the two passes that cost the
-// most found the least: nothing. That is as close to closed as sampling gets.
 // It is still sampling -- the nightly, which shoots five times on the runner
-// that actually takes the picture, is what keeps the claim honest over time.
+// that actually takes the picture, is what keeps the claim honest over time,
+// and this list is where its catches land. An entry here is a promise to
+// diagnose, not a place to rest.
 //
-// Two absences from this list are deliberate. `svg-renderer` reports "no
+// Two absences never belonged on this list. `svg-renderer` reports "no
 // canvas" by construction -- it swaps its canvas for an `<svg>`, which
 // Chromatic archives as DOM, so there is nothing here to be flaky about.
 // `minecraft` could not be measured at all: it does not build on the machine
 // this ran on (a missing rapier dependency) though it builds in CI, so the
 // nightly gets the first word on it.
 //
-export const UNPUBLISHED = {
-  aquarium: "2 canvases in 3 shots: d3f6a86f7103, 0d8dd7384ac0",
-  "backdrop-and-cables": "2 canvases in 6 shots: 350486b815b9, 70adbce4ef64",
-  "bloom-hdr-workflow-gltf":
-    "2 canvases in 6 shots: c8891071d7ec, 57ff01daeab4",
-  "bounds-and-makedefault": "2 canvases in 3 shots: 5f92bc3f91cb, e95595f50825",
-  "bruno-simons-20k-challenge":
-    "3 canvases in 3 shots: aa618731777f, ca8e33d30ec9, 73bfe55fd994",
-  "camera-shake": "2 canvases in 9 shots: aec6545a48a1, 1d5339483013",
-  caustics: "2 canvases in 3 shots: d1775d7e0beb, 90460cd587e1",
-  clones: "3 canvases in 3 shots: 26b4a0ef757f, 6e7394cc476f, 8e284f7877d0",
-  "gltfjsx-400kb-drone":
-    "3 canvases in 3 shots: ec0d9b2fe09d, 57c384a82886, 0bdc00ff550e",
-  "html-input-fields": "2 canvases in 3 shots: 392b03eb2d9c, adf82f519618",
-  "html-markers": "2 canvases in 3 shots: 208ab6f9aeb8, 335602fd188f",
-  "image-gallery":
-    "3 canvases in 3 shots: 8949d072482b, fba50d9b6a51, bc09175a9357",
-  "instanced-particles-effects":
-    "3 canvases in 3 shots: 3d94d4ef0d6f, 71dfd65eb4d8, 651ac53adf90",
-  "inverted-stencil-buffer":
-    "2 canvases in 6 shots: d881d7a3bd21, 23492ebc13d1",
-  "iridescent-decals": "2 canvases in 3 shots: 23111f0386cb, 1a1c9b85e77b",
-  "lusion-connectors": "2 canvases in 6 shots: 6fbdf8ea09f6, 7c36d5ccde45",
-  "mixing-html-and-webgl-w-occlusion":
-    "2 canvases in 9 shots: 795f651106ab, e351a41a74af",
-  monitors: "2 canvases in 3 shots: b88238564eb2, cb7c4d34622b",
-  motionpathcontrols: "2 canvases in 3 shots: d4e8dfd0fea7, 27cb03b86fe8",
-  portals: "2 canvases in 3 shots: 0cc8be025ed8, b7e49c963536",
-  "react-pp-outlines": "2 canvases in 3 shots: facbb0ecdd8f, b446575fa4d1",
-  "room-with-soft-shadows": "2 canvases in 3 shots: f4e044d4ec72, 304b616fc7c5",
-  "simple-physics-example-with-debug-bounds":
-    "3 canvases in 3 shots: a02c996ee4f8, 72b6f6ffa743, 05b287c017c8",
-  "space-game":
-    "3 canvases in 3 shots: 13baa491a2d3, 6824835d33ee, 4da0a1107c3e",
-  "sport-hall": "2 canvases in 6 shots: 61b6397a4653, fce5bdde00a1",
-  "springy-boxes":
-    "3 canvases in 3 shots: 651bf6641f1b, f08df57944ec, e1df6c71e657",
-  "ssgi-spheres-with-rapier-physics":
-    "2 canvases in 3 shots: b45418b5bb92, c8a9b1f2ef9d",
-  "threejs-journey-lv-1-fisheye":
-    "2 canvases in 3 shots: da4ae62c5a6b, 088d8b64a20e",
-  "thunder-clouds":
-    "3 canvases in 6 shots: 1d505dfb52cd, 635f5c4316fc, 050d7406562d",
-  "transformcontrols-and-makedefault":
-    "2 canvases in 3 shots: 463de95d6242, 6fa59a5cce08",
-  "video-cookies":
-    "3 canvases in 3 shots: b53f5b2661be, 8d64de626c18, 17446eddb86f",
-  "video-textures": "2 canvases in 6 shots: 1daa4cefebef, 8afe2467e6ba",
-  "view-tracking":
-    "3 canvases in 3 shots: e18095014d7f, 60408229779d, 008cfa4a07a6",
-  "viking-ship": "2 canvases in 3 shots: a6a037281f60, b75ddeedab49",
-  "volumetric-light-godray":
-    "3 canvases in 3 shots: a6f86faeb565, 55689a37abfb, 64b6808eb278",
-};
+export const UNPUBLISHED = {};

--- a/examples/bruno-simons-20k-challenge/src/App.tsx
+++ b/examples/bruno-simons-20k-challenge/src/App.tsx
@@ -168,7 +168,8 @@ function Hats({
     (_, i) => ({
       key: i,
       position: [rand(2) + 1, 10 + i / 2, rand(2) - 2],
-      rotation: [Math.random(), Math.random(), Math.random()],
+      // From the index, not the shared seeded sequence -- see e2e/deterministic.js
+      rotation: [spread(i), spread(i + 1), spread(i + 2)],
     }),
   );
   return (
@@ -193,4 +194,10 @@ function Hats({
       </instancedMesh>
     </InstancedRigidBodies>
   );
+}
+
+/** A repeatable stand-in for `Math.random()`, keyed on the instance. */
+function spread(n: number) {
+  const x = Math.sin(n * 12.9898) * 43758.5453;
+  return x - Math.floor(x);
 }

--- a/examples/clones/src/Room.tsx
+++ b/examples/clones/src/Room.tsx
@@ -111,14 +111,21 @@ function Lights() {
   const light = useRef<THREE.SpotLight>(null!);
   const [color] = useState(() => new THREE.Color("white"));
   const { nodes } = useGLTF(sceneModel) as unknown as GLTFResult;
-  useEffect(() => {
-    const timeout = setInterval(
-      () => color.setRGB(Math.random(), Math.random(), Math.random()),
-      3000,
-    );
-    return () => clearInterval(timeout);
-  }, []);
+  //
+  // Counted in frames rather than seconds, and drawn from a cycle rather than
+  // `Math.random()`. Both for the same reason: on a `setInterval`, the light had
+  // already been recoloured a machine-dependent number of times by the time the
+  // scene was first drawn, and each draw pulled from a shared random sequence
+  // that three.js also consumes -- four values per object it creates -- so no
+  // two loads agreed. Every 180 frames is the same three seconds at 60fps.
+  //
+  const tick = useRef(0);
   useFrame(() => {
+    if (tick.current++ % 180 === 0) {
+      const hue = ((tick.current / 180) * 0.618) % 1; // golden angle: spread, repeatable
+      color.setHSL(hue, 0.8, 0.55);
+    }
+
     light.current.color.lerp(color, 0.01);
     ref.current.traverse(
       (obj) =>

--- a/examples/gltf-animations-re-used/src/Model.tsx
+++ b/examples/gltf-animations-re-used/src/Model.tsx
@@ -65,9 +65,11 @@ export default function Model({ pose, ...props }: ModelProps) {
   useEffect(() => {
     // Reset and fade in animation after an index has been changed
     actions[names[index]]!.reset().fadeIn(0.5).play();
-    // In the clean-up phase, fade it out
+    // In the clean-up phase, fade it out. On unmount the hook has already
+    // uncached the action, so the lookup can come back empty -- and a cleanup
+    // that throws takes the whole React root down with it.
     return () => {
-      actions[names[index]]!.fadeOut(0.5);
+      actions[names[index]]?.fadeOut(0.5);
     };
   }, [index, actions, names]);
 

--- a/examples/gltf-animations/src/Model.tsx
+++ b/examples/gltf-animations/src/Model.tsx
@@ -45,8 +45,10 @@ export default function Model(props: ThreeElements["group"]) {
   useEffect(() => {
     // Reset and fade in animation after an index has been changed
     actions[names[index]]!.reset().fadeIn(0.5).play();
-    // In the clean-up phase, fade it out
-    return () => void actions[names[index]]!.fadeOut(0.5);
+    // In the clean-up phase, fade it out. On unmount the hook has already
+    // uncached the action, so the lookup can come back empty -- and a cleanup
+    // that throws takes the whole React root down with it.
+    return () => void actions[names[index]]?.fadeOut(0.5);
   }, [index, actions, names]);
 
   useFrame((state, delta) => {

--- a/examples/image-gallery/src/App.tsx
+++ b/examples/image-gallery/src/App.tsx
@@ -14,6 +14,26 @@ import getUuid from "uuid-by-string";
 
 const GOLDENRATIO = 1.61803398875;
 
+//
+// Not `Math.random()`, and the reason is not style.
+//
+// The harness seeds `Math.random` so the sequence is fixed -- but every three.js
+// object, material, geometry and texture draws four values from that same
+// sequence for a UUID, and the order they are created in follows the order
+// assets happen to arrive. So a card that draws after a texture resolved gets a
+// different number than one that drew before, and the gallery laid itself out
+// differently on every run.
+//
+// Deriving it from the image URL removes the question: the same card gets the
+// same number whenever it mounts.
+//
+function stableRandom(key: string) {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++)
+    h = Math.imul(h ^ key.charCodeAt(i), 16777619);
+  return ((h >>> 0) % 10000) / 10000;
+}
+
 export type ImageData = {
   position: [number, number, number];
   rotation: [number, number, number];
@@ -105,7 +125,7 @@ function Frame({
   >(null!);
   const [, params] = useRoute("/item/:id");
   const [hovered, hover] = useState(false);
-  const [rnd] = useState(() => Math.random());
+  const [rnd] = useState(() => stableRandom(url));
   const name = getUuid(url);
   const isActive = params?.id === name;
   useCursor(hovered);

--- a/examples/monitors/src/Computers.tsx
+++ b/examples/monitors/src/Computers.tsx
@@ -869,7 +869,7 @@ function ScreenText({
     "children"
   >) {
   const textRef = useRef<THREE.Mesh>(null!);
-  const rand = Math.random() * 10000;
+  const rand = stablePhase(props.frame); // not Math.random(): see the note below
   useFrame(
     (state) =>
       (textRef.current.position.x =
@@ -996,4 +996,19 @@ function Leds({ instances }: { instances: Instance }) {
       />
     </group>
   );
+}
+
+//
+// A phase offset that depends on which screen this is, not on when it mounted.
+//
+// `Math.random()` looks harmless here -- it only spreads the screens' text out
+// of sync. But three.js draws four values from the same seeded sequence for
+// every object it creates, so where this call lands in that sequence follows
+// the order assets happened to resolve, and the offsets differed on every run.
+//
+function stablePhase(key: string) {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++)
+    h = Math.imul(h ^ key.charCodeAt(i), 16777619);
+  return (h >>> 0) % 10000;
 }

--- a/examples/simple-physics-example-with-debug-bounds/src/App.tsx
+++ b/examples/simple-physics-example-with-debug-bounds/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { Canvas } from "@react-three/fiber";
+import React, { useState, useRef } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
 import {
   Physics,
   Debug,
@@ -52,10 +52,25 @@ function CompoundBody(props: BodyProps) {
   );
 }
 
-export default function () {
-  // Mount a 3rd <CompoundBody /> object after 2 seconds
+// Mounts its children after `seconds` of *scene* time. A wall-clock
+// setTimeout lands whenever the machine gets there; counting through
+// useFrame keeps the two-second entrance exact at any refresh rate.
+function MountAfter({
+  seconds,
+  children,
+}: {
+  seconds: number;
+  children: React.ReactNode;
+}) {
   const [flag, set] = useState(false);
-  useEffect(() => void setTimeout(() => set(true), 2000), []);
+  const elapsed = useRef(0);
+  useFrame((_, delta) => {
+    if (!flag && (elapsed.current += delta) >= seconds) set(true);
+  });
+  return flag ? <>{children}</> : null;
+}
+
+export default function () {
   return (
     <Canvas
       dpr={[1, 2]}
@@ -80,12 +95,13 @@ export default function () {
           <Plane rotation={[-Math.PI / 2, 0, 0]} />
           <CompoundBody position={[1.5, 5, 0.5]} rotation={[1.25, 0, 0]} />
           <CompoundBody position={[2.5, 3, 0.25]} rotation={[1.25, -1.25, 0]} />
-          {flag && (
+          {/* A third body makes its entrance after 2 seconds */}
+          <MountAfter seconds={2}>
             <CompoundBody
               position={[2.5, 4, 0.25]}
               rotation={[1.25, -1.25, 0]}
             />
-          )}
+          </MountAfter>
         </Debug>
       </Physics>
     </Canvas>

--- a/examples/springy-boxes/src/index.tsx
+++ b/examples/springy-boxes/src/index.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from "react-dom/client";
 import * as THREE from "three";
-import React, { useEffect } from "react";
-import { Canvas, type ThreeElements } from "@react-three/fiber";
+import React, { useRef } from "react";
+import { Canvas, useFrame, type ThreeElements } from "@react-three/fiber";
 import { useSprings, a, type AnimatedProps } from "@react-spring/three";
 import "./styles.css";
 
@@ -45,14 +45,17 @@ function Content() {
     ...random(i),
     config: { mass: 20, tension: 150, friction: 50 },
   }));
-  useEffect(
-    () =>
-      void setInterval(
-        () => set((i) => ({ ...random(i), delay: i * 40 })),
-        3000,
-      ),
-    [],
-  );
+  // Every 3s of *scene* time, not a wall-clock interval: a real timer set at
+  // mount fires whenever the machine gets there, and it was never cleared, so
+  // each mount stacked another one.
+  const elapsed = useRef(0);
+  useFrame((_, delta) => {
+    elapsed.current += delta;
+    if (elapsed.current >= 3) {
+      elapsed.current = 0;
+      set((i) => ({ ...random(i), delay: i * 40 }));
+    }
+  });
   return data.map((d, index) => (
     <a.mesh
       key={index}

--- a/examples/ssgi-spheres-with-rapier-physics/src/realism-effects/v2.js
+++ b/examples/ssgi-spheres-with-rapier-physics/src/realism-effects/v2.js
@@ -790,18 +790,32 @@ class GBufferPass extends Pass {
 
 var fragmentShader$6 = "#define GLSLIFY 1\nvarying vec2 vUv;uniform sampler2D accumulatedTexture;uniform highp sampler2D depthTexture;uniform highp sampler2D velocityTexture;uniform sampler2D directLightTexture;uniform vec3 backgroundColor;uniform mat4 projectionMatrix;uniform mat4 projectionMatrixInverse;uniform mat4 cameraMatrixWorld;uniform float maxEnvMapMipLevel;uniform float rayDistance;uniform float thickness;uniform float envBlur;uniform vec2 resolution;uniform float cameraNear;uniform float cameraFar;uniform float nearMinusFar;uniform float nearMulFar;uniform float farMinusNear;struct EquirectHdrInfo{sampler2D marginalWeights;sampler2D conditionalWeights;sampler2D map;vec2 size;float totalSumWhole;float totalSumDecimal;};uniform EquirectHdrInfo envMapInfo;\n#define INVALID_RAY_COORDS vec2(-1.0);\n#define EPSILON 0.00001\n#define ONE_MINUS_EPSILON 1.0 - EPSILON\nvec2 invTexSize;\n#define MODE_SSGI 0\n#define MODE_SSR 1\n#include <packing>\n#include <gbuffer_packing>\n#include <ssgi_utils>\nvec2 RayMarch(inout vec3 dir,inout vec3 hitPos,vec4 random);vec2 BinarySearch(inout vec3 dir,inout vec3 hitPos);struct RayTracingInfo{float NoV;float NoL;float NoH;float LoH;float VoH;bool isDiffuseSample;bool isEnvSample;};struct RayTracingResult{vec3 gi;vec3 l;vec3 hitPos;bool isMissedRay;vec3 brdf;float pdf;};struct EnvMisSample{float pdf;float probability;bool isEnvSample;};vec3 worldNormal;vec3 doSample(const vec3 viewPos,const vec3 viewDir,const vec3 viewNormal,const vec3 worldPos,const float metalness,const float roughness,const bool isDiffuseSample,const bool isEnvSample,const float NoV,const float NoL,const float NoH,const float LoH,const float VoH,const vec4 random,inout vec3 l,inout vec3 hitPos,out bool isMissedRay,out vec3 brdf,out float pdf);void calculateAngles(inout vec3 h,inout vec3 l,inout vec3 v,inout vec3 n,inout float NoL,inout float NoH,inout float LoH,inout float VoH){h=normalize(v+l);NoL=clamp(dot(n,l),EPSILON,ONE_MINUS_EPSILON);NoH=clamp(dot(n,h),EPSILON,ONE_MINUS_EPSILON);LoH=clamp(dot(l,h),EPSILON,ONE_MINUS_EPSILON);VoH=clamp(dot(v,h),EPSILON,ONE_MINUS_EPSILON);}vec3 worldPos;Material mat;void main(){float unpackedDepth=textureLod(depthTexture,vUv,0.0).r;if(unpackedDepth==1.0){vec4 directLight=textureLod(directLightTexture,vUv,0.0);gl_FragColor=packTwoVec4(directLight,directLight);return;}mat=getMaterial(gBufferTexture,vUv);float roughnessSq=clamp(mat.roughness*mat.roughness,0.000001,1.0);invTexSize=1./resolution;float viewZ=getViewZ(unpackedDepth);vec3 viewPos=getViewPosition(viewZ);vec3 viewDir=normalize(viewPos);worldNormal=mat.normal;vec3 viewNormal=normalize((vec4(worldNormal,0.)*cameraMatrixWorld).xyz);worldPos=(cameraMatrixWorld*vec4(viewPos,1.)).xyz;vec3 n=viewNormal;vec3 v=-viewDir;float NoV=max(EPSILON,dot(n,v));vec3 V=(vec4(v,0.)*viewMatrix).xyz;vec3 N=worldNormal;vec4 random;vec3 H,l,h,F,T,B,envMisDir,gi;vec3 diffuseGI,specularGI,brdf,hitPos,specularHitPos;Onb(N,T,B);V=ToLocal(T,B,N,V);vec3 f0=mix(vec3(0.04),mat.diffuse.rgb,mat.metalness);float NoL,NoH,LoH,VoH,diffW,specW,invW,pdf,envPdf,diffuseSamples,specularSamples;bool isDiffuseSample,isEnvSample,isMissedRay;random=blueNoise();H=SampleGGXVNDF(V,roughnessSq,roughnessSq,random.r,random.g);if(H.z<0.0)H=-H;l=normalize(reflect(-V,H));l=ToWorld(T,B,N,l);l=(vec4(l,0.)*cameraMatrixWorld).xyz;l=normalize(l);calculateAngles(h,l,v,n,NoL,NoH,LoH,VoH);\n#if mode == MODE_SSGI\nF=F_Schlick(f0,VoH);diffW=(1.-mat.metalness)*luminance(mat.diffuse.rgb);specW=luminance(F);diffW=max(diffW,EPSILON);specW=max(specW,EPSILON);invW=1./(diffW+specW);diffW*=invW;isDiffuseSample=random.b<diffW;\n#else\nisDiffuseSample=false;\n#endif\nEnvMisSample ems;ems.pdf=1.;envMisDir=vec3(0.0);envPdf=1.;\n#ifdef importanceSampling\nems.pdf=sampleEquirectProbability(envMapInfo,random.rg,envMisDir);envMisDir=normalize((vec4(envMisDir,0.)*cameraMatrixWorld).xyz);ems.probability=dot(envMisDir,viewNormal);ems.probability*=mat.roughness;ems.probability=min(ONE_MINUS_EPSILON,ems.probability);ems.isEnvSample=random.a<ems.probability;if(ems.isEnvSample){ems.pdf/=1.-ems.probability;l=envMisDir;calculateAngles(h,l,v,n,NoL,NoH,LoH,VoH);}else{ems.pdf=1.-ems.probability;}\n#endif\nvec3 diffuseRay=ems.isEnvSample ? envMisDir : cosineSampleHemisphere(viewNormal,random.rg);vec3 specularRay=ems.isEnvSample ? envMisDir : l;\n#if mode == MODE_SSGI\nif(isDiffuseSample){l=diffuseRay;calculateAngles(h,l,v,n,NoL,NoH,LoH,VoH);gi=doSample(viewPos,viewDir,viewNormal,worldPos,mat.metalness,roughnessSq,isDiffuseSample,ems.isEnvSample,NoV,NoL,NoH,LoH,VoH,random,l,hitPos,isMissedRay,brdf,pdf);gi*=brdf;if(ems.isEnvSample){gi*=misHeuristic(ems.pdf,pdf);}else{gi/=pdf;}gi/=ems.pdf;diffuseSamples++;diffuseGI=mix(diffuseGI,gi,1./diffuseSamples);}\n#endif\nl=specularRay;calculateAngles(h,l,v,n,NoL,NoH,LoH,VoH);gi=doSample(viewPos,viewDir,viewNormal,worldPos,mat.metalness,roughnessSq,isDiffuseSample,ems.isEnvSample,NoV,NoL,NoH,LoH,VoH,random,l,hitPos,isMissedRay,brdf,pdf);gi*=brdf;if(ems.isEnvSample){gi*=misHeuristic(ems.pdf,pdf);}else{gi/=pdf;}gi/=ems.pdf;specularHitPos=hitPos;specularSamples++;specularGI=mix(specularGI,gi,1./specularSamples);\n#ifdef useDirectLight\nvec3 directLight=textureLod(directLightTexture,vUv,0.).rgb;diffuseGI+=directLight;specularGI+=directLight;\n#endif\nhighp vec4 gDiffuse,gSpecular;\n#if mode == MODE_SSGI\nif(diffuseSamples==0.0)diffuseGI=vec3(-1.0);gDiffuse=vec4(diffuseGI,mat.roughness);\n#endif\nhighp float rayLength=0.0;vec4 hitPosWS;vec3 cameraPosWS=cameraMatrixWorld[3].xyz;isMissedRay=hitPos.x>10.0e8;if(!isMissedRay){hitPosWS=cameraMatrixWorld*vec4(specularHitPos,1.0);rayLength=distance(cameraPosWS,hitPosWS.xyz);}highp uint packedRoughnessRayLength=packHalf2x16(vec2(rayLength,mat.roughness));highp float a=uintBitsToFloat(packedRoughnessRayLength);\n#if mode == MODE_SSGI\ngSpecular=vec4(specularGI,rayLength);gl_FragColor=packTwoVec4(gDiffuse,gSpecular);\n#else\ngSpecular=vec4(specularGI,a);gl_FragColor=gSpecular;\n#endif\n}vec3 getEnvColor(vec3 l,vec3 worldPos,float roughness,bool isDiffuseSample,bool isEnvSample){vec3 envMapSample;\n#ifdef USE_ENVMAP\nvec3 reflectedWS=normalize((vec4(l,0.)*viewMatrix).xyz);\n#ifdef BOX_PROJECTED_ENV_MAP\nreflectedWS=parallaxCorrectNormal(reflectedWS.xyz,envMapSize,envMapPosition,worldPos);reflectedWS=normalize(reflectedWS.xyz);\n#endif\nfloat mip=envBlur*maxEnvMapMipLevel;if(!isDiffuseSample&&roughness<0.15)mip*=roughness/0.15;envMapSample=sampleEquirectEnvMapColor(reflectedWS,envMapInfo.map,mip);float maxEnvLum=isEnvSample ? 100.0 : 25.0;if(maxEnvLum!=0.0){float envLum=luminance(envMapSample);if(envLum>maxEnvLum){envMapSample*=maxEnvLum/envLum;}}return envMapSample;\n#else\nreturn vec3(0.0);\n#endif\n}float getSaturation(vec3 c){float maxComponent=max(max(c.r,c.g),c.b);float minComponent=min(min(c.r,c.g),c.b);float delta=maxComponent-minComponent;if(maxComponent==minComponent){return 0.0;}else{return delta/maxComponent;}}vec3 doSample(const vec3 viewPos,const vec3 viewDir,const vec3 viewNormal,const vec3 worldPos,const float metalness,const float roughness,const bool isDiffuseSample,const bool isEnvSample,const float NoV,const float NoL,const float NoH,const float LoH,const float VoH,const vec4 random,inout vec3 l,inout vec3 hitPos,out bool isMissedRay,out vec3 brdf,out float pdf){float cosTheta=max(0.0,dot(viewNormal,l));if(isDiffuseSample){vec3 diffuseBrdf=evalDisneyDiffuse(NoL,NoV,LoH,roughness,metalness);pdf=NoL/M_PI;brdf=diffuseBrdf;}else{vec3 specularBrdf=evalDisneySpecular(roughness,NoH,NoV,NoL);pdf=GGXVNDFPdf(NoH,NoV,roughness);brdf=specularBrdf;}brdf*=cosTheta;pdf=max(EPSILON,pdf);hitPos=viewPos;vec2 coords=RayMarch(l,hitPos,random);bool allowMissedRays=false;\n#ifdef missedRays\nallowMissedRays=true;\n#endif\nisMissedRay=hitPos.x==10.0e9;vec3 envMapSample=vec3(0.);if(isMissedRay&&!allowMissedRays)return getEnvColor(l,worldPos,roughness,isDiffuseSample,isEnvSample);vec4 velocity=textureLod(velocityTexture,coords.xy,0.0);vec2 reprojectedUv=coords.xy-velocity.xy;vec3 SSGI;vec3 envColor=getEnvColor(l,worldPos,roughness,isDiffuseSample,isEnvSample);if(reprojectedUv.x>=0.0&&reprojectedUv.x<=1.0&&reprojectedUv.y>=0.0&&reprojectedUv.y<=1.0){vec4 reprojectedGI=textureLod(accumulatedTexture,reprojectedUv,0.);float saturation=getSaturation(mat.diffuse.rgb);reprojectedGI.rgb=mix(reprojectedGI.rgb,vec3(luminance(reprojectedGI.rgb)),(1.-roughness)*saturation*0.4);SSGI=reprojectedGI.rgb;float aspect=resolution.x/resolution.y;float border=0.15;float borderFactor=smoothstep(0.0,border,coords.x)*smoothstep(1.0,1.0-border,coords.x)*smoothstep(0.0,border,coords.y)*smoothstep(1.0,1.0-border,coords.y);borderFactor=sqrt(borderFactor);SSGI=mix(envColor,SSGI,borderFactor);}else{return envColor;}if(allowMissedRays){float ssgiLum=luminance(SSGI);float envLum=luminance(envMapSample);if(envLum>ssgiLum)SSGI=envMapSample;}return SSGI;}vec2 RayMarch(inout vec3 dir,inout vec3 hitPos,vec4 random){float rayHitDepthDifference;dir*=rayDistance/float(steps);vec2 uv;for(int i=1;i<steps;i++){float cs=1.-exp(-0.25*pow(float(i)+random.b-0.5,2.));hitPos+=dir*cs;uv=viewSpaceToScreenSpace(hitPos);float unpackedDepth=textureLod(depthTexture,uv,0.0).r;float z=getViewZ(unpackedDepth);rayHitDepthDifference=z-hitPos.z;if(rayHitDepthDifference>=0.0&&rayHitDepthDifference<thickness){if(refineSteps==0){return uv;}else{return BinarySearch(dir,hitPos);}}}hitPos.xyz=vec3(10.0e9);return uv;}vec2 BinarySearch(inout vec3 dir,inout vec3 hitPos){float rayHitDepthDifference;vec2 uv;dir*=0.5;hitPos-=dir;for(int i=0;i<refineSteps;i++){uv=viewSpaceToScreenSpace(hitPos);float unpackedDepth=textureLod(depthTexture,uv,0.0).r;float z=getViewZ(unpackedDepth);rayHitDepthDifference=z-hitPos.z;dir*=0.5;if(rayHitDepthDifference>=0.0){hitPos-=dir;}else{hitPos+=dir;}}uv=viewSpaceToScreenSpace(hitPos);return uv;}"; // eslint-disable-line
 
-var ssgi_utils = "#define GLSLIFY 1\n#define PI M_PI\n#define luminance(a) dot(vec3(0.2125, 0.7154, 0.0721), a)\nfloat getViewZ(const in float depth){\n#ifdef PERSPECTIVE_CAMERA\nreturn nearMulFar/(farMinusNear*depth-cameraFar);\n#else\nreturn depth*nearMinusFar-cameraNear;\n#endif\n}vec3 getViewPosition(float viewZ){float clipW=projectionMatrix[2][3]*viewZ+projectionMatrix[3][3];vec4 clipPosition=vec4((vec3(vUv,viewZ)-0.5)*2.0,1.0);clipPosition*=clipW;vec3 p=(projectionMatrixInverse*clipPosition).xyz;p.z=viewZ;return p;}vec2 viewSpaceToScreenSpace(const vec3 position){vec4 projectedCoord=projectionMatrix*vec4(position,1.0);projectedCoord.xy/=projectedCoord.w;projectedCoord.xy=projectedCoord.xy*0.5+0.5;return projectedCoord.xy;}vec3 worldSpaceToViewSpace(vec3 worldPosition){vec4 viewPosition=viewMatrix*vec4(worldPosition,1.0);return viewPosition.xyz/viewPosition.w;}\n#ifdef BOX_PROJECTED_ENV_MAP\nuniform vec3 envMapSize;uniform vec3 envMapPosition;vec3 parallaxCorrectNormal(const vec3 v,const vec3 cubeSize,const vec3 cubePos,const vec3 worldPosition){vec3 nDir=normalize(v);vec3 rbmax=(.5*cubeSize+cubePos-worldPosition)/nDir;vec3 rbmin=(-.5*cubeSize+cubePos-worldPosition)/nDir;vec3 rbminmax;rbminmax.x=(nDir.x>0.)? rbmax.x : rbmin.x;rbminmax.y=(nDir.y>0.)? rbmax.y : rbmin.y;rbminmax.z=(nDir.z>0.)? rbmax.z : rbmin.z;float correction=min(min(rbminmax.x,rbminmax.y),rbminmax.z);vec3 boxIntersection=worldPosition+nDir*correction;return boxIntersection-cubePos;}\n#endif\n#define M_PI 3.1415926535897932384626433832795\nvec2 equirectDirectionToUv(const vec3 direction){vec2 uv=vec2(atan(direction.z,direction.x),acos(direction.y));uv/=vec2(2.0*M_PI,M_PI);uv.x+=0.5;uv.y=1.0-uv.y;return uv;}vec3 equirectUvToDirection(vec2 uv){uv.x-=0.5;uv.y=1.0-uv.y;float theta=uv.x*2.0*PI;float phi=uv.y*PI;float sinPhi=sin(phi);return vec3(sinPhi*cos(theta),cos(phi),sinPhi*sin(theta));}vec3 sampleEquirectEnvMapColor(const vec3 direction,const sampler2D map,const float lod){return textureLod(map,equirectDirectionToUv(direction),lod).rgb;}mat3 getBasisFromNormal(const vec3 normal){vec3 other;if(abs(normal.x)>0.5){other=vec3(0.0,1.0,0.0);}else{other=vec3(1.0,0.0,0.0);}vec3 ortho=normalize(cross(normal,other));vec3 ortho2=normalize(cross(normal,ortho));return mat3(ortho2,ortho,normal);}vec3 F_Schlick(const vec3 f0,const float theta){return f0+(1.-f0)*pow(1.0-theta,5.);}float F_Schlick(const float f0,const float f90,const float theta){return f0+(f90-f0)*pow(1.0-theta,5.0);}float D_GTR(const float roughness,const float NoH,const float k){float a2=pow(roughness,2.);return a2/(PI*pow((NoH*NoH)*(a2*a2-1.)+1.,k));}float SmithG(const float NDotV,const float alphaG){float a=alphaG*alphaG;float b=NDotV*NDotV;return(2.0*NDotV)/(NDotV+sqrt(a+b-a*b));}float GGXVNDFPdf(const float NoH,const float NoV,const float roughness){float D=D_GTR(roughness,NoH,2.);float G1=SmithG(NoV,roughness*roughness);return(D*G1)/max(0.00001,4.0*NoV);}float GeometryTerm(const float NoL,const float NoV,const float roughness){float a2=roughness*roughness;float G1=SmithG(NoV,a2);float G2=SmithG(NoL,a2);return G1*G2;}vec3 evalDisneyDiffuse(const float NoL,const float NoV,const float LoH,const float roughness,const float metalness){float FD90=0.5+2.*roughness*pow(LoH,2.);float a=F_Schlick(1.,FD90,NoL);float b=F_Schlick(1.,FD90,NoV);return vec3((a*b/PI)*(1.-metalness));}vec3 evalDisneySpecular(const float roughness,const float NoH,const float NoV,const float NoL){float D=D_GTR(roughness,NoH,2.);float G=GeometryTerm(NoL,NoV,pow(0.5+roughness*.5,2.));vec3 spec=vec3(D*G/(4.*NoL*NoV));return spec;}vec3 SampleGGXVNDF(const vec3 V,const float ax,const float ay,const float r1,const float r2){vec3 Vh=normalize(vec3(ax*V.x,ay*V.y,V.z));float lensq=Vh.x*Vh.x+Vh.y*Vh.y;vec3 T1=lensq>0. ? vec3(-Vh.y,Vh.x,0.)*inversesqrt(lensq): vec3(1.,0.,0.);vec3 T2=cross(Vh,T1);float r=sqrt(r1);float phi=2.0*PI*r2;float t1=r*cos(phi);float t2=r*sin(phi);float s=0.5*(1.0+Vh.z);t2=(1.0-s)*sqrt(1.0-t1*t1)+s*t2;vec3 Nh=t1*T1+t2*T2+sqrt(max(0.0,1.0-t1*t1-t2*t2))*Vh;return normalize(vec3(ax*Nh.x,ay*Nh.y,max(0.0,Nh.z)));}void Onb(const vec3 N,inout vec3 T,inout vec3 B){vec3 up=abs(N.z)<0.9999999 ? vec3(0,0,1): vec3(1,0,0);T=normalize(cross(up,N));B=cross(N,T);}vec3 ToLocal(const vec3 X,const vec3 Y,const vec3 Z,const vec3 V){return vec3(dot(V,X),dot(V,Y),dot(V,Z));}vec3 ToWorld(const vec3 X,const vec3 Y,const vec3 Z,const vec3 V){return V.x*X+V.y*Y+V.z*Z;}vec3 cosineSampleHemisphere(const vec3 n,const vec2 u){float r=sqrt(u.x);float theta=2.0*PI*u.y;vec3 b=normalize(cross(n,vec3(0.0,1.0,1.0)));vec3 t=cross(b,n);return normalize(r*sin(theta)*b+sqrt(1.0-u.x)*n+r*cos(theta)*t);}float equirectDirectionPdf(vec3 direction){vec2 uv=equirectDirectionToUv(direction);float theta=uv.y*PI;float sinTheta=sin(theta);if(sinTheta==0.0){return 0.0;}return 1.0/(2.0*PI*PI*sinTheta);}float sampleEquirectProbability(EquirectHdrInfo info,vec2 blueNoise,out vec3 direction){float v=textureLod(info.marginalWeights,vec2(blueNoise.x,0.0),0.).x;float u=textureLod(info.conditionalWeights,vec2(blueNoise.y,v),0.).x;vec2 uv=vec2(u,v);vec3 derivedDirection=equirectUvToDirection(uv);direction=derivedDirection;vec3 color=texture(info.map,uv).rgb;float totalSum=info.totalSumWhole+info.totalSumDecimal;float lum=luminance(color);float pdf=lum/totalSum;return info.size.x*info.size.y*pdf;}float misHeuristic(float a,float b){float aa=a*a;float bb=b*b;return aa/(aa+bb);}vec3 alignToNormal(const vec3 normal,const vec3 direction){vec3 tangent;vec3 bitangent;Onb(normal,tangent,bitangent);vec3 localDir=ToLocal(tangent,bitangent,normal,direction);vec3 localDirAligned=vec3(localDir.x,localDir.y,abs(localDir.z));vec3 alignedDir=ToWorld(tangent,bitangent,normal,localDirAligned);return alignedDir;}float getFlatness(vec3 g,vec3 rp){vec3 gw=fwidth(g);vec3 pw=fwidth(rp);float wfcurvature=length(gw)/length(pw);wfcurvature=smoothstep(0.0,30.,wfcurvature);return clamp(wfcurvature,0.,1.);}"; // eslint-disable-line
+//
+// `sampleEquirectProbability` used to read the env map with `texture()` --
+// automatic LOD, from screen-space derivatives. It runs behind the shader's
+// early `return` for sky pixels, i.e. in non-uniform control flow, where the
+// spec leaves those derivatives undefined: on quads straddling a sphere
+// silhouette the helper lanes have already returned, and SwiftShader fills
+// their registers with whatever the worker thread last held -- so the mip
+// level chosen there varies run to run, and with it one or two silhouette
+// pixels of the SSGI buffer. `spp: 1` accumulation then never averages the
+// flicker away, and the snapshot lands on a different canvas per run
+// (measured: 4 distinct md5s over 9 cold shots; re-executing the identical
+// draw in one run gave 4 distinct buffers). Explicit LOD reads mip 0
+// unconditionally -- no derivatives, deterministic on every backend, and the
+// only consumer of this sample is the MIS pdf estimate, which never wanted a
+// derivative-picked mip in the first place.
+//
+var ssgi_utils = "#define GLSLIFY 1\n#define PI M_PI\n#define luminance(a) dot(vec3(0.2125, 0.7154, 0.0721), a)\nfloat getViewZ(const in float depth){\n#ifdef PERSPECTIVE_CAMERA\nreturn nearMulFar/(farMinusNear*depth-cameraFar);\n#else\nreturn depth*nearMinusFar-cameraNear;\n#endif\n}vec3 getViewPosition(float viewZ){float clipW=projectionMatrix[2][3]*viewZ+projectionMatrix[3][3];vec4 clipPosition=vec4((vec3(vUv,viewZ)-0.5)*2.0,1.0);clipPosition*=clipW;vec3 p=(projectionMatrixInverse*clipPosition).xyz;p.z=viewZ;return p;}vec2 viewSpaceToScreenSpace(const vec3 position){vec4 projectedCoord=projectionMatrix*vec4(position,1.0);projectedCoord.xy/=projectedCoord.w;projectedCoord.xy=projectedCoord.xy*0.5+0.5;return projectedCoord.xy;}vec3 worldSpaceToViewSpace(vec3 worldPosition){vec4 viewPosition=viewMatrix*vec4(worldPosition,1.0);return viewPosition.xyz/viewPosition.w;}\n#ifdef BOX_PROJECTED_ENV_MAP\nuniform vec3 envMapSize;uniform vec3 envMapPosition;vec3 parallaxCorrectNormal(const vec3 v,const vec3 cubeSize,const vec3 cubePos,const vec3 worldPosition){vec3 nDir=normalize(v);vec3 rbmax=(.5*cubeSize+cubePos-worldPosition)/nDir;vec3 rbmin=(-.5*cubeSize+cubePos-worldPosition)/nDir;vec3 rbminmax;rbminmax.x=(nDir.x>0.)? rbmax.x : rbmin.x;rbminmax.y=(nDir.y>0.)? rbmax.y : rbmin.y;rbminmax.z=(nDir.z>0.)? rbmax.z : rbmin.z;float correction=min(min(rbminmax.x,rbminmax.y),rbminmax.z);vec3 boxIntersection=worldPosition+nDir*correction;return boxIntersection-cubePos;}\n#endif\n#define M_PI 3.1415926535897932384626433832795\nvec2 equirectDirectionToUv(const vec3 direction){vec2 uv=vec2(atan(direction.z,direction.x),acos(direction.y));uv/=vec2(2.0*M_PI,M_PI);uv.x+=0.5;uv.y=1.0-uv.y;return uv;}vec3 equirectUvToDirection(vec2 uv){uv.x-=0.5;uv.y=1.0-uv.y;float theta=uv.x*2.0*PI;float phi=uv.y*PI;float sinPhi=sin(phi);return vec3(sinPhi*cos(theta),cos(phi),sinPhi*sin(theta));}vec3 sampleEquirectEnvMapColor(const vec3 direction,const sampler2D map,const float lod){return textureLod(map,equirectDirectionToUv(direction),lod).rgb;}mat3 getBasisFromNormal(const vec3 normal){vec3 other;if(abs(normal.x)>0.5){other=vec3(0.0,1.0,0.0);}else{other=vec3(1.0,0.0,0.0);}vec3 ortho=normalize(cross(normal,other));vec3 ortho2=normalize(cross(normal,ortho));return mat3(ortho2,ortho,normal);}vec3 F_Schlick(const vec3 f0,const float theta){return f0+(1.-f0)*pow(1.0-theta,5.);}float F_Schlick(const float f0,const float f90,const float theta){return f0+(f90-f0)*pow(1.0-theta,5.0);}float D_GTR(const float roughness,const float NoH,const float k){float a2=pow(roughness,2.);return a2/(PI*pow((NoH*NoH)*(a2*a2-1.)+1.,k));}float SmithG(const float NDotV,const float alphaG){float a=alphaG*alphaG;float b=NDotV*NDotV;return(2.0*NDotV)/(NDotV+sqrt(a+b-a*b));}float GGXVNDFPdf(const float NoH,const float NoV,const float roughness){float D=D_GTR(roughness,NoH,2.);float G1=SmithG(NoV,roughness*roughness);return(D*G1)/max(0.00001,4.0*NoV);}float GeometryTerm(const float NoL,const float NoV,const float roughness){float a2=roughness*roughness;float G1=SmithG(NoV,a2);float G2=SmithG(NoL,a2);return G1*G2;}vec3 evalDisneyDiffuse(const float NoL,const float NoV,const float LoH,const float roughness,const float metalness){float FD90=0.5+2.*roughness*pow(LoH,2.);float a=F_Schlick(1.,FD90,NoL);float b=F_Schlick(1.,FD90,NoV);return vec3((a*b/PI)*(1.-metalness));}vec3 evalDisneySpecular(const float roughness,const float NoH,const float NoV,const float NoL){float D=D_GTR(roughness,NoH,2.);float G=GeometryTerm(NoL,NoV,pow(0.5+roughness*.5,2.));vec3 spec=vec3(D*G/(4.*NoL*NoV));return spec;}vec3 SampleGGXVNDF(const vec3 V,const float ax,const float ay,const float r1,const float r2){vec3 Vh=normalize(vec3(ax*V.x,ay*V.y,V.z));float lensq=Vh.x*Vh.x+Vh.y*Vh.y;vec3 T1=lensq>0. ? vec3(-Vh.y,Vh.x,0.)*inversesqrt(lensq): vec3(1.,0.,0.);vec3 T2=cross(Vh,T1);float r=sqrt(r1);float phi=2.0*PI*r2;float t1=r*cos(phi);float t2=r*sin(phi);float s=0.5*(1.0+Vh.z);t2=(1.0-s)*sqrt(1.0-t1*t1)+s*t2;vec3 Nh=t1*T1+t2*T2+sqrt(max(0.0,1.0-t1*t1-t2*t2))*Vh;return normalize(vec3(ax*Nh.x,ay*Nh.y,max(0.0,Nh.z)));}void Onb(const vec3 N,inout vec3 T,inout vec3 B){vec3 up=abs(N.z)<0.9999999 ? vec3(0,0,1): vec3(1,0,0);T=normalize(cross(up,N));B=cross(N,T);}vec3 ToLocal(const vec3 X,const vec3 Y,const vec3 Z,const vec3 V){return vec3(dot(V,X),dot(V,Y),dot(V,Z));}vec3 ToWorld(const vec3 X,const vec3 Y,const vec3 Z,const vec3 V){return V.x*X+V.y*Y+V.z*Z;}vec3 cosineSampleHemisphere(const vec3 n,const vec2 u){float r=sqrt(u.x);float theta=2.0*PI*u.y;vec3 b=normalize(cross(n,vec3(0.0,1.0,1.0)));vec3 t=cross(b,n);return normalize(r*sin(theta)*b+sqrt(1.0-u.x)*n+r*cos(theta)*t);}float equirectDirectionPdf(vec3 direction){vec2 uv=equirectDirectionToUv(direction);float theta=uv.y*PI;float sinTheta=sin(theta);if(sinTheta==0.0){return 0.0;}return 1.0/(2.0*PI*PI*sinTheta);}float sampleEquirectProbability(EquirectHdrInfo info,vec2 blueNoise,out vec3 direction){float v=textureLod(info.marginalWeights,vec2(blueNoise.x,0.0),0.).x;float u=textureLod(info.conditionalWeights,vec2(blueNoise.y,v),0.).x;vec2 uv=vec2(u,v);vec3 derivedDirection=equirectUvToDirection(uv);direction=derivedDirection;vec3 color=textureLod(info.map,uv,0.).rgb;float totalSum=info.totalSumWhole+info.totalSumDecimal;float lum=luminance(color);float pdf=lum/totalSum;return info.size.x*info.size.y*pdf;}float misHeuristic(float a,float b){float aa=a*a;float bb=b*b;return aa/(aa+bb);}vec3 alignToNormal(const vec3 normal,const vec3 direction){vec3 tangent;vec3 bitangent;Onb(normal,tangent,bitangent);vec3 localDir=ToLocal(tangent,bitangent,normal,direction);vec3 localDirAligned=vec3(localDir.x,localDir.y,abs(localDir.z));vec3 alignedDir=ToWorld(tangent,bitangent,normal,localDirAligned);return alignedDir;}float getFlatness(vec3 g,vec3 rp){vec3 gw=fwidth(g);vec3 pw=fwidth(rp);float wfcurvature=length(gw)/length(pw);wfcurvature=smoothstep(0.0,30.,wfcurvature);return clamp(wfcurvature,0.,1.);}"; // eslint-disable-line
 
 // source: https://github.com/gkjohnson/three-gpu-pathtracer/blob/main/src/uniforms/EquirectHdrInfoUniform.js
 
-const workerOnMessage = ({
-  data: {
-    width,
-    height,
-    isFloatType,
-    flipY,
-    data
-  }
+const computeEquirectCDF = ({
+  width,
+  height,
+  isFloatType,
+  flipY,
+  data
 }) => {
   // from: https://github.com/mrdoob/three.js/blob/dev/src/extras/DataUtils.js
   // importing modules doesn't seem to work for workers that were generated through createObjectURL() for some reason
@@ -1036,17 +1050,13 @@ const workerOnMessage = ({
   const marginalDataArray = new Float32Array(height);
   const conditionalDataArray = new Float32Array(width * height);
   const totalSumValue = gatherData(data, width, height, flipY, marginalDataArray, conditionalDataArray);
-  postMessage({
+  return {
     totalSumValue,
     marginalDataArray,
     conditionalDataArray
-  });
+  };
 };
 
-const blob = new Blob(["onmessage = " + workerOnMessage], {
-  type: "application/javascript"
-});
-const workerUrl = URL.createObjectURL(blob);
 class EquirectHdrInfoUniform {
   constructor() {
     // we use NearestFilter instead of LinearFilter because on many recent Apple devices filtering from such a texture does not work
@@ -1106,52 +1116,47 @@ class EquirectHdrInfoUniform {
       type
     } = map;
     this.size.set(width, height);
-    return new Promise(resolve => {
-      var _this$worker;
-
-      (_this$worker = this.worker) == null ? void 0 : _this$worker.terminate();
-      this.worker = new Worker(workerUrl);
-      this.worker.postMessage({
-        width,
-        height,
-        isFloatType: type === FloatType,
-        flipY: map.flipY,
-        data
-      });
-
-      this.worker.onmessage = ({
-        data: {
-          totalSumValue,
-          marginalDataArray,
-          conditionalDataArray
-        }
-      }) => {
-        this.dispose();
-        const {
-          marginalWeights,
-          conditionalWeights
-        } = this;
-        marginalWeights.image = {
-          width: height,
-          height: 1,
-          data: marginalDataArray
-        };
-        marginalWeights.needsUpdate = true;
-        conditionalWeights.image = {
-          width,
-          height,
-          data: conditionalDataArray
-        };
-        conditionalWeights.needsUpdate = true;
-        const totalSumWhole = ~~totalSumValue;
-        const totalSumDecimal = totalSumValue - totalSumWhole;
-        this.totalSumWhole = totalSumWhole;
-        this.totalSumDecimal = totalSumDecimal;
-        this.map = map;
-        this.worker = null;
-        resolve(map);
-      };
+    // The CDF used to be computed in a Worker spawned here, and its reply
+    // landed on the main thread at whatever real moment the OS chose. Under
+    // ?saycheese that moment falls between two pumped frames, flipping the
+    // importanceSampling define at a run-dependent frame index -- which the
+    // temporal accumulation then keeps forever. Synchronous instead: a few
+    // milliseconds of prefix sums, paid once, in a frame that already pays
+    // for shader compilation.
+    const {
+      totalSumValue,
+      marginalDataArray,
+      conditionalDataArray
+    } = computeEquirectCDF({
+      width,
+      height,
+      isFloatType: type === FloatType,
+      flipY: map.flipY,
+      data
     });
+    this.dispose();
+    const {
+      marginalWeights,
+      conditionalWeights
+    } = this;
+    marginalWeights.image = {
+      width: height,
+      height: 1,
+      data: marginalDataArray
+    };
+    marginalWeights.needsUpdate = true;
+    conditionalWeights.image = {
+      width,
+      height,
+      data: conditionalDataArray
+    };
+    conditionalWeights.needsUpdate = true;
+    const totalSumWhole = ~~totalSumValue;
+    const totalSumDecimal = totalSumValue - totalSumWhole;
+    this.totalSumWhole = totalSumWhole;
+    this.totalSumDecimal = totalSumDecimal;
+    this.map = map;
+    return Promise.resolve(map);
   }
 
 }

--- a/packages/e2e/bin/flaky.mjs
+++ b/packages/e2e/bin/flaky.mjs
@@ -42,12 +42,13 @@ import { chromium } from "@playwright/test";
 import { preview } from "vite";
 
 import { canvasHash, shoot } from "../lib/shoot.mjs";
+import { UNPUBLISHED } from "../../../bin/e2e-exceptions.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 const argv = minimist(process.argv.slice(2));
 const RUNS = Number(argv.runs) || 3;
-const PORT = 5399; // one example at a time, so one port is enough
+const PORT = Number(argv.port) || 5399; // `--port` so two sweeps can run at once
 
 const asked = argv._.map((a) => String(a).replace("@example/", ""));
 const examples = (
@@ -90,7 +91,9 @@ async function shotOf(example) {
   const server = await preview({
     root: join(root, "examples", example),
     base: `/${example}`,
-    preview: { host: "127.0.0.1", port: PORT, strictPort: true },
+    // Not `strictPort`: vite walks up from here, so a port left busy by
+    // another sweep costs a second, not the whole run.
+    preview: { host: "127.0.0.1", port: PORT },
     logLevel: "silent",
   });
   const browser = await chromium.launch();
@@ -163,15 +166,47 @@ if (argv.json) {
   );
 }
 
-const unstable = results.filter((r) => r.status !== "stable");
+//
+// What this reports is a change of status, not a census.
+//
+// The nightly shoots every example that has a `test` script, and some of those
+// are in `UNPUBLISHED` precisely because they were measured drifting. Failing on
+// them would paint the nightly red every night for reasons already written
+// down -- and a job that is always red is a job nobody opens, which would cost
+// us the one thing this exists to catch.
+//
+// So there are two kinds of news, and they point in opposite directions:
+//
+//   a published example that drifted     -- a regression, and Chromatic is
+//                                           about to flag a change nobody made
+//   an unpublished one that held still   -- a fix worth collecting, whether it
+//                                           was aimed at this or not
+//
+const drifted = results.filter(
+  (r) => r.status !== "stable" && !(r.example in UNPUBLISHED),
+);
+const settled = results.filter(
+  (r) => r.status === "stable" && r.example in UNPUBLISHED,
+);
 
-if (unstable.length) {
+if (settled.length) {
   console.log(
-    `\n${unstable.length}/${results.length} would flag a phantom change:\n${unstable
+    `\n🎉 ${settled.length} held still over ${RUNS} shots and could be published:\n${settled
+      .map((r) => `  ${r.example.padEnd(40)}${r.hashes[0]}`)
+      .join("\n")}`,
+  );
+}
+
+if (drifted.length) {
+  console.log(
+    `\n${drifted.length} published example(s) would now flag a phantom change:\n${drifted
       .map((r) => `  ${r.example.padEnd(40)}${r.status}`)
       .join("\n")}`,
   );
   process.exit(1);
 }
 
-console.log(`\n${results.length}/${results.length} stable over ${RUNS} runs.`);
+const expected = results.length - drifted.length - settled.length;
+console.log(
+  `\n${expected}/${results.length} as expected over ${RUNS} shots -- nothing to report.`,
+);

--- a/packages/e2e/lib/shoot.mjs
+++ b/packages/e2e/lib/shoot.mjs
@@ -41,6 +41,35 @@ export async function shoot(page, host) {
   await page.goto(`${host}/?saycheese`);
   await waitForAssets(page);
 
+  //
+  // 🔁 second take -- see `CheesyCanvas`. The first mount happened in
+  // asset-arrival order, which is the network's order, not ours. Now that
+  // every loader cache is warm, remounting the scene is one synchronous
+  // render in JSX order, and everything the mount order decides -- `useFrame`
+  // registration, scene-graph children, physics insertion, who draws what
+  // from the seeded random sequence -- comes out the same, every run.
+  //
+  // `networkidle` cannot be waited on twice (load states are monotonic per
+  // navigation), and mostly nothing loads here anyway: the point of the
+  // second take is that the caches answer. What can still be in flight is a
+  // `<video>` element recreated by the remount, re-pinning itself to its
+  // fixed frame, so that is what gets waited on -- then the same settle the
+  // first wait uses.
+  //
+  await page.evaluate(() => window.__cheeseRemount?.());
+  await page
+    .waitForFunction(
+      () =>
+        [...document.querySelectorAll("video")].every(
+          (video) => video.paused && video.readyState >= 2,
+        ),
+      { timeout: 20_000 },
+    )
+    .catch(() => {
+      console.log("A video never pinned itself, shooting anyway");
+    });
+  await page.waitForTimeout(500);
+
   // 🎬 flags rather than events, so neither side can miss the other's
   await page.evaluate(() => (window.__cheeseShoot = true));
   await page.waitForFunction(() => window.__cheeseReady === true);

--- a/packages/e2e/lib/shoot.mjs
+++ b/packages/e2e/lib/shoot.mjs
@@ -22,7 +22,27 @@ export async function waitForAssets(page) {
   await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {
     console.log("Network never went idle, shooting anyway");
   });
+  await waitForDecodes(page);
   await page.waitForTimeout(500);
+}
+
+//
+// `networkidle` says the bytes arrived, not that they were decoded: a Draco
+// mesh still has a worker round-trip ahead of it, an HDR a parse, and under
+// load the settle can lose that race -- at which point the second take
+// re-suspends and mounts in arrival order again, reviving exactly what the
+// remount exists to fix. The page tracks its loading manager (see
+// `deterministic.js`), whose `itemEnd` fires after the parse, and this waits
+// for it to go quiet.
+//
+async function waitForDecodes(page) {
+  await page
+    .waitForFunction(() => (window.__cheeseInflight?.() ?? 0) === 0, {
+      timeout: 60_000,
+    })
+    .catch(() => {
+      console.log("Loaders never went quiet, shooting anyway");
+    });
 }
 
 /**
@@ -57,6 +77,7 @@ export async function shoot(page, host) {
   // first wait uses.
   //
   await page.evaluate(() => window.__cheeseRemount?.());
+  await waitForDecodes(page); // in case the second take re-suspended anything
   await page
     .waitForFunction(
       () =>

--- a/packages/e2e/src/CheesyCanvas.jsx
+++ b/packages/e2e/src/CheesyCanvas.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { Canvas, useThree } from "@react-three/fiber";
 
@@ -160,11 +160,44 @@ export default function CheesyCanvas({ children, frameloop, ...props }) {
   //
   const cheesyFrameloop = sayCheeseParam ? "never" : frameloop;
 
+  //
+  // The second take.
+  //
+  // The first mount happens in asset-arrival order: each suspense boundary
+  // resolves when its download does, so which component mounts first -- and
+  // with it the order `useFrame` callbacks register, the order children land
+  // in the scene graph, the order physics bodies enter the world, the order
+  // draws are taken from the seeded `Math.random` sequence -- is decided by
+  // the network, run to run. That order is the drift no amount of waiting
+  // fixed: serialising `fetch` was measured and changed nothing, because
+  // arrival is only the first domino.
+  //
+  // So once everything has arrived, the harness asks for a second mount, by
+  // key. Every `useLoader` is now warm in the suspend-react cache and answers
+  // synchronously, so nothing suspends: the whole scene mounts in one
+  // synchronous render, in JSX order -- the same order every run, on every
+  // machine. The seeded sequence is rewound first (see `deterministic.js`) so
+  // the draws land on the same values too. The canvas, its GL context and its
+  // compiled shaders survive, since the key sits below `<Canvas>`; what gets
+  // rebuilt is exactly the part whose order was wrong.
+  //
+  const [take, setTake] = useState(0);
+
+  useEffect(() => {
+    if (!sayCheeseParam) return;
+
+    window.__cheeseRemount = () => {
+      window.__cheeseReseed?.();
+      flushSync(() => setTake((take) => take + 1));
+    };
+    return () => delete window.__cheeseRemount;
+  }, [sayCheeseParam]);
+
   return (
     <Canvas {...props} frameloop={cheesyFrameloop}>
       {sayCheeseParam && <SayCheese />}
 
-      {children}
+      <React.Fragment key={take}>{children}</React.Fragment>
     </Canvas>
   );
 }

--- a/packages/e2e/src/CheesyCanvas.jsx
+++ b/packages/e2e/src/CheesyCanvas.jsx
@@ -96,12 +96,21 @@ function SayCheese() {
       // 158 examples still to be covered will.
       //
       if (window.__cheeseShoot === true && frame < FRAMES) {
-        if (frame === 0) started = performance.now();
+        if (frame === 0) started = window.__cheeseRealNow?.() ?? 0;
+
+        //
+        // The page's clock moves here, and only here -- see `deterministic.js`.
+        // Before `advance`, so that anything reading `performance.now()` inside
+        // this frame (a spring, an easing, a `rafz` tick) sees the same instant
+        // r3f is about to render.
+        //
+        window.__cheeseAdvanceClock?.(STEP * 1000);
+
         flushSync(() => advance(++frame * STEP));
 
         if (frame === FRAMES) {
           console.log(
-            `📸 Shot ${FRAMES} frames in ${Math.round(performance.now() - started)}ms`,
+            `📸 Shot ${FRAMES} frames in ${Math.round((window.__cheeseRealNow?.() ?? 0) - started)}ms`,
           );
           window.__cheeseReady = true; // tells the harness to take its screenshot
         }

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -70,8 +70,75 @@ if (sayCheeseParam) {
   const rAF = window.requestAnimationFrame.bind(window);
   window.requestAnimationFrame = (callback) => rAF(() => callback(virtual));
 
+  //
+  // Timers move onto the virtual clock too -- but only once the shot starts.
+  //
+  // `setTimeout` is how a scene schedules anything it does not want to do right
+  // now, and it was still keeping wall time: `threejs-journey-lv-1-fisheye`
+  // re-aims its subject on `setTimeout(wander, (1 + Math.random() * 2) * 800)`,
+  // so how many of our frames elapse before it fires depended entirely on how
+  // fast the machine drew them.
+  //
+  // Only once the shot starts, and that boundary was measured rather than
+  // guessed. Virtualising from page load instead -- to catch `clones`, which
+  // recolours its light on `setInterval(..., 3000)` a machine-dependent number
+  // of times *while loading* -- deadlocked the load: the clock does not move
+  // until we pump, so anything waiting on a long timer waits forever.
+  // `bruno-simons-20k-challenge` never finished loading and spent all three of
+  // its shots hitting the 300s budget. Exempting short delays was not enough.
+  //
+  // So a scene that does something time-based before the shot is beyond this,
+  // and has to stop doing it -- see `clones`.
+  //
+  const realSetTimeout = window.setTimeout.bind(window);
+  const pending = new Map();
+  let nextId = 1;
+  let shooting = false;
+
+  const realSetInterval = window.setInterval.bind(window);
+
+  function schedule(callback, delay, args, every) {
+    const id = -nextId++; // negative, so it cannot collide with a real handle
+    pending.set(id, { at: virtual + delay, callback, args, every });
+    return id;
+  }
+
+  window.setTimeout = (callback, delay = 0, ...args) =>
+    shooting
+      ? schedule(callback, delay, args, 0)
+      : realSetTimeout(callback, delay, ...args);
+
+  // `clones` recolours its light on `setInterval(..., 3000)`, drawing from the
+  // shared sequence each time it fires -- so what it had drawn by the shot
+  // depended on how long the shot took to reach.
+  window.setInterval = (callback, delay = 0, ...args) =>
+    shooting
+      ? schedule(callback, delay, args, delay)
+      : realSetInterval(callback, delay, ...args);
+
+  const realClearTimeout = window.clearTimeout.bind(window);
+  const realClearInterval = window.clearInterval.bind(window);
+  window.clearTimeout = (id) =>
+    id < 0 ? pending.delete(id) : realClearTimeout(id);
+  window.clearInterval = (id) =>
+    id < 0 ? pending.delete(id) : realClearInterval(id);
+
   // Called by the pump in CheesyCanvas, once per frame, before it advances r3f.
-  window.__cheeseAdvanceClock = (ms) => (virtual += ms);
+  window.__cheeseAdvanceClock = (ms) => {
+    shooting = true;
+    virtual += ms;
+
+    // Due callbacks, oldest first, and taken out of the map before they run so
+    // that one rescheduling itself cannot loop inside this frame.
+    for (const [id, timer] of [...pending].sort((a, b) => a[1].at - b[1].at)) {
+      if (timer.at > virtual) break;
+
+      if (timer.every) timer.at += timer.every;
+      else pending.delete(id);
+
+      timer.callback(...timer.args);
+    }
+  };
 
   //
   // A `<video>` answers to none of the above: it plays off the media clock, in

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -48,6 +48,45 @@ if (sayCheeseParam) {
   };
 
   //
+  // Draw order must not depend on which asset finished decoding first.
+  //
+  // three's default opaque sort (`painterSortStable`) orders by `material.id`
+  // before depth -- and that id is a global counter, burned in whatever order
+  // GLTFLoader's async pipeline happened to construct materials: Draco decodes
+  // in a four-worker pool, textures land when they land, and
+  // `assignFinalMaterial` mints its clones as each mesh's Promise.all
+  // resolves. The loader cache then hands those same instances to the second
+  // mount, so the remount cannot renumber them and the reseed cannot reach a
+  // module-private counter. Wherever two of those materials meet on a
+  // coplanar surface -- or anywhere at all inside a depthTest=false overdraw
+  // pass like ContactShadows' depth bake -- the draw order IS the picture.
+  //
+  // Measured as the entire remaining drift of `bloom-hdr-workflow-gltf` (one
+  // MSAA-contested pixel, 10/10 identical with this in place) and
+  // `bruno-simons-20k-challenge` (9/9), and the same mechanism was traced in
+  // `bounds-and-makedefault`, `clones` and `html-markers`.
+  //
+  // Same keys the default uses, minus `material.id`. The `id` tiebreaker is
+  // `object.id`, which the second take mints in JSX order. Installed through
+  // the `__THREE_DEVTOOLS__` hook because every renderer announces itself
+  // there at construction, whichever version of three and whoever created it
+  // -- this module just has to exist first, and it is the entry's first
+  // import.
+  //
+  const opaqueSort = (a, b) =>
+    a.groupOrder - b.groupOrder ||
+    a.renderOrder - b.renderOrder ||
+    a.z - b.z ||
+    a.id - b.id;
+  window.__THREE_DEVTOOLS__ = {
+    dispatchEvent(event) {
+      const it = event.detail;
+      if (it && it.isWebGLRenderer && it.setOpaqueSort)
+        it.setOpaqueSort(opaqueSort);
+    },
+  };
+
+  //
   // The clock the whole page reads, replaced by one that only moves when we
   // move it -- the same thing three.js does in its own screenshot harness.
   //

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -34,6 +34,42 @@ if (sayCheeseParam) {
     );
   };
 
+  //
+  // The clock the whole page reads, replaced by one that only moves when we
+  // move it -- the same thing three.js does in its own screenshot harness.
+  //
+  // `frameloop="never"` freezes r3f's loop. It does not freeze the *page*, and
+  // that turned out to be most of what was left: `@react-spring/three` animates
+  // on its own `rafz` loop reading `performance.now()`, never through
+  // `useFrame`, so it kept advancing by however long our thirty frames happened
+  // to take -- which varies with shader compilation, run to run, by seconds.
+  // That is why postprocessing and physics never correlated with drift (they
+  // live inside `useFrame`) while springs and easings did.
+  //
+  // So: time starts at zero, stays there through loading, and advances exactly
+  // `1/60` per frame we pump. `rAF` callbacks get the same virtual timestamp,
+  // for anything that reads the argument rather than the clock.
+  //
+  // `Date.now` moves with it off a fixed epoch. `new Date()` is deliberately
+  // left alone: patching the constructor breaks `instanceof` for very little,
+  // since animation libraries read `performance.now` or `Date.now`.
+  //
+  const EPOCH = 1767225600000; // 2026-01-01T00:00:00Z, an arbitrary fixed point
+  let virtual = 0;
+
+  // Kept for the one thing that still wants wall clock: reporting how long the
+  // shot really took, which is what tells us whether the budget still fits.
+  window.__cheeseRealNow = performance.now.bind(performance);
+
+  performance.now = () => virtual;
+  Date.now = () => EPOCH + virtual;
+
+  const rAF = window.requestAnimationFrame.bind(window);
+  window.requestAnimationFrame = (callback) => rAF(() => callback(virtual));
+
+  // Called by the pump in CheesyCanvas, once per frame, before it advances r3f.
+  window.__cheeseAdvanceClock = (ms) => (virtual += ms);
+
   var style = document.createElement("style");
   style.innerHTML = `
   canvas[data-engine] {

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -1,10 +1,36 @@
 import seedrandom from "seedrandom";
+import { DefaultLoadingManager } from "three";
 
 const sayCheeseParam = new URLSearchParams(window.location.search).has(
   "saycheese",
 );
 if (sayCheeseParam) {
   seedrandom("hello.", { global: true });
+
+  //
+  // `networkidle` says the bytes arrived; it says nothing about the decode
+  // that follows -- a Draco mesh unpacks in a worker pool, an HDR parses off
+  // the main thread, and under load the settle after idle can lose that
+  // race. Then the second take re-suspends and mounts in arrival order
+  // again, quietly reviving everything the remount exists to fix
+  // (`iridescent-decals` flipped once in ten shots exactly this way, only
+  // under full-sweep load). The loading manager is the signal with the right
+  // shape: `itemEnd` fires after the parse, not after the bytes. Patched at
+  // the method rather than the `onLoad` slot, which drei's `useProgress`
+  // overwrites for its own loader UI.
+  //
+  let inflight = 0;
+  const itemStart = DefaultLoadingManager.itemStart.bind(DefaultLoadingManager);
+  const itemEnd = DefaultLoadingManager.itemEnd.bind(DefaultLoadingManager);
+  DefaultLoadingManager.itemStart = (url) => {
+    inflight += 1;
+    itemStart(url);
+  };
+  DefaultLoadingManager.itemEnd = (url) => {
+    inflight -= 1;
+    itemEnd(url);
+  };
+  window.__cheeseInflight = () => inflight;
 
   //
   // Seeding fixes the *sequence*; it does not fix who draws from it in what

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -42,7 +42,13 @@ if (sayCheeseParam) {
       this,
       type,
       /^(webgl2?|experimental-webgl)$/.test(type)
-        ? { ...attributes, preserveDrawingBuffer: true }
+        ? // `antialias: false` too: which surface wins each MSAA sample on a
+          // knife edge is resolved inside the driver, below anything a page
+          // can patch. `room-with-soft-shadows` flipped two pixels of its
+          // window pane by one sample's worth, run to run, with every
+          // JS-visible state byte-identical -- and held 8/8 without MSAA.
+          // Aliased edges are the price of a comparison with zero tolerance.
+          { ...attributes, preserveDrawingBuffer: true, antialias: false }
         : attributes,
     );
   };
@@ -66,23 +72,43 @@ if (sayCheeseParam) {
   // `bruno-simons-20k-challenge` (9/9), and the same mechanism was traced in
   // `bounds-and-makedefault`, `clones` and `html-markers`.
   //
-  // Same keys the default uses, minus `material.id`. The `id` tiebreaker is
-  // `object.id`, which the second take mints in JSX order. Installed through
-  // the `__THREE_DEVTOOLS__` hook because every renderer announces itself
-  // there at construction, whichever version of three and whoever created it
-  // -- this module just has to exist first, and it is the entry's first
-  // import.
+  // Same keys the defaults use, minus `material.id`, and with the final
+  // tiebreak on the object's *name* before its id. `object.id` is only safe
+  // for meshes the second take minted itself, in JSX order; a mesh drawn
+  // straight out of a cached GLTF scene graph carries an id burned at parse
+  // time, in the same racy order as the materials'. Its name, though, comes
+  // from the file. The transparent sort needs the same treatment for its
+  // z-ties -- `sport-hall`'s backboard glass sits exactly on its trim, and
+  // three's default falls back to `object.id` right there.
   //
+  // Installed through the `__THREE_DEVTOOLS__` hook because every renderer
+  // announces itself there at construction, whichever version of three and
+  // whoever created it -- this module just has to exist first, and it is the
+  // entry's first import.
+  //
+  const byName = (a, b) =>
+    a.object.name < b.object.name
+      ? -1
+      : a.object.name > b.object.name
+        ? 1
+        : a.id - b.id;
   const opaqueSort = (a, b) =>
     a.groupOrder - b.groupOrder ||
     a.renderOrder - b.renderOrder ||
     a.z - b.z ||
-    a.id - b.id;
+    byName(a, b);
+  const transparentSort = (a, b) =>
+    a.groupOrder - b.groupOrder ||
+    a.renderOrder - b.renderOrder ||
+    b.z - a.z ||
+    byName(a, b);
   window.__THREE_DEVTOOLS__ = {
     dispatchEvent(event) {
       const it = event.detail;
-      if (it && it.isWebGLRenderer && it.setOpaqueSort)
+      if (it && it.isWebGLRenderer && it.setOpaqueSort) {
         it.setOpaqueSort(opaqueSort);
+        it.setTransparentSort(transparentSort);
+      }
     },
   };
 
@@ -98,16 +124,26 @@ if (sayCheeseParam) {
   // That is why postprocessing and physics never correlated with drift (they
   // live inside `useFrame`) while springs and easings did.
   //
-  // So: time starts at zero, stays there through loading, and advances exactly
+  // So: time starts frozen, stays frozen through loading, and advances exactly
   // `1/60` per frame we pump. `rAF` callbacks get the same virtual timestamp,
   // for anything that reads the argument rather than the clock.
+  //
+  // Frozen at one frame's worth, not at zero. Zero is the one value a clock
+  // must never idle on: react-spring's `rafz` computes its delta as
+  // `prevTs ? ts - prevTs : 16.667`, so a clock stuck at 0 keeps `prevTs`
+  // falsy forever and every *real* pre-shot rAF tick advances every spring by
+  // a full frame -- how many, the machine decides. Stuck at 16.667 instead,
+  // the fallback fires once and every later tick computes `dt = 0`: springs
+  // hold perfectly still until the pump moves the clock. Measured on
+  // `springy-boxes`, which entered the shot a machine-dependent number of
+  // frames into flight.
   //
   // `Date.now` moves with it off a fixed epoch. `new Date()` is deliberately
   // left alone: patching the constructor breaks `instanceof` for very little,
   // since animation libraries read `performance.now` or `Date.now`.
   //
   const EPOCH = 1767225600000; // 2026-01-01T00:00:00Z, an arbitrary fixed point
-  let virtual = 0;
+  let virtual = 1000 / 60;
 
   // Kept for the one thing that still wants wall clock: reporting how long the
   // shot really took, which is what tells us whether the budget still fits.
@@ -225,12 +261,23 @@ if (sayCheeseParam) {
     return Promise.resolve();
   };
 
+  //
+  // CSS animations run on the compositor's timeline, which none of the clock
+  // patching above can reach -- and they do not have to touch the canvas to
+  // move pixels in it: `view-tracking` animates plain divs whose bounding
+  // rects drei's <View> reads every frame to place its scissor, so the
+  // picture followed real seconds since page load. Killed everywhere, not
+  // just on the canvas: the hash is canvas-only, so a frozen page costs
+  // nothing, and no example gates its loading on an animation ever ending.
+  //
   var style = document.createElement("style");
   style.innerHTML = `
-  canvas[data-engine] {
+  *, *::before, *::after {
     animation: none !important;
     transition: none !important;
+  }
 
+  canvas[data-engine] {
     opacity: 1!important;
   }
 `;

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -63,12 +63,48 @@ if (sayCheeseParam) {
 
   performance.now = () => virtual;
   Date.now = () => EPOCH + virtual;
+  // three.js patches this one too, and it is not redundant: `new Date().getTime()`
+  // never goes through `Date.now`.
+  Date.prototype.getTime = () => EPOCH + virtual;
 
   const rAF = window.requestAnimationFrame.bind(window);
   window.requestAnimationFrame = (callback) => rAF(() => callback(virtual));
 
   // Called by the pump in CheesyCanvas, once per frame, before it advances r3f.
   window.__cheeseAdvanceClock = (ms) => (virtual += ms);
+
+  //
+  // A `<video>` answers to none of the above: it plays off the media clock, in
+  // its own thread, and a texture sampled from it lands on whatever frame the
+  // decoder had reached. It is the single strongest predictor of drift we
+  // measured -- ten times over-represented among the examples that will not
+  // hold still.
+  //
+  // three.js pins it by letting playback start and pausing on the first
+  // `timeupdate`, and calls the result "semi-deterministic" for good reason:
+  // `timeupdate` fires about four times a second, so where playback stops still
+  // depends on how quickly the machine got there. We measured that as still
+  // drifting.
+  //
+  // So it never plays. It seeks to a fixed position instead, and waits for the
+  // decoder to say it landed -- `seeked` is the guarantee that this exact frame
+  // is the one a texture will sample. Half a second in, because the first frame
+  // of a video is often black or a fade.
+  //
+  const SEEK = 0.5;
+  HTMLVideoElement.prototype.play = function () {
+    const seek = () => {
+      this.pause();
+      this.currentTime = SEEK;
+    };
+
+    // `currentTime` before metadata is a no-op, so wait for the duration to
+    // exist when it does not yet.
+    if (this.readyState >= 1) seek();
+    else this.addEventListener("loadedmetadata", seek, { once: true });
+
+    return Promise.resolve();
+  };
 
   var style = document.createElement("style");
   style.innerHTML = `

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -7,6 +7,19 @@ if (sayCheeseParam) {
   seedrandom("hello.", { global: true });
 
   //
+  // Seeding fixes the *sequence*; it does not fix who draws from it in what
+  // order. Assets resolve in whatever order the network hands them back, the
+  // components waiting on them mount in that order, and every draw they make
+  // -- a spread position, a phase, the four values three.js burns per object
+  // for a UUID -- lands on a different point of the same fixed sequence.
+  //
+  // The harness deals with that by mounting the scene twice (see
+  // `CheesyCanvas`), and the second mount only helps if it starts from the top
+  // of the sequence. This is the rewind.
+  //
+  window.__cheeseReseed = () => seedrandom("hello.", { global: true });
+
+  //
   // Chromatic archives the frozen page by serialising the DOM, and a <canvas>
   // only survives that as whatever `toDataURL()` returns. WebGL clears its
   // drawing buffer right after compositing, so by the time the archive is


### PR DESCRIPTION
Stacked on #173, which published 126 examples and held back **35 that drew a different canvas run to run**. This PR is the answer to why, mechanism by mechanism — and it ends with **all 35 recovered and the unpublished list empty**.

## The result

Measured with the dry protocol (`e2e-flaky`, repeated passes of three cold shots on every former drifter plus three always-stable controls, until two consecutive passes catch nothing). The first protocol run came back clean at six shots per example — and doubling it under full-machine load caught **three low-frequency flakers** (one flip in ten to fifteen shots, load-only) that six shots could not see: `ssgi-spheres-with-rapier-physics`, `iridescent-decals`, `simple-physics-example-with-debug-bounds`. All three were diagnosed to a proven mechanism (rows 9-11 below), fixed, and re-measured 9/9 under load each; the other **35 held ~18 cold shots each**. The final certification — all 38 under sustained load until two clean passes, with a parallel sweep hammering the six heaviest examples for ~135 extra cold shots — **caught nothing, twice over**. Zero drifters. The nightly keeps the claim honest from here; `UNPUBLISHED`'s contract makes any future catch a promise to diagnose.

## The mechanisms, each proven on the example that exposed it

Every one of these was diagnosed with instrumentation (pixel diffs, GL call traces, id dumps, A/B falsification), not by reading tea leaves. Documented in place in `packages/e2e/src/deterministic.js` / `CheesyCanvas.jsx`.

| # | mechanism | proven on | fix |
|---|---|---|---|
| 1 | **The page keeps its own clock.** `@react-spring`'s rafz loop reads `performance.now()`, never `useFrame`, so springs advanced by wall time | `springy-boxes`, `aquarium`, `caustics` | virtual clock: `performance.now`/`Date.now`/`getTime`/rAF timestamps frozen through load, +1/60 s per pumped frame |
| 2 | **Wall-clock timers during the shot.** A `setTimeout` lands at a machine-dependent frame | `threejs-journey-lv-1-fisheye` | timers virtualized once the shot starts (from load deadlocks — measured) |
| 3 | **The media clock.** A `<video>` texture samples whatever frame the decoder reached | `video-textures`, `video-cookies` | `play()` never plays: seek to 0.5 s, wait for `seeked` |
| 4 | **Mount order is asset-arrival order.** Suspense resolves in network order, deciding `useFrame` registration, scene-graph children, physics insertion, and who draws what from the seeded RNG | `image-gallery`, `monitors`, `space-game`… | **the second take**: once everything is cached, remount the scene by key — one synchronous render in JSX order, seed rewound first |
| 5 | **The id lottery in the draw sorts.** three sorts opaque draws by `material.id` *before depth* — a global counter dealt in Draco-worker/texture-decode completion order, carried through the cache where no remount can renumber it; transparent z-ties fall back on `object.id`, same lottery. One coplanar edge or one `depthTest=false` shadow pass, and the draw order *is* the picture | `bloom-hdr-workflow-gltf` (one MSAA-contested pixel at (632,326)), `bruno-simons-20k-challenge`, `bounds-and-makedefault`, `clones`, `html-markers`, `sport-hall`, `transformcontrols-and-makedefault`, `viking-ship` | both sorts replaced under `?saycheese` via the `__THREE_DEVTOOLS__` hook: same keys minus the ids, tie-breaking on the object's *name* (from the file) |
| 6 | **A clock frozen at zero is a special value.** rafz computes `prevTs ? ts - prevTs : 16.667`, so 0 keeps the fallback firing on every real pre-shot rAF tick | `springy-boxes` | the clock freezes at 16.667 ms, not 0 |
| 7 | **CSS animations live on the compositor's timeline**, out of reach of any JS clock — and drei's `<View>` reads animated divs' rects to place its scissor | `view-tracking` | animation/transition kill widened from the canvas to every element |
| 8 | **One MSAA sample, resolved inside the driver.** Two window-pane pixels flipped by one sample's worth with every JS-visible state byte-identical | `room-with-soft-shadows` (8/8 without MSAA) | `?saycheese` contexts ask for `antialias: false` — aliased edges are the price of zero-tolerance comparison |
| 9 | **An async Worker reply landing mid-shot.** SSGI computes its env-map importance-sampling CDF in a Worker; the reply flips a shader define at a run-dependent pumped frame, baked forever by temporal accumulation | `ssgi-spheres-with-rapier-physics` | the CDF is synchronous in the vendored `realism-effects` — a few ms of prefix sums, paid once |
| 10 | **`networkidle` says arrived, not decoded.** A Draco mesh still has a worker round-trip ahead, an HDR a parse; under load the settle loses that race and the second take re-suspends — mounting in arrival order again | `iridescent-decals` (one flip in ten, load-only) | the shot waits for `DefaultLoadingManager` inflight = 0 (post-parse `itemEnd`), before the remount and before pumping |
| 11 | **Undefined derivatives in non-uniform control flow.** `texture()` picks its mip from screen-space derivatives — after an early `return`, GLSL leaves them undefined, and SwiftShader reads whatever the returned lanes' registers hold, which follows thread scheduling. The same byte-identical draw produced four different buffers in one run | `ssgi-spheres-with-rapier-physics` (10/10 under load with the fix) | `textureLod(…, 0.)` — the sample feeds a pdf estimate that never wanted a derivative-picked mip |

Three examples also stopped scheduling real time themselves (the harness deliberately cannot virtualize pre-shot timers — it deadlocks loading): `clones` recolours its light, `springy-boxes` retargets its springs and `simple-physics-example-with-debug-bounds` mounts its third body on scene time now, via `useFrame` — the last one used to race its `setTimeout(2000)` against a shot that starts at ~2s, a knife edge it lost once in twelve.

Ruled out along the way, with measurements: asset races (serializing `fetch` changed nothing), physics (rapier is bit-deterministic under the pump), postprocessing, `AccumulativeShadows` (exactly 30 seeded accumulations), GPU nondeterminism everywhere except №8.

## What it costs

The clock, the remount, the sorts and `antialias: false` change the shot for **every** example, so this invalidates all Chromatic baselines at once — deliberately kept to one baseline move on `main`, which is the reason this is a separate PR rather than more commits on #173.

## How it was found

Per-example forensic agents: pixel-diff the divergent canvases, trace the GL call streams to the first divergent call, dump ids/matrices/uniforms across runs, then falsify the hypothesis by injection (e.g. neutralize one sort key → 10/10 identical). Same approach three.js uses for its own Playwright captures, taken a few steps further.
