### PR TITLE
Shoot the dist that ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,14 @@ jobs:
           [ -z "$filters" ] || pnpm exec turbo test --continue --concurrency=1 $filters
         env:
           BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
+          # `build2` hashes on `BASE_URL` too (`vite-plugin-head` writes the
+          # deployment origin into each demo's <head>). Without it here, the
+          # shards built a *different* artifact from the one `build-job`
+          # publishes -- so the shot was of a dist nobody deploys, and every
+          # `build2` below re-ran despite 161 warm cache entries, since a
+          # different env is a different hash. Same value, same artifact:
+          # what gets tested is what ships, and build-job is a cache hit.
+          BASE_URL: ${{ steps.configurepages.outputs.base_url }}
 
       # Even when the shard went red: a failing example still archives, and the
       # Chromatic build has to see every published example or it reads the
@@ -231,6 +239,11 @@ jobs:
         if: ${{ env.PREVIEW == 'true' }}
         env:
           BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
+          # The production origin, deliberately: the <head> URLs are canonical
+          # links, and a preview that is "the production layout" should carry
+          # them too -- besides, a different value is a different `build2`
+          # hash, and the whole point is that the shards already built this.
+          BASE_URL: ${{ steps.configurepages.outputs.base_url }}
       - id: preview
         if: ${{ env.PREVIEW == 'true' }}
         env:

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -173,14 +173,21 @@ describe("ci.yml", () => {
     expect(buildingSteps().length).toBeGreaterThan(0);
   });
 
-  it("gives each of those steps a BASE_PATH", () => {
-    for (const step of buildingSteps()) {
-      expect(step.env?.BASE_PATH, step.run).toBeDefined();
-    }
-  });
+  // `BASE_URL` rides along: `build2` declares it in its `env` (vite-plugin-head
+  // writes the deployment origin into each demo's <head>), so it is part of the
+  // hash for the same reason `BASE_PATH` is. #180 added it to the build steps
+  // only, and for a while the shards quietly built -- and shot -- a dist nobody
+  // deploys, while build-job rebuilt all 161 examples on every run.
+  for (const name of ["BASE_PATH", "BASE_URL"] as const) {
+    it(`gives each of those steps a ${name}`, () => {
+      for (const step of buildingSteps()) {
+        expect(step.env?.[name], step.run).toBeDefined();
+      }
+    });
 
-  it("gives them all the same one", () => {
-    const values = new Set(buildingSteps().map((step) => step.env?.BASE_PATH));
-    expect([...values]).toHaveLength(1);
-  });
+    it(`gives them all the same ${name}`, () => {
+      const values = new Set(buildingSteps().map((step) => step.env?.[name]));
+      expect([...values]).toHaveLength(1);
+    });
+  }
 });


### PR DESCRIPTION
`build2` hashes on `BASE_URL` (`vite-plugin-head` writes the deployment origin into each demo's `<head>`), and #180 set it on the build steps only. Since then the test shards have been building — and shooting — a dist nobody deploys, and `build-job` rebuilt all 161 examples on every run: 161 warm cache entries, zero hits, because a different env is a different hash. Measured on the first post-merge `main` run: the same `build2` hashed `9d2cc95a` in its shard and `d159d7d5` in `build-job`.

The shards and the preview now carry the same `BASE_URL` as the Pages build:

- what gets tested is what ships,
- `build-job` and the preview go back to being cache hits (~3-4 min per run),
- the `ci-workflow` invariants now assert `BASE_URL` alongside `BASE_PATH`, so the next variable added to `build2`'s env cannot drift apart quietly.

The `<head>` is metadata, so no canvas changes — but the `build2` hashes move once, so the next run is cold, once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
