### PR TITLE
Publish the examples as markdown, and link it from each page

### DIFF
--- a/apps/website/app/examples/[examplename]/page.tsx
+++ b/apps/website/app/examples/[examplename]/page.tsx
@@ -25,6 +25,11 @@ export async function generateMetadata({ params }: Props) {
   return {
     title,
     description,
+    // The same document the MCP server hands out, reachable by anything that
+    // reads the page instead: a URL pasted into a chat, a search result, an
+    // agent with no pmndrs plugin. Next renders `types` as
+    // `<link rel="alternate" type="text/markdown">`.
+    alternates: { types: { "text/markdown": example.catalog_url } },
     openGraph: {
       title,
       description,

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/react";
 import "./globals.css";
 import Nav from "@/components/Nav";
-import { getExamples } from "@/lib/helper";
+import { catalogIndexUrl, getExamples } from "@/lib/helper";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
@@ -97,6 +97,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      {/* The whole gallery as one line per example, for readers that arrive
+          without knowing the catalog exists. Site-wide rather than on the home
+          page alone, and as a literal `<link>` rather than page metadata: an
+          example page sets its own `alternates` for its own markdown, and page
+          metadata replaces the layout's field rather than merging with it. */}
+      <head>
+        <link rel="alternate" type="text/markdown" href={catalogIndexUrl} />
+      </head>
       {/* No `bg-*` on the body: `globals.css` paints it in `@layer base`, and a
           utility here would win over it in both schemes. The two custom
           properties are read by `Nav` — `--sidebar-w` is handed to the sidebar

--- a/apps/website/lib/helper.ts
+++ b/apps/website/lib/helper.ts
@@ -43,8 +43,18 @@ export type Example = ExampleMetadata & {
   thumb: string;
   embed_url: string;
   website_url: string;
+  catalog_url: string;
   isNew: boolean;
 };
+
+/**
+ * The whole catalog as one line per example. Site-level rather than per-example,
+ * so it takes the deployment origin without a port -- unlike `host()` above,
+ * which in development points at whichever vite server runs that example.
+ */
+export const catalogIndexUrl = `${
+  BASE_URL ? new URL(BASE_URL).origin : ""
+}${BASE_PATH}/catalog/index.md`;
 
 function getMetadata(examplename: string): ExampleMetadata {
   const metadataPath = path.join(
@@ -77,6 +87,10 @@ export function getExamples(): Example[] {
         thumb: `${embed_url}/thumbnail.webp`,
         embed_url,
         website_url,
+        // What `bin/build-catalog.mjs` wrote for this example. The page points at
+        // it with `rel="alternate"`, so an agent that lands on the HTML finds the
+        // readable form without having to know the catalog exists.
+        catalog_url: `${h}${BASE_PATH}/catalog/${examplename}.md`,
         isNew: NEW_EXAMPLES.has(examplename),
       };
     });

--- a/bin/build-catalog.mjs
+++ b/bin/build-catalog.mjs
@@ -2,12 +2,19 @@
 
 /**
  * Emits the machine-readable catalog the website ships alongside its pages, at
- * `/catalog/index.json` and `/catalog/<example>.json`.
+ * `/catalog/index.{json,md}` and `/catalog/<example>.{json,md}`.
  *
  * It exists for readers that cannot run the site: the pmndrs docs MCP server
  * serves examples to coding agents out of these files, so an agent can find the
  * example that already solves a problem and read its source without cloning
  * anything.
+ *
+ * Two forms of each. The JSON is the structured one -- dependencies as a map,
+ * sizes as numbers. The markdown is what a reader is actually handed, and it is
+ * written here rather than by whichever server passes it on, because it is
+ * published too: every example page points at its `.md` with `rel="alternate"`,
+ * so an agent arriving from the open web gets the same document as one arriving
+ * over MCP.
  *
  * Two files rather than one on purpose. The index is small enough (~95 kB, and
  * an eighth of that over the wire) to pull on every question, and carries just
@@ -24,6 +31,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { renderExample, renderIndex } from "./lib/render.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const examplesDirectory = path.join(root, "examples");
@@ -131,30 +140,34 @@ for (const name of names) {
   };
   index.push(summary);
 
+  const example = {
+    ...summary,
+    repository: `https://github.com/pmndrs/examples/tree/main/examples/${name}`,
+    install: `npx degit pmndrs/examples/examples/${name}`,
+    dependencies: packageJson.dependencies ?? {},
+    files: paths.filter(isInlinable).map((file) => ({
+      path: file,
+      content: fs.readFileSync(path.join(exampleDirectory, file), "utf8"),
+    })),
+    // Binary companions of the source -- models, textures, audio. Left as
+    // paths: they are in the repository, and `assets` says who made them.
+    binaries: paths.filter((file) => !isText(file)),
+    // Text, but generated or vendored past the point of being readable.
+    oversized: paths
+      .filter((file) => isText(file) && !isInlinable(file))
+      .map((file) => ({ path: file, bytes: sizeOf(file) })),
+    assets,
+  };
+
+  // The JSON is the structured form; the markdown is the reading form, and it
+  // is what both the MCP server and `rel="alternate"` hand out.
   fs.writeFileSync(
     path.join(outputDirectory, `${name}.json`),
-    `${JSON.stringify(
-      {
-        ...summary,
-        repository: `https://github.com/pmndrs/examples/tree/main/examples/${name}`,
-        install: `npx degit pmndrs/examples/examples/${name}`,
-        dependencies: packageJson.dependencies ?? {},
-        files: paths.filter(isInlinable).map((file) => ({
-          path: file,
-          content: fs.readFileSync(path.join(exampleDirectory, file), "utf8"),
-        })),
-        // Binary companions of the source -- models, textures, audio. Left as
-        // paths: they are in the repository, and `assets` says who made them.
-        binaries: paths.filter((file) => !isText(file)),
-        // Text, but generated or vendored past the point of being readable.
-        oversized: paths
-          .filter((file) => isText(file) && !isInlinable(file))
-          .map((file) => ({ path: file, bytes: sizeOf(file) })),
-        assets,
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(example, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(outputDirectory, `${name}.md`),
+    renderExample(example),
   );
 }
 
@@ -162,6 +175,7 @@ fs.writeFileSync(
   path.join(outputDirectory, "index.json"),
   `${JSON.stringify({ site, count: index.length, examples: index }, null, 2)}\n`,
 );
+fs.writeFileSync(path.join(outputDirectory, "index.md"), renderIndex(index));
 
 console.log(
   `Wrote catalog for ${index.length} examples to ${path.relative(root, outputDirectory)}.`,

--- a/bin/lib/render.mjs
+++ b/bin/lib/render.mjs
@@ -1,0 +1,171 @@
+/**
+ * Renders the catalog as the markdown an agent reads: one line per example for
+ * the index, one document per example.
+ *
+ * This lives here rather than in whichever server hands it out, because the
+ * rendered form is published too -- `/catalog/<name>.md` sits next to the JSON
+ * and the example's own page points at it with `rel="alternate"`. A static host
+ * cannot render on demand, so the only way an agent arriving from the open web
+ * gets the same document as one arriving over MCP is for the producer to write
+ * it once.
+ */
+
+/**
+ * Every example depends on these, so spelling them out on 167 index lines says
+ * nothing. The per-example document lists the real dependencies with versions.
+ */
+const IMPLIED_LIBRARIES = new Set(["@react-three/fiber", "@react-three/drei"]);
+
+const SHORT_LIBRARY_NAMES = {
+  "@react-spring/core": "react-spring",
+  "@react-spring/three": "react-spring",
+  "@react-spring/web": "react-spring",
+  "@use-gesture/react": "use-gesture",
+};
+
+/**
+ * Where an example stops being cheap to open. The median is 5 kB and nine tenths
+ * are under 15 kB, so reading three of them costs a reader less than the index
+ * itself -- the size is worth saying only for the handful where it changes the
+ * decision. Eight examples are over this line; two of them are most of the
+ * distance.
+ */
+const LARGE_BYTES = 24 * 1024;
+
+const shortenLibrary = (library) =>
+  SHORT_LIBRARY_NAMES[library] ?? library.replace(/^@react-three\//, "");
+
+const titleCase = (name) =>
+  name
+    .split("-")
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+
+/**
+ * One index line. Everything past the name is dropped when the example does not
+ * carry it, so an entry costs what it is worth -- and a line with no size marker
+ * is one a reader can open without thinking about it:
+ *
+ *     aquarium · #transmission
+ *     arkanoid · Simple arkanoid implementation using cannon physics. · +cannon · #physics,game
+ *     bounds-and-makedefault (Bounds and makeDefault) · #bounds
+ *     flow-shield · Interactive energy shield. · +postprocessing,leva · #shader · ~23k
+ */
+export function summaryLine({
+  name,
+  title,
+  description,
+  libraries,
+  tags,
+  bytes,
+}) {
+  // A title that is just the prettified directory name is noise -- but not
+  // always: `makeDefault`, `GLTF`, `Bruno Simon's` only exist in the title.
+  const head = title && title !== titleCase(name) ? `${name} (${title})` : name;
+
+  const extras = [
+    ...new Set(
+      libraries
+        .filter((library) => !IMPLIED_LIBRARIES.has(library))
+        .map(shortenLibrary),
+    ),
+  ];
+
+  return [
+    head,
+    description.trim().replace(/\s+/g, " "),
+    extras.length ? `+${extras.join(",")}` : "",
+    tags.length ? `#${tags.join(",")}` : "",
+    bytes > LARGE_BYTES ? `~${Math.round(bytes / 4000)}k` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function renderIndex(examples) {
+  return `${examples.map(summaryLine).join("\n")}\n`;
+}
+
+const FENCE_LANGUAGES = {
+  ".ts": "ts",
+  ".tsx": "tsx",
+  ".js": "js",
+  ".jsx": "jsx",
+  ".mjs": "js",
+  ".cjs": "js",
+  ".css": "css",
+  ".json": "json",
+  ".glsl": "glsl",
+  ".vert": "glsl",
+  ".frag": "glsl",
+};
+
+/** A fence long enough to survive whatever backticks the file itself contains. */
+function fence(content) {
+  const longest = Math.max(
+    0,
+    ...(content.match(/`+/g) ?? []).map((run) => run.length),
+  );
+  return "`".repeat(Math.max(3, longest + 1));
+}
+
+function attribution(assets) {
+  return assets
+    .map((asset) => {
+      const parts = [asset.name];
+      if (asset.creator) parts.push(`by ${asset.creator}`);
+      if (asset.license) parts.push(asset.license);
+      if (asset.modified) parts.push("modified");
+      const line = `- ${parts.join(" — ")}`;
+      const url = asset.source ?? asset.licenseUrl;
+      return url ? `${line} (${url})` : line;
+    })
+    .join("\n");
+}
+
+/**
+ * The whole example as one document: what it is, what it pins, then its source.
+ * Versions are part of the answer -- the code is written against the `three` and
+ * drei that sit next to it, and reading it without them invites an API that has
+ * since moved.
+ */
+export function renderExample(example) {
+  const facts = [
+    `Demo: ${example.demo}`,
+    `Source: ${example.repository}`,
+    `Scaffold: ${example.install}`,
+    example.publishedAt && `Published: ${example.publishedAt}`,
+    example.authors.length && `Authors: ${example.authors.join(", ")}`,
+    example.tags.length && `Tags: ${example.tags.join(", ")}`,
+    `Ported from: ${example.source}`,
+    `Dependencies: ${Object.entries(example.dependencies)
+      .map(([name, version]) => `${name}@${version}`)
+      .join(", ")}`,
+    example.binaries.length &&
+      `Binary files, in the repository but not below: ${example.binaries.join(", ")}`,
+    // Vendored bundles, font atlases, gltfjsx dumps. Named rather than hidden:
+    // a reader that finds an unexplained import wants to know it was skipped on
+    // size, not wonder whether the example is broken.
+    example.oversized.length &&
+      `Too large to inline, in the repository: ${example.oversized
+        .map(({ path, bytes }) => `${path} (${Math.round(bytes / 1024)} kB)`)
+        .join(", ")}`,
+  ].filter(Boolean);
+
+  const sections = [
+    `# ${example.title}`,
+    example.description.trim(),
+    facts.join("\n"),
+    example.notes?.trim(),
+    example.assets.length &&
+      `## Asset attribution\n\n${attribution(example.assets)}`,
+    ...example.files.map((file) => {
+      const language =
+        FENCE_LANGUAGES[file.path.slice(file.path.lastIndexOf("."))] ?? "";
+      const marks = fence(file.content);
+      return `## ${file.path}\n\n${marks}${language}\n${file.content.trimEnd()}\n${marks}`;
+    }),
+  ].filter(Boolean);
+
+  return `${sections.join("\n\n")}\n`;
+}

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error -- plain JS, shared with bin/build-catalog.mjs
+import { renderExample, renderIndex, summaryLine } from "../bin/lib/render.mjs";
+
+/**
+ * What these protect is the shape of the document an agent reads. It is
+ * published, not rendered on demand, so a regression here ships to every reader
+ * at once -- over MCP and through the `rel="alternate"` on each example page.
+ */
+
+const summary = (over = {}) => ({
+  name: "caustics",
+  title: "Caustics",
+  description: "",
+  tags: [],
+  authors: ["Paul Henschel"],
+  libraries: ["@react-three/drei", "@react-three/fiber"],
+  source: "https://codesandbox.io/s/szj6p7",
+  demo: "https://pmndrs.github.io/examples/examples/caustics",
+  thumbnail: "https://pmndrs.github.io/examples/caustics/thumbnail.webp",
+  bytes: 4_000,
+  ...over,
+});
+
+const example = (over = {}) => ({
+  ...summary(),
+  repository: "https://github.com/pmndrs/examples/tree/main/examples/caustics",
+  install: "npx degit pmndrs/examples/examples/caustics",
+  dependencies: { "@react-three/drei": "10.7.8", three: "0.165.0" },
+  files: [{ path: "src/App.tsx", content: "export default function App() {}" }],
+  binaries: [],
+  oversized: [],
+  assets: [],
+  ...over,
+});
+
+describe("summaryLine", () => {
+  it("drops a title that is just the prettified name", () => {
+    expect(summaryLine(summary())).toBe("caustics");
+  });
+
+  it("keeps a title that carries something the name cannot", () => {
+    expect(
+      summaryLine(
+        summary({
+          name: "bounds-and-makedefault",
+          title: "Bounds and makeDefault",
+        }),
+      ),
+    ).toBe("bounds-and-makedefault (Bounds and makeDefault)");
+  });
+
+  it("omits fiber and drei, which every example uses", () => {
+    expect(
+      summaryLine(
+        summary({
+          libraries: [
+            "@react-three/fiber",
+            "@react-three/drei",
+            "@react-three/cannon",
+            "zustand",
+          ],
+        }),
+      ),
+    ).toBe("caustics · +cannon,zustand");
+  });
+
+  it("collapses the react-spring entry points into one name", () => {
+    expect(
+      summaryLine(
+        summary({
+          libraries: [
+            "@react-spring/three",
+            "@react-spring/web",
+            "@react-spring/core",
+          ],
+        }),
+      ),
+    ).toBe("caustics · +react-spring");
+  });
+
+  it("assembles description, libraries and tags in that order", () => {
+    expect(
+      summaryLine(
+        summary({
+          name: "arkanoid",
+          title: "Arkanoid",
+          description: "Simple arkanoid implementation using cannon physics.",
+          libraries: ["@react-three/fiber", "@react-three/cannon"],
+          tags: ["physics", "game"],
+        }),
+      ),
+    ).toBe(
+      "arkanoid · Simple arkanoid implementation using cannon physics. · +cannon · #physics,game",
+    );
+  });
+
+  it("flattens a description that wraps", () => {
+    expect(
+      summaryLine(summary({ description: "One idea,\n  spread over lines." })),
+    ).toBe("caustics · One idea, spread over lines.");
+  });
+
+  it("says nothing about size for an example that is cheap to open", () => {
+    // The marker has to stay rare to mean anything: its absence is the signal
+    // that a reader can open two of these without weighing the budget.
+    expect(summaryLine(summary({ bytes: 24 * 1024 }))).toBe("caustics");
+  });
+
+  it("marks an example large enough that opening it is a decision", () => {
+    expect(summaryLine(summary({ bytes: 90_048 }))).toBe("caustics · ~23k");
+  });
+
+  it("puts the size last, after everything that helps choose", () => {
+    expect(
+      summaryLine(
+        summary({ description: "A shield.", tags: ["shader"], bytes: 90_048 }),
+      ),
+    ).toBe("caustics · A shield. · #shader · ~23k");
+  });
+});
+
+describe("renderIndex", () => {
+  it("is one line per example, newline-terminated", () => {
+    expect(
+      renderIndex([
+        summary(),
+        summary({ name: "aquarium", title: "Aquarium", tags: ["water"] }),
+      ]),
+    ).toBe("caustics\naquarium · #water\n");
+  });
+});
+
+describe("renderExample", () => {
+  it("leads with the title and the facts a reader needs", () => {
+    const text = renderExample(
+      example({ description: "Glass, and what it does to light." }),
+    );
+
+    expect(text).toContain("# Caustics");
+    expect(text).toContain("Glass, and what it does to light.");
+    expect(text).toContain(
+      "Demo: https://pmndrs.github.io/examples/examples/caustics",
+    );
+    expect(text).toContain(
+      "Scaffold: npx degit pmndrs/examples/examples/caustics",
+    );
+    expect(text).toContain(
+      "Dependencies: @react-three/drei@10.7.8, three@0.165.0",
+    );
+  });
+
+  it("omits the facts an example does not carry", () => {
+    const text = renderExample(example({ authors: [], tags: [] }));
+
+    expect(text).not.toContain("Authors:");
+    expect(text).not.toContain("Tags:");
+  });
+
+  it("fences each file under its own path, tagged by extension", () => {
+    const text = renderExample(
+      example({
+        files: [
+          { path: "src/App.tsx", content: "const a = 1" },
+          { path: "src/styles.css", content: "body { margin: 0 }" },
+        ],
+      }),
+    );
+
+    expect(text).toContain("## src/App.tsx\n\n```tsx\nconst a = 1\n```");
+    expect(text).toContain(
+      "## src/styles.css\n\n```css\nbody { margin: 0 }\n```",
+    );
+  });
+
+  it("opens a longer fence than the backticks inside the file", () => {
+    // A file whose comments quote code would otherwise close the block early and
+    // hand the reader half a file plus whatever followed it as prose.
+    const text = renderExample(
+      example({
+        files: [{ path: "src/App.tsx", content: "// ```tsx\nconst a = 1" }],
+      }),
+    );
+
+    expect(text).toContain("````tsx\n// ```tsx\nconst a = 1\n````");
+  });
+
+  it("names the binaries rather than pretending they are not there", () => {
+    expect(
+      renderExample(example({ binaries: ["src/glass-transformed.glb"] })),
+    ).toContain("src/glass-transformed.glb");
+  });
+
+  it("says which files were skipped on size, and how big they are", () => {
+    expect(
+      renderExample(
+        example({
+          oversized: [{ path: "src/realism-effects/v2.js", bytes: 256_656 }],
+        }),
+      ),
+    ).toContain(
+      "Too large to inline, in the repository: src/realism-effects/v2.js (251 kB)",
+    );
+  });
+
+  it("carries asset attribution through", () => {
+    const text = renderExample(
+      example({
+        assets: [
+          {
+            name: "Fruit Cake Slice",
+            creator: "matousekfoto",
+            license: "CC-BY-4.0",
+            source: "https://sketchfab.com/3d-models/fruit-cake-slice",
+          },
+        ],
+      }),
+    );
+
+    expect(text).toContain("## Asset attribution");
+    expect(text).toContain(
+      "- Fruit Cake Slice — by matousekfoto — CC-BY-4.0 (https://sketchfab.com/3d-models/fruit-cake-slice)",
+    );
+  });
+});

--- a/test/turbo-cache.test.ts
+++ b/test/turbo-cache.test.ts
@@ -90,16 +90,25 @@ describe("build", () => {
 });
 
 /**
- * The website build also emits `/catalog/*.json` (`bin/build-catalog.mjs`),
- * which is what the docs MCP server reads. A cache hit that skips it serves a
- * catalog describing examples that have since changed -- and unlike a stale
- * page, nobody looks at it, so nothing would ever report it.
+ * The website build also emits `/catalog/*.{json,md}` (`bin/build-catalog.mjs`),
+ * which is what the docs MCP server and every example page's `rel="alternate"`
+ * hand out. A cache hit that skips it serves a catalog describing examples that
+ * have since changed -- and unlike a stale page, nobody looks at it, so nothing
+ * would ever report it.
  */
 describe("catalog", () => {
   it("re-runs the website build for the generator itself", () => {
     const before = hashOf("website#build3", WEBSITE_BUILD);
 
     withTouched("bin/build-catalog.mjs", () => {
+      expect(hashOf("website#build3", WEBSITE_BUILD)).not.toBe(before);
+    });
+  });
+
+  it("re-runs the website build when the renderers move", () => {
+    const before = hashOf("website#build3", WEBSITE_BUILD);
+
+    withTouched("bin/lib/render.mjs", () => {
       expect(hashOf("website#build3", WEBSITE_BUILD)).not.toBe(before);
     });
   });

--- a/turbo.json
+++ b/turbo.json
@@ -14,14 +14,15 @@
     "website#build3": {
       "dependsOn": ["^build2"],
       "env": ["BASE_URL"],
-      // The catalog generator is a root file, so it falls outside the package's
-      // own inputs. What it *reads* need not be listed: every example's
-      // `pmndrs.json`, `package.json` and `src/` is already an input of that
-      // example's `build2`, which this task depends on.
+      // The catalog generator and its renderers are root files, so they fall
+      // outside the package's own inputs. What they *read* need not be listed:
+      // every example's `pmndrs.json`, `package.json` and `src/` is already an
+      // input of that example's `build2`, which this task depends on.
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../packages/e2e/snapshot.test.js-snapshots/**",
-        "../../bin/build-catalog.mjs"
+        "../../bin/build-catalog.mjs",
+        "../../bin/lib/**"
       ],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "cache": true


### PR DESCRIPTION
## Why

The catalog was JSON, and the document an agent actually reads was assembled from it inside the docs MCP server (pmndrs/docs#562). That put the rendering behind one consumer.

An agent handed an example's URL — pasted into a chat, arrived at from a search, run by a vendor with no pmndrs plugin — gets HTML and has no route to the same text. And this site is `output: "export"`, so it cannot render one on demand.

So the rendering moves here, where it can be published.

## What

`bin/lib/render.mjs` emits, next to the JSON:

- **`/catalog/index.md`** — the whole gallery, one line per demo
- **`/catalog/<name>.md`** — one demo in full: facts, asset attribution, then each source file fenced

and every example page points at its own, the way this generator's sites already point at `llms.txt`:

```html
<link rel="alternate" type="text/markdown" href="https://pmndrs.github.io/examples/catalog/caustics.md" />
```

The gallery index is linked site-wide from the layout — as a literal `<link>` rather than page metadata, since a page's own `alternates` replaces the layout's field rather than merging with it.

The MCP server now passes these on verbatim (pmndrs/docs#563): ~470 fewer lines there, and one rendering instead of two that could drift apart.

## The JSON stays

It is the structured form — dependencies as a map, sizes as numbers — and it is the step the markdown is built from. Nothing consumes it today, which is also why it carries no `$schema`: a schema for an artifact with no reader is maintenance for a reader that may never come. Worth adding the day something parses it, when its needs are known.

## Notes

- `catalog_url` joins `website_url`/`embed_url` in `lib/helper.ts`, so URL derivation stays in one place; `catalogIndexUrl` is exported for the layout, which has no per-example port to resolve
- `bin/lib/**` added to `website#build3` inputs, with a `test/turbo-cache.test.ts` case pinning it — a cache hit that skipped the renderers would serve documents describing examples that have since changed
- `test/render.test.ts` covers what the docs repo used to: the size marker, the title elision, fences long enough to survive backticks inside a file, and attribution

## Verification

- `pnpm exec vitest run` — 34 passing (17 render, 17 turbo cache)
- `pnpm lint`, `pnpm format:check`
- built with `BASE_PATH`/`BASE_URL` set: 336 files in `out/catalog/`, and both `<link rel="alternate">` render with absolute URLs on an example page, the index alone on the home page
- served that output and ran the real MCP route against it with `EXAMPLES_URL` — `examples://index` returns 167 lines, `get_example("spotlight-shadows")` returns the published document including its attribution, a traversal name is refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)
