### PR TITLE
Put the published documents at guessable URLs, and give the demos a head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ build
 dist
 # Written by bin/build-catalog.mjs into the website's public/, on its way to
 # out/. Here rather than in apps/website/.gitignore so that prettier, which
-# only reads the root one, skips it as well.
+# only reads the root one, skips them as well.
+apps/website/public/examples/
+apps/website/public/llms.txt
 apps/website/public/catalog/
 
 

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -97,13 +97,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      {/* The whole gallery as one line per example, for readers that arrive
-          without knowing the catalog exists. Site-wide rather than on the home
-          page alone, and as a literal `<link>` rather than page metadata: an
-          example page sets its own `alternates` for its own markdown, and page
-          metadata replaces the layout's field rather than merging with it. */}
+      {/* The whole gallery as one line per example, the way every site built
+          with pmndrs/docs points at its own `llms.txt`. Site-wide rather than on
+          the home page alone, and as a literal `<link>` rather than page
+          metadata: an example page sets its own `alternates` for its own
+          markdown, and page metadata replaces the layout's field rather than
+          merging with it. */}
       <head>
-        <link rel="alternate" type="text/markdown" href={catalogIndexUrl} />
+        <link rel="alternate" type="text/plain" href={catalogIndexUrl} />
       </head>
       {/* No `bg-*` on the body: `globals.css` paints it in `@layer base`, and a
           utility here would win over it in both schemes. The two custom

--- a/apps/website/lib/helper.ts
+++ b/apps/website/lib/helper.ts
@@ -48,13 +48,14 @@ export type Example = ExampleMetadata & {
 };
 
 /**
- * The whole catalog as one line per example. Site-level rather than per-example,
- * so it takes the deployment origin without a port -- unlike `host()` above,
- * which in development points at whichever vite server runs that example.
+ * The whole gallery as one line per example. Site-level rather than
+ * per-example, so it takes the deployment origin without a port -- unlike
+ * `host()` above, which in development points at whichever vite server runs
+ * that example.
  */
 export const catalogIndexUrl = `${
   BASE_URL ? new URL(BASE_URL).origin : ""
-}${BASE_PATH}/catalog/index.md`;
+}${BASE_PATH}/llms.txt`;
 
 function getMetadata(examplename: string): ExampleMetadata {
   const metadataPath = path.join(
@@ -87,10 +88,10 @@ export function getExamples(): Example[] {
         thumb: `${embed_url}/thumbnail.webp`,
         embed_url,
         website_url,
-        // What `bin/build-catalog.mjs` wrote for this example. The page points at
-        // it with `rel="alternate"`, so an agent that lands on the HTML finds the
-        // readable form without having to know the catalog exists.
-        catalog_url: `${h}${BASE_PATH}/catalog/${examplename}.md`,
+        // What `bin/build-catalog.mjs` wrote for this example -- this page's URL
+        // with `.md` on the end. The page points at it with `rel="alternate"`
+        // for readers that look, and the shape lets the rest guess.
+        catalog_url: `${website_url}.md`,
         isNew: NEW_EXAMPLES.has(examplename),
       };
     });

--- a/bin/build-catalog.mjs
+++ b/bin/build-catalog.mjs
@@ -1,31 +1,36 @@
 #!/usr/bin/env node
 
 /**
- * Emits the machine-readable catalog the website ships alongside its pages, at
- * `/catalog/index.{json,md}` and `/catalog/<example>.{json,md}`.
+ * Emits what the website ships for readers that cannot run it: the pmndrs docs
+ * MCP server serves examples to coding agents out of these files, and so does
+ * anything that just fetches a URL.
  *
- * It exists for readers that cannot run the site: the pmndrs docs MCP server
- * serves examples to coding agents out of these files, so an agent can find the
- * example that already solves a problem and read its source without cloning
- * anything.
+ * The URLs are the page URLs with an extension, so they can be guessed rather
+ * than discovered:
  *
- * Two forms of each. The JSON is the structured one -- dependencies as a map,
- * sizes as numbers. The markdown is what a reader is actually handed, and it is
- * written here rather than by whichever server passes it on, because it is
- * published too: every example page points at its `.md` with `rel="alternate"`,
- * so an agent arriving from the open web gets the same document as one arriving
- * over MCP.
+ *     /examples/aquarium        the page
+ *     /examples/aquarium.md     the same example, as the document an agent reads
+ *     /examples/aquarium.json   the same, structured -- deps as a map, sizes as numbers
+ *     /llms.txt                 the whole gallery, one line each
  *
- * Two files rather than one on purpose. The index is small enough (~95 kB, and
- * an eighth of that over the wire) to pull on every question, and carries just
- * enough -- title, description, tags, libraries -- to pick from; the per-example
- * file then costs one more request for the ~6 kB that actually answers it. A
- * single bundle would be ~2 MB, paid in full to read one example.
+ * `/llms.txt` rather than `/examples.md` because appending an extension only
+ * works for a page that has a filename: an agent that tries it on the gallery
+ * root asks for `/.md`. The root convention for "the whole site, for agents"
+ * already exists, and pmndrs/docs already publishes one.
+ *
+ * The markdown is written here rather than by whichever server passes it on,
+ * because it is published: every example page points at its `.md` with
+ * `rel="alternate"`, so an agent arriving from the open web gets the same
+ * document as one arriving over MCP.
+ *
+ * The index and the example are separate fetches on purpose. `/llms.txt` is
+ * ~19 kB and is read on every question; the example is the ~6 kB that answers
+ * it. One bundle would be ~2 MB, paid in full to read one example.
  *
  * The published set is whatever `apps/website/package.json` depends on, which is
  * what the site itself builds from (`apps/website/lib/helper.ts`). Example
  * directories that are not workspace dependencies -- `ssr-test`, `starwars` --
- * are not on the site and are not in the catalog either.
+ * are not on the site and are not published here either.
  */
 
 import fs from "node:fs";
@@ -37,7 +42,19 @@ import { renderExample, renderIndex } from "./lib/render.mjs";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const examplesDirectory = path.join(root, "examples");
 const websiteDirectory = path.join(root, "apps", "website");
-const outputDirectory = path.join(websiteDirectory, "public", "catalog");
+const publicDirectory = path.join(websiteDirectory, "public");
+// Siblings of the exported pages: Next writes `out/examples/<name>.html`, and
+// `public/` is copied over it verbatim.
+const outputDirectory = path.join(publicDirectory, "examples");
+const indexPath = path.join(publicDirectory, "llms.txt");
+
+/**
+ * Where these lived before the move, kept for exactly one release: the deployed
+ * MCP server still asks for them, and the two repos deploy on their own
+ * schedules. Delete once pmndrs/docs is serving from the URLs above -- nothing
+ * else has ever read them.
+ */
+const legacyDirectory = path.join(publicDirectory, "catalog");
 
 // Same derivation as `lib/helper.ts`: absolute when the build knows where it is
 // deploying, relative otherwise, so a local build never emits production links.
@@ -106,8 +123,10 @@ if (names.length === 0) {
 
 const index = [];
 
-fs.rmSync(outputDirectory, { recursive: true, force: true });
-fs.mkdirSync(outputDirectory, { recursive: true });
+for (const directory of [outputDirectory, legacyDirectory]) {
+  fs.rmSync(directory, { recursive: true, force: true });
+  fs.mkdirSync(directory, { recursive: true });
+}
 
 for (const name of names) {
   const exampleDirectory = path.join(examplesDirectory, name);
@@ -161,22 +180,18 @@ for (const name of names) {
 
   // The JSON is the structured form; the markdown is the reading form, and it
   // is what both the MCP server and `rel="alternate"` hand out.
+  const document = renderExample(example);
   fs.writeFileSync(
     path.join(outputDirectory, `${name}.json`),
     `${JSON.stringify(example, null, 2)}\n`,
   );
-  fs.writeFileSync(
-    path.join(outputDirectory, `${name}.md`),
-    renderExample(example),
-  );
+  fs.writeFileSync(path.join(outputDirectory, `${name}.md`), document);
+  fs.writeFileSync(path.join(legacyDirectory, `${name}.md`), document);
 }
 
-fs.writeFileSync(
-  path.join(outputDirectory, "index.json"),
-  `${JSON.stringify({ site, count: index.length, examples: index }, null, 2)}\n`,
-);
-fs.writeFileSync(path.join(outputDirectory, "index.md"), renderIndex(index));
+fs.writeFileSync(indexPath, renderIndex(index));
+fs.writeFileSync(path.join(legacyDirectory, "index.md"), renderIndex(index));
 
 console.log(
-  `Wrote catalog for ${index.length} examples to ${path.relative(root, outputDirectory)}.`,
+  `Wrote ${index.length} examples to ${path.relative(root, outputDirectory)}, and ${path.relative(root, indexPath)}.`,
 );

--- a/packages/e2e/src/vite-plugin-head.js
+++ b/packages/e2e/src/vite-plugin-head.js
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Gives every built example a `<head>` that says what it is.
+ *
+ * The demos are published at `/<name>/`, and that is the URL the READMEs' badges
+ * point at -- so it is the one people share. Until now it shipped vite's
+ * scaffold: `<title>Vite + React + TS</title>`, no description, and nothing
+ * connecting it to the page that frames it or to the document an agent can read.
+ * The website's own pages carry all of that; the demo itself carried none.
+ *
+ * So: the real title and description out of `pmndrs.json`, a `canonical`
+ * pointing at the page (they are the same example, and the page is the richer
+ * of the two), and the `rel="alternate"` that reaches the markdown -- the same
+ * three the page has.
+ *
+ * Only the built output. `vite dev` serves the untouched `index.html`, which is
+ * what you want while working on a demo.
+ */
+export default function vitePluginHead() {
+  let root;
+
+  return {
+    name: "vite-plugin-head",
+    apply: "build",
+
+    configResolved(config) {
+      root = config.root;
+    },
+
+    transformIndexHtml(html) {
+      const metadataPath = path.join(root, "pmndrs.json");
+      if (!fs.existsSync(metadataPath)) return html;
+
+      const { title, description } = JSON.parse(
+        fs.readFileSync(metadataPath, "utf8"),
+      );
+      const name = path.basename(root);
+
+      // Same derivation as the website's `lib/helper.ts`: absolute once the
+      // build knows where it is deploying, relative otherwise, so a local build
+      // never emits production links.
+      const BASE_PATH = process.env.BASE_PATH || "";
+      const BASE_URL = process.env.BASE_URL;
+      const site = `${BASE_URL ? new URL(BASE_URL).origin : ""}${BASE_PATH}`;
+      const page = `${site}/examples/${name}`;
+
+      const tags = [
+        `<link rel="canonical" href="${page}" />`,
+        `<link rel="alternate" type="text/markdown" href="${page}.md" />`,
+        `<link rel="alternate" type="text/plain" href="${site}/llms.txt" />`,
+      ];
+      if (description?.trim()) {
+        tags.push(
+          `<meta name="description" content="${escape(description)}" />`,
+        );
+      }
+
+      return html
+        .replace(
+          /<title>[^<]*<\/title>/,
+          `<title>${escape(title)} — pmndrs examples</title>`,
+        )
+        .replace("</head>", `  ${tags.join("\n    ")}\n  </head>`);
+    },
+  };
+}
+
+/** Attribute-safe: these come from `pmndrs.json`, which is prose. */
+function escape(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/packages/e2e/src/vite.config.build.ts
+++ b/packages/e2e/src/vite.config.build.ts
@@ -2,9 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 import monkeyPatch from "./vite-plugin-monkey";
+import head from "./vite-plugin-head";
 
 export default defineConfig({
-  plugins: [react(), monkeyPatch()],
+  plugins: [react(), monkeyPatch(), head()],
   resolve: {
     dedupe: ["three", "postprocessing"],
   },

--- a/test/turbo-cache.test.ts
+++ b/test/turbo-cache.test.ts
@@ -87,6 +87,24 @@ describe("build", () => {
       expect(hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE)).toBe(before);
     });
   });
+
+  /**
+   * The regression this exists for: `inputs` listed
+   * `packages/e2e/src/vite.config.ts`, which has never existed. The config the
+   * build actually loads is `vite.config.build.ts`, so every example's build
+   * kept replaying a cached pass over a config that had changed.
+   */
+  it.each([
+    "packages/e2e/src/vite.config.build.ts",
+    "packages/e2e/src/vite-plugin-head.js",
+    "packages/e2e/src/vite-plugin-monkey.js",
+  ])("re-runs every example build when %s moves", (file) => {
+    const before = hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE);
+
+    withTouched(file, () => {
+      expect(hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE)).not.toBe(before);
+    });
+  });
 });
 
 /**

--- a/test/vite-plugin-head.test.ts
+++ b/test/vite-plugin-head.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// @ts-expect-error -- plain JS, loaded by packages/e2e/src/vite.config.build.ts
+import vitePluginHead from "../packages/e2e/src/vite-plugin-head.js";
+
+/**
+ * The demos are published at `/<name>/`, and that is where the READMEs' badges
+ * point -- so it is the URL people share. What it says about itself is all this
+ * plugin, and none of it comes from the website that frames it.
+ */
+
+const HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body><div id="root"></div></body>
+</html>
+`;
+
+let root: string;
+
+function transform(metadata: unknown) {
+  writeFileSync(path.join(root, "pmndrs.json"), JSON.stringify(metadata));
+  const plugin = vitePluginHead();
+  plugin.configResolved({ root });
+  return plugin.transformIndexHtml(HTML);
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "aquarium-"));
+  process.env.BASE_PATH = "/examples";
+  process.env.BASE_URL = "https://pmndrs.github.io/examples";
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.BASE_PATH;
+  delete process.env.BASE_URL;
+});
+
+describe("vite-plugin-head", () => {
+  it("replaces vite's scaffold title with the example's own", () => {
+    const html = transform({ title: "Aquarium", description: "" });
+
+    expect(html).toContain("<title>Aquarium — pmndrs examples</title>");
+    expect(html).not.toContain("Vite + React + TS");
+  });
+
+  it("points at the page as canonical, and at both alternates", () => {
+    const html = transform({ title: "Aquarium", description: "" });
+    const site = "https://pmndrs.github.io/examples";
+    const name = path.basename(root);
+
+    expect(html).toContain(
+      `<link rel="canonical" href="${site}/examples/${name}" />`,
+    );
+    expect(html).toContain(
+      `<link rel="alternate" type="text/markdown" href="${site}/examples/${name}.md" />`,
+    );
+    expect(html).toContain(
+      `<link rel="alternate" type="text/plain" href="${site}/llms.txt" />`,
+    );
+  });
+
+  it("carries the description when the example has one", () => {
+    const html = transform({
+      title: "Arkanoid",
+      description: "Cannon physics.",
+    });
+
+    expect(html).toContain(
+      '<meta name="description" content="Cannon physics." />',
+    );
+  });
+
+  it("omits the description rather than emitting an empty one", () => {
+    // 39 of the 167 have none, and `content=""` is worse than silence.
+    expect(transform({ title: "Aquarium", description: "  " })).not.toContain(
+      'name="description"',
+    );
+  });
+
+  it("escapes what it takes from pmndrs.json", () => {
+    const html = transform({
+      title: 'Bruno "Simon" & co',
+      description: 'A <canvas> "demo" & more',
+    });
+
+    expect(html).toContain(
+      "<title>Bruno &quot;Simon&quot; &amp; co — pmndrs examples</title>",
+    );
+    expect(html).toContain(
+      '<meta name="description" content="A &lt;canvas&gt; &quot;demo&quot; &amp; more" />',
+    );
+  });
+
+  it("leaves the html alone when there is no metadata beside it", () => {
+    const plugin = vitePluginHead();
+    plugin.configResolved({ root });
+
+    expect(plugin.transformIndexHtml(HTML)).toBe(HTML);
+  });
+
+  it("only runs on builds -- `vite dev` serves the untouched file", () => {
+    expect(vitePluginHead().apply).toBe("build");
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -3,10 +3,13 @@
   "globalEnv": ["BASE_PATH"],
   "tasks": {
     "build2": {
+      // `vite.config.build.ts`, not `vite.config.ts`: the latter has never
+      // existed, so this pattern matched nothing and editing the config the
+      // build actually loads left the cache looking valid.
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../packages/e2e/bin/build.mjs",
-        "../../packages/e2e/src/{CheesyCanvas.jsx,deterministic.js,vite-plugin-monkey.js,vite.config.ts}"
+        "../../packages/e2e/src/{CheesyCanvas.jsx,deterministic.js,vite-plugin-monkey.js,vite-plugin-head.js,vite.config.build.ts}"
       ],
       "outputs": ["dist/**"],
       "cache": true


### PR DESCRIPTION
Two gaps, both about a reader arriving without being told anything.

## The documents were not guessable

They sat under `/catalog/`, so finding one meant reading the page's `<link>` first. They now sit where the page is, with an extension on the end:

| | |
| --- | --- |
| `/examples/aquarium` | the page |
| `/examples/aquarium.md` | the same example, as a document |
| `/examples/aquarium.json` | the same, structured |
| `/llms.txt` | the whole gallery, one line each |

That is what a reader tries unprompted, and the `rel="alternate"` stays for the ones that look rather than guess.

The index is `/llms.txt` rather than `/examples.md` because appending an extension only works for a page that has a filename — a reader trying it on the gallery root asks for `/.md`. The root convention for "the whole site, for agents" already exists, and every site built with pmndrs/docs publishes one.

**No `llms-full.txt`.** Concatenated, the gallery is ~1.5 MB — about 378k tokens, against ~50k for drei's. A documentation site is prose; 167 self-contained apps each repeat their `index.tsx`, `styles.css` and `vite-env.d.ts`. The index plus one example is the whole design.

## The demos said nothing at all

`/aquarium/` is what each README's badge points at, so it is the URL people actually share — and it shipped vite's scaffold:

```html
<title>Vite + React + TS</title>
```

No description, nothing connecting it to the page that frames it or to the document an agent can read. The website's pages carry all three; the demo carried none.

`packages/e2e/src/vite-plugin-head.js` gives it the real title and description from `pmndrs.json`, a `canonical` back to the page — they are the same example, and the page is the richer of the two — and the same two alternates. Build only: `vite dev` serves the untouched file, which is what you want while working on a demo.

## A turbo input that had never matched

`build2` listed `packages/e2e/src/vite.config.ts`. That file has never existed; the config the build actually loads is `vite.config.build.ts`. So editing the config left every example's cache looking valid, and the pattern silently matched nothing.

Fixed, with three cases pinning it — the config and both plugins. Worth noting since this PR adds a plugin to that very config, and would otherwise have inherited the bug.

## Verification

- `pnpm exec vitest run` — 44 passing (17 render, 7 head plugin, 20 turbo cache)
- `pnpm lint`, `pnpm format:check`, `node bin/validate-pmndrs-metadata.mjs`
- built with `BASE_PATH`/`BASE_URL`: `out/examples/aquarium.{html,md,json}` and `out/llms.txt` all land, both `<link rel="alternate">` render absolute
- built one example and read its `<head>`: title, canonical and both alternates present
- served the output and ran the real MCP route against it — index from `/llms.txt` returns 167 lines, `get_example("spotlight-shadows")` returns the document with its attribution, an unknown name 404s naming `examples/no-such-demo.md`

## Order

Ships first; pmndrs/docs#565 follows it to the new URLs.

Unlike the previous pair, this one *moves* files rather than adding them — the deployed MCP server still asks for `/catalog/`, and the two repos deploy on their own schedules. So the generator keeps writing the old paths too, byte-identical, for exactly one release. Zero downtime, and a follow-up deletes them once #565 is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
