### PR TITLE
Build the preview under the same base path as Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,25 +97,42 @@ jobs:
       #
       # Preview (only for pull requests)
       #
-      # The same build with no base path -- a preview is served from its own
-      # domain root -- uploaded as-is: Vercel hosts `out`, it never rebuilds it.
+      # The same `BASE_PATH` as the Pages build, and for the same reason the
+      # step above exists at all: `BASE_PATH` is a `globalEnv`, and it really
+      # does change every example's `dist` (vite's `--base`). Building the
+      # preview without it gave every `build2` a different hash -- 167 rebuilds,
+      # ~3.5min, and never a cache hit across runs either, since `main` never
+      # produces those hashes and a pull request cannot read another one's
+      # cache. With it, `pnpm test` above has already built all of them.
+      #
+      # What it costs: the preview is served from `<url>${BASE_PATH}`, not the
+      # domain root, since the pages link to each other by absolute path. That
+      # is the production layout, which is what a preview should be showing.
       - run: pnpm build
         if: ${{ env.PREVIEW == 'true' }}
+        env:
+          BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
       - id: preview
         if: ${{ env.PREVIEW == 'true' }}
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
         run: |
           mkdir -p .vercel/output
+          # `out`, not `out${BASE_PATH}`: the site lives one level down, and the
+          # static root has to be the level its absolute links resolve against
           mv out .vercel/output/static
           # `cleanUrls`: the website exports flat `<name>.html` pages and links
-          # to them without the extension
-          echo '{"version":3,"cleanUrls":true}' > .vercel/output/config.json
+          # to them without the extension. The route sends the bare deployment
+          # URL -- the one Vercel prints, and the one anyone trims to -- to the
+          # home page, which now sits under the base path rather than at `/`.
+          printf '{"version":3,"cleanUrls":true,"routes":[{"src":"/","status":308,"headers":{"Location":"%s"}}]}' \
+            "${BASE_PATH:-/}" > .vercel/output/config.json
           # `--archive`: one tarball, not 2.4k file uploads
           url=$(pnpm dlx vercel@latest deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN")
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "url=$url$BASE_PATH" >> "$GITHUB_OUTPUT"
       # The pull request's "View deployment" box, which Vercel's git integration
       # would have filled had we let it deploy
       - uses: actions/github-script@v9

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ it, the build always happens in the CI. Needs `VERCEL_TOKEN`, `VERCEL_ORG_ID` an
 `VERCEL_PROJECT_ID` as repo secrets; a pull request from a fork cannot read them,
 and gets no preview.
 
+The preview is built with the same `BASE_PATH` as the Pages one, so it is served
+from `<deployment-url>/examples` and not from the domain root — same layout as
+production, and the same `build2` cache entries, which is what keeps a preview
+an upload rather than a rebuild of all 167 examples.
+
 # test
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "turbo": "^2.10.7",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.66.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.9.0"
   },
   "engines": {
     "node": ">=24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   apps/website:
     dependencies:

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `turbo-cache.test.ts` asserts which *file* invalidates which task. This one
+ * asserts the other half of the same contract -- which *env* does -- because
+ * `BASE_PATH` is a `globalEnv` that genuinely changes what a `build2` emits
+ * (vite's `--base`), and nothing in a green run says so.
+ *
+ * #165 added the preview upload on the stated grounds that "`test` already
+ * builds every example, so the extra `pnpm build` on a pull request is the
+ * website plus `out.sh`; the rest is a turbo cache hit" -- and left `BASE_PATH`
+ * unset for that one build. Both halves cannot be true: every `build2` hashed
+ * differently, so a pull request rebuilt all 167 (~3.5min), and never hit the
+ * cache across runs either, since `main` never produces those hashes and one
+ * pull request cannot read another's cache. `main` stayed a cache hit
+ * throughout, which is why two years of green runs never mentioned it.
+ *
+ * So: every step that builds runs under the same `BASE_PATH`, or one of them is
+ * paying for a full rebuild of the examples.
+ */
+
+const root = path.resolve(import.meta.dirname, "..");
+
+/**
+ * `pnpm build`, `pnpm test`, `pnpm exec turbo test` -- and not `pnpm check`,
+ * `pnpm install`, or `pnpm test:turbo`, which resolves hashes without building.
+ */
+const BUILDS =
+  /\b(?:pnpm|turbo)\s+(?:exec\s+turbo\s+)?(?:build|test)(?![\w:-])/;
+
+type Step = { run?: string; env?: Record<string, string> };
+type Workflow = { jobs: Record<string, { steps?: Step[] }> };
+
+const workflow = parse(
+  readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8"),
+) as Workflow;
+
+const steps = Object.values(workflow.jobs)
+  .flatMap((job) => job.steps ?? [])
+  .filter((step) => step.run && BUILDS.test(step.run));
+
+describe("ci.yml", () => {
+  // A canary on the regex above: if the steps are renamed out from under it,
+  // an empty list would satisfy every assertion below.
+  it("runs the examples through turbo in four steps", () => {
+    expect(steps.map((step) => step.run!.trim())).toEqual([
+      "pnpm test",
+      "pnpm exec turbo test --force -- --update-snapshots=all",
+      "pnpm build",
+      "pnpm build",
+    ]);
+  });
+
+  it("gives each of them a BASE_PATH", () => {
+    for (const step of steps) {
+      expect(step.env?.BASE_PATH, step.run).toBeDefined();
+    }
+  });
+
+  it("gives them all the same one", () => {
+    const values = new Set(steps.map((step) => step.env?.BASE_PATH));
+    expect([...values]).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Every pull request was rebuilding all 167 examples, for nothing.

| step | pull request ([run](https://github.com/pmndrs/examples/actions/runs/31585017756)) | push on `main` ([run](https://github.com/pmndrs/examples/actions/runs/31585609871)) |
| --- | --- | --- |
| `pnpm test` | 149/170 cached | 170/170 FULL TURBO |
| `pnpm build` | **0/168 cached — 3m34** | 167/168 cached — 11s |

#165 added the preview upload on the stated grounds that "`test` already builds every example, so the extra `pnpm build` on a pull request is the website plus `out.sh`; the rest is a turbo cache hit" — and, two paragraphs later, left `BASE_PATH` unset for that build, since a preview is served from its own domain root. Both cannot be true: `BASE_PATH` is a `globalEnv`, and it really does change what every example emits (vite's `--base`). So the preview build shared no `build2` hash with the `pnpm test` that had just built all of them.

It never hit across runs either. `main` never builds without the base path, so those hashes only ever exist in the cache scope of the pull request that wrote them, and no other one can read it. `main` stayed 167/168 cached and 12s throughout — which is why the runs never looked wrong.

## What this does

- the preview `pnpm build` gets the same `BASE_PATH` as the Pages one
- the Vercel static root moves up one level, to `out/` — the directory the pages' absolute links resolve against
- a `308` sends the bare deployment URL (the one Vercel prints, and the one anyone trims to) to `/examples`
- the deployment status URL points at `<url>/examples`

The preview is now the production layout rather than a second one nobody serves.

## The guard

`turbo-cache.test.ts` asserts which *file* invalidates which task; nothing asserted which *env* does, which is the hole #165 went through. `test/ci-workflow.test.ts` parses the workflow and requires every step that builds to run under the same `BASE_PATH`. Reverting the one-line fix fails it with `pnpm build: expected undefined to be defined`.

Costs one devDependency, `yaml`.

## Verified

- `turbo test --dry` vs `turbo build3 --dry` at `BASE_PATH=/examples`: **167/167 `build2` hashes identical**, 0 divergent (before: 167/167 divergent)
- generated `config.json` parses, `Location: /examples`
- `pnpm check` and `pnpm test:turbo` (37 tests) pass

Expected on this very pull request: the preview step drops from ~3m34 to ~10s. The one task still rebuilding is `website#build3`, because `BASE_URL` cannot be known before the deploy exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
