### PR TITLE
Publish a machine-readable catalog of the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ test-results
 out/
 build
 dist
+# Written by bin/build-catalog.mjs into the website's public/, on its way to
+# out/. Here rather than in apps/website/.gitignore so that prettier, which
+# only reads the root one, skips it as well.
+apps/website/public/catalog/
 
 
 # Debug

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node ../../bin/build-catalog.mjs && next dev",
     "dev2": "pnpm run dev",
-    "build": "NODE_ENV=production next build",
+    "build": "node ../../bin/build-catalog.mjs && NODE_ENV=production next build",
     "build3": "pnpm run build",
     "start": "next start",
     "lint": "eslint"

--- a/bin/build-catalog.mjs
+++ b/bin/build-catalog.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/**
+ * Emits the machine-readable catalog the website ships alongside its pages, at
+ * `/catalog/index.json` and `/catalog/<example>.json`.
+ *
+ * It exists for readers that cannot run the site: the pmndrs docs MCP server
+ * serves examples to coding agents out of these files, so an agent can find the
+ * example that already solves a problem and read its source without cloning
+ * anything.
+ *
+ * Two files rather than one on purpose. The index is small enough (~95 kB, and
+ * an eighth of that over the wire) to pull on every question, and carries just
+ * enough -- title, description, tags, libraries -- to pick from; the per-example
+ * file then costs one more request for the ~6 kB that actually answers it. A
+ * single bundle would be ~2 MB, paid in full to read one example.
+ *
+ * The published set is whatever `apps/website/package.json` depends on, which is
+ * what the site itself builds from (`apps/website/lib/helper.ts`). Example
+ * directories that are not workspace dependencies -- `ssr-test`, `starwars` --
+ * are not on the site and are not in the catalog either.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const examplesDirectory = path.join(root, "examples");
+const websiteDirectory = path.join(root, "apps", "website");
+const outputDirectory = path.join(websiteDirectory, "public", "catalog");
+
+// Same derivation as `lib/helper.ts`: absolute when the build knows where it is
+// deploying, relative otherwise, so a local build never emits production links.
+const BASE_PATH = process.env.BASE_PATH || "";
+const BASE_URL = process.env.BASE_URL;
+const site = `${BASE_URL ? new URL(BASE_URL).origin : ""}${BASE_PATH}`;
+
+/**
+ * Being text is not enough to be worth inlining. Nine files across the gallery
+ * are payloads that happen to have a source extension -- vendored
+ * `realism-effects` bundles, a 881 kB Inter atlas, one gltfjsx dump -- and
+ * together they are three quarters of the catalog's weight. Inlined, the largest
+ * example alone is ~258k tokens, which no reader can hold.
+ *
+ * 40 kB is where that split falls cleanly: every hand-written file in the
+ * gallery is under it (the largest, a gltfjsx-generated `Tower.tsx`, is 30 kB),
+ * and every file over it is generated or vendored. Those are listed with their
+ * size instead, so a reader knows they exist and where to find them.
+ */
+const MAX_FILE_BYTES = 40 * 1024;
+
+// Source we can hand to a reader as text. Everything else in `src/` is an asset
+// -- .glb, .jpg, .mp3 -- which is listed by path and left where it is.
+const TEXT_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".css",
+  ".json",
+  ".glsl",
+  ".vert",
+  ".frag",
+]);
+
+function readJson(...segments) {
+  return JSON.parse(fs.readFileSync(path.join(...segments), "utf8"));
+}
+
+/** Every file under `dir`, as paths relative to the example directory. */
+function walk(dir, base) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walk(absolute, base);
+      return [path.relative(base, absolute)];
+    })
+    .sort();
+}
+
+const websitePackage = readJson(websiteDirectory, "package.json");
+const names = Object.keys(websitePackage.dependencies ?? {})
+  .filter((dependency) => dependency.startsWith("@example/"))
+  .map((dependency) => dependency.slice("@example/".length))
+  .sort();
+
+if (names.length === 0) {
+  throw new Error(
+    "No @example/* dependencies in apps/website/package.json -- the catalog would be empty",
+  );
+}
+
+const index = [];
+
+fs.rmSync(outputDirectory, { recursive: true, force: true });
+fs.mkdirSync(outputDirectory, { recursive: true });
+
+for (const name of names) {
+  const exampleDirectory = path.join(examplesDirectory, name);
+  const { $schema, assets, ...metadata } = readJson(
+    exampleDirectory,
+    "pmndrs.json",
+  );
+  const packageJson = readJson(exampleDirectory, "package.json");
+
+  const paths = walk(path.join(exampleDirectory, "src"), exampleDirectory);
+  const sizeOf = (file) => fs.statSync(path.join(exampleDirectory, file)).size;
+  const isText = (file) => TEXT_EXTENSIONS.has(path.extname(file));
+  const isInlinable = (file) => isText(file) && sizeOf(file) <= MAX_FILE_BYTES;
+
+  // What the index carries: enough to choose an example without fetching it.
+  // `assets` -- the attribution and licensing records -- stays out; it is only
+  // needed once you are actually reusing the example.
+  const summary = {
+    name,
+    ...metadata,
+    demo: `${site}/examples/${name}`,
+    thumbnail: `${site}/${name}/thumbnail.webp`,
+  };
+  index.push(summary);
+
+  fs.writeFileSync(
+    path.join(outputDirectory, `${name}.json`),
+    `${JSON.stringify(
+      {
+        ...summary,
+        repository: `https://github.com/pmndrs/examples/tree/main/examples/${name}`,
+        install: `npx degit pmndrs/examples/examples/${name}`,
+        dependencies: packageJson.dependencies ?? {},
+        files: paths.filter(isInlinable).map((file) => ({
+          path: file,
+          content: fs.readFileSync(path.join(exampleDirectory, file), "utf8"),
+        })),
+        // Binary companions of the source -- models, textures, audio. Left as
+        // paths: they are in the repository, and `assets` says who made them.
+        binaries: paths.filter((file) => !isText(file)),
+        // Text, but generated or vendored past the point of being readable.
+        oversized: paths
+          .filter((file) => isText(file) && !isInlinable(file))
+          .map((file) => ({ path: file, bytes: sizeOf(file) })),
+        assets,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+fs.writeFileSync(
+  path.join(outputDirectory, "index.json"),
+  `${JSON.stringify({ site, count: index.length, examples: index }, null, 2)}\n`,
+);
+
+console.log(
+  `Wrote catalog for ${index.length} examples to ${path.relative(root, outputDirectory)}.`,
+);

--- a/bin/build-catalog.mjs
+++ b/bin/build-catalog.mjs
@@ -121,6 +121,13 @@ for (const name of names) {
     ...metadata,
     demo: `${site}/examples/${name}`,
     thumbnail: `${site}/${name}/thumbnail.webp`,
+    // How much source a reader takes on by opening this one. Examples run from
+    // a few hundred bytes to 90 kB, and without this in the index the choice is
+    // made blind -- which is what pushes a reader into "open one and hope"
+    // instead of opening the two that would answer the question.
+    bytes: paths
+      .filter(isInlinable)
+      .reduce((total, file) => total + sizeOf(file), 0),
   };
   index.push(summary);
 

--- a/test/turbo-cache.test.ts
+++ b/test/turbo-cache.test.ts
@@ -58,6 +58,7 @@ function withTouched<T>(file: string, run: () => T): T {
 const LINT = ["lint", "lint:examples", "lint:metadata", "lint:versions"];
 const FORMAT = ["format:check"];
 const BUILD = ["build2"];
+const WEBSITE_BUILD = ["build3"];
 
 const EXAMPLE = "@example/basic-example";
 const EXAMPLE_SOURCE = "examples/basic-example/src/App.tsx";
@@ -84,6 +85,38 @@ describe("build", () => {
 
     withTouched(OTHER_EXAMPLE_SOURCE, () => {
       expect(hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE)).toBe(before);
+    });
+  });
+});
+
+/**
+ * The website build also emits `/catalog/*.json` (`bin/build-catalog.mjs`),
+ * which is what the docs MCP server reads. A cache hit that skips it serves a
+ * catalog describing examples that have since changed -- and unlike a stale
+ * page, nobody looks at it, so nothing would ever report it.
+ */
+describe("catalog", () => {
+  it("re-runs the website build for the generator itself", () => {
+    const before = hashOf("website#build3", WEBSITE_BUILD);
+
+    withTouched("bin/build-catalog.mjs", () => {
+      expect(hashOf("website#build3", WEBSITE_BUILD)).not.toBe(before);
+    });
+  });
+
+  it("re-runs the website build when an example's metadata moves", () => {
+    const before = hashOf("website#build3", WEBSITE_BUILD);
+
+    withTouched("examples/wireframes/pmndrs.json", () => {
+      expect(hashOf("website#build3", WEBSITE_BUILD)).not.toBe(before);
+    });
+  });
+
+  it("leaves the website build alone for a docs-only change", () => {
+    const before = hashOf("website#build3", WEBSITE_BUILD);
+
+    withTouched("docs/agents/domain.md", () => {
+      expect(hashOf("website#build3", WEBSITE_BUILD)).toBe(before);
     });
   });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -14,9 +14,14 @@
     "website#build3": {
       "dependsOn": ["^build2"],
       "env": ["BASE_URL"],
+      // The catalog generator is a root file, so it falls outside the package's
+      // own inputs. What it *reads* need not be listed: every example's
+      // `pmndrs.json`, `package.json` and `src/` is already an input of that
+      // example's `build2`, which this task depends on.
       "inputs": [
         "$TURBO_DEFAULT$",
-        "../../packages/e2e/snapshot.test.js-snapshots/**"
+        "../../packages/e2e/snapshot.test.js-snapshots/**",
+        "../../bin/build-catalog.mjs"
       ],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "cache": true


### PR DESCRIPTION
## Why

The gallery is only reachable by running it. An agent asked *"how do I make glass refract in r3f"* has no way to find out that `caustics` exists, let alone read it, short of cloning the repo — so it writes the scene from memory instead of from the one that already works.

## What

`bin/build-catalog.mjs` emits, alongside the site:

- **`/catalog/index.json`** — every published example with its title, description, tags, libraries and source size. ~99 kB, an eighth of that over the wire.
- **`/catalog/{name}.json`** — that example in full: metadata, the exact dependency versions it is written against, its source files, and its asset attribution. Median 7 kB.

Two files rather than one because the index is what you read on every question and the example is what you read once you have chosen. A single bundle would be ~2 MB, paid in full to read one example.

The published set is `apps/website/package.json`'s `@example/*` dependencies — the same list the site itself builds from (`apps/website/lib/helper.ts`) — so `ssr-test` and `starwars` stay out of both.

### Files over 40 kB are named, not inlined

Nine files across the gallery are payloads that happen to have a source extension: vendored `realism-effects` bundles, an 881 kB Inter atlas, one gltfjsx dump. They are three quarters of the catalog's weight, and inlining them put one example at ~258k tokens. They now appear as `oversized: [{path, bytes}]`.

Every hand-written file in the gallery is under the threshold; the largest, a gltfjsx-generated `Tower.tsx`, is 30 kB. Catalog: 4.6 MB → 2.0 MB. Largest example: 258k → 23k tokens.

### `bytes` on each index entry

Sizes run from a few hundred bytes to 90 kB, and without this the consumer chooses blind. Eight examples are over 24 kB; the rest are cheap enough that reading three costs less than the index.

## Wiring

- runs from `apps/website`'s `dev` and `build` scripts (pnpm does not run `pre*` hooks by default, so it is explicit in the command)
- output gitignored at the repo root, where prettier also reads it
- `bin/build-catalog.mjs` added to `website#build3` inputs — what it *reads* needs no entry, since every example's `pmndrs.json`, `package.json` and `src/` is already an input of that example's `build2`, which the task depends on
- three cases in `test/turbo-cache.test.ts` pin that: a cache hit must not be able to serve a catalog describing examples that have since changed

## Verification

- `pnpm test:turbo` — 16 passing
- `pnpm lint`, `pnpm format:check`, `node bin/validate-pmndrs-metadata.mjs`
- built the site with `BASE_PATH`/`BASE_URL` set: 168 files land in `out/catalog/` with correct absolute URLs
- served that output and made real MCP calls against it from the docs branch below

## Consumer

pmndrs/docs reads these files to serve the gallery over MCP: pmndrs/docs#562. **This one ships first** — until it is deployed, that branch's `examples://index` fails with a clear `Failed to fetch … Not Found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)