### PR TITLE
Drop the transitional paths, and give the demos absolute URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ dist
 # only reads the root one, skips them as well.
 apps/website/public/examples/
 apps/website/public/llms.txt
-apps/website/public/catalog/
 
 
 # Debug

--- a/bin/build-catalog.mjs
+++ b/bin/build-catalog.mjs
@@ -48,14 +48,6 @@ const publicDirectory = path.join(websiteDirectory, "public");
 const outputDirectory = path.join(publicDirectory, "examples");
 const indexPath = path.join(publicDirectory, "llms.txt");
 
-/**
- * Where these lived before the move, kept for exactly one release: the deployed
- * MCP server still asks for them, and the two repos deploy on their own
- * schedules. Delete once pmndrs/docs is serving from the URLs above -- nothing
- * else has ever read them.
- */
-const legacyDirectory = path.join(publicDirectory, "catalog");
-
 // Same derivation as `lib/helper.ts`: absolute when the build knows where it is
 // deploying, relative otherwise, so a local build never emits production links.
 const BASE_PATH = process.env.BASE_PATH || "";
@@ -123,10 +115,8 @@ if (names.length === 0) {
 
 const index = [];
 
-for (const directory of [outputDirectory, legacyDirectory]) {
-  fs.rmSync(directory, { recursive: true, force: true });
-  fs.mkdirSync(directory, { recursive: true });
-}
+fs.rmSync(outputDirectory, { recursive: true, force: true });
+fs.mkdirSync(outputDirectory, { recursive: true });
 
 for (const name of names) {
   const exampleDirectory = path.join(examplesDirectory, name);
@@ -180,17 +170,17 @@ for (const name of names) {
 
   // The JSON is the structured form; the markdown is the reading form, and it
   // is what both the MCP server and `rel="alternate"` hand out.
-  const document = renderExample(example);
   fs.writeFileSync(
     path.join(outputDirectory, `${name}.json`),
     `${JSON.stringify(example, null, 2)}\n`,
   );
-  fs.writeFileSync(path.join(outputDirectory, `${name}.md`), document);
-  fs.writeFileSync(path.join(legacyDirectory, `${name}.md`), document);
+  fs.writeFileSync(
+    path.join(outputDirectory, `${name}.md`),
+    renderExample(example),
+  );
 }
 
 fs.writeFileSync(indexPath, renderIndex(index));
-fs.writeFileSync(path.join(legacyDirectory, "index.md"), renderIndex(index));
 
 console.log(
   `Wrote ${index.length} examples to ${path.relative(root, outputDirectory)}, and ${path.relative(root, indexPath)}.`,

--- a/test/turbo-cache.test.ts
+++ b/test/turbo-cache.test.ts
@@ -105,6 +105,23 @@ describe("build", () => {
       expect(hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE)).not.toBe(before);
     });
   });
+
+  /**
+   * `vite-plugin-head` puts absolute URLs in each demo's `<head>`, so the
+   * deployment origin is part of the output. Undeclared, turbo does not pass
+   * `BASE_URL` to the task at all -- not a stale cache, the variable simply
+   * never arrives -- and every demo shipped root-relative links instead.
+   */
+  it("re-runs every example build when the deployment origin changes", () => {
+    const before = hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE);
+
+    process.env.BASE_URL = "https://example.test";
+    try {
+      expect(hashOf(`${EXAMPLE}#build2`, BUILD, EXAMPLE)).not.toBe(before);
+    } finally {
+      delete process.env.BASE_URL;
+    }
+  });
 });
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,11 @@
   "globalEnv": ["BASE_PATH"],
   "tasks": {
     "build2": {
+      // `vite-plugin-head` puts absolute URLs in each demo's <head>, so it
+      // needs the deployment origin. Undeclared, turbo does not pass it to the
+      // task at all -- not a stale cache, the variable simply never arrives --
+      // and every demo shipped root-relative links instead.
+      "env": ["BASE_URL"],
       // `vite.config.build.ts`, not `vite.config.ts`: the latter has never
       // existed, so this pattern matched nothing and editing the config the
       // build actually loads left the cache looking valid.


### PR DESCRIPTION
Two loose ends from #180.

## The transitional paths

pmndrs/docs#565 is deployed and reading from `/examples/<name>.md` and `/llms.txt`. The copies under `/catalog/`, which existed only to carry the previous release across the gap between two deploys, have no reader left.

## A bug that release shipped

`vite-plugin-head` writes absolute URLs into each demo's `<head>`, which needs the deployment origin. `build2` never declared `BASE_URL` — and turbo does not pass an undeclared variable to a task at all.

Not a stale cache. The variable simply never arrived, `--force` and all:

```
$ BASE_URL=https://pmndrs.github.io/examples pnpm exec turbo run build2 --filter=@example/aquarium --force
$ grep canonical examples/aquarium/dist/index.html
<link rel="canonical" href="/examples/examples/aquarium" />
```

So every demo went out with root-relative links. They resolve against the document, so nothing is broken — but they are not what the plugin is written to emit, nor what its own test asserts, and a `canonical` is the one place where an absolute URL genuinely earns its keep.

With `"env": ["BASE_URL"]` on the task:

```
<title>Aquarium — pmndrs examples</title>
<link rel="canonical" href="https://pmndrs.github.io/examples/examples/aquarium" />
<link rel="alternate" type="text/markdown" href="https://pmndrs.github.io/examples/examples/aquarium.md" />
<link rel="alternate" type="text/plain" href="https://pmndrs.github.io/examples/llms.txt" />
```

A case in `test/turbo-cache.test.ts` pins it, and it is a real pin — reverted, it fails on exactly the identical hashes the bug produced:

```
AssertionError: expected 'ea02ca5966fca844' not to be 'ea02ca5966fca844'
```

That file tests which *files* make which task re-run; this is its first case about an environment variable, which turns out to be the same class of silent staleness.

## Verification

- `pnpm exec vitest run` — 45 passing; `pnpm lint`, `pnpm format:check`
- built one example through turbo, before and after, with the output quoted above
- built the site: `out/examples/caustics.{html,md,json}` and `out/llms.txt` all land, and `out/catalog/` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
