### PR TITLE
Freeze the one clock still ticking: User Timing

### DIFF
--- a/bin/e2e-exceptions.mjs
+++ b/bin/e2e-exceptions.mjs
@@ -111,6 +111,16 @@ export const EXCEPTIONS = {
 // sustained load, plus a parallel sweep hammering the six heaviest with
 // ~135 extra shots -- caught nothing, twice over.
 //
+// One mechanism arrived after that certification, and from production, which
+// is the other measurement lesson: the certifying protocol hashes the WebGL
+// canvas, Chromatic archives the whole DOM -- stats-gl's little panel
+// canvases included -- so `clouds` could flip a digit of real CPU time on its
+// StatsGl panel through every local pass without the protocol ever seeing
+// it. Chromatic build 42 saw it. The wall time got there through the User
+// Timing API: `performance.mark` stamps the browser's internal clock, not
+// `performance.now`, so it walked straight past the virtual clock until
+// `deterministic.js` moved marks onto it too.
+//
 // It is still sampling -- the nightly, which shoots five times on the runner
 // that actually takes the picture, is what keeps the claim honest over time,
 // and this list is where its catches land. An entry here is a promise to

--- a/packages/e2e/src/deterministic.js
+++ b/packages/e2e/src/deterministic.js
@@ -184,6 +184,29 @@ if (sayCheeseParam) {
   const rAF = window.requestAnimationFrame.bind(window);
   window.requestAnimationFrame = (callback) => rAF(() => callback(virtual));
 
+  // The User Timing API is its own clock: `performance.mark()` stamps the
+  // browser's internal monotonic time, and `measure().duration` is computed
+  // from those stamps -- none of it goes through `performance.now`, so it is
+  // the one channel wall time still had into the page. And into the pixels:
+  // stats-gl profiles each frame's CPU cost with mark/measure pairs, and the
+  // max of that range is printed onto the `clouds` StatsGl panel, one machine
+  // measurement away from flipping a digit. Marks land on the virtual clock
+  // instead; anything measured inside one pumped frame is exactly 0. Nothing
+  // is forwarded to the native calls on purpose -- a real entry in the buffer
+  // would hand `getEntriesByName` the same wall time back.
+  const marks = new Map();
+  performance.mark = (name) => {
+    marks.set(name, virtual);
+    return { name, entryType: "mark", startTime: virtual, duration: 0 };
+  };
+  performance.measure = (name, start, end) => {
+    // Marks we never saw (or the options-object form) resolve to `virtual`:
+    // every unknown duration is 0, which is the deterministic answer.
+    const from = marks.get(start) ?? virtual;
+    const to = marks.get(end) ?? virtual;
+    return { name, entryType: "measure", startTime: from, duration: to - from };
+  };
+
   //
   // Timers move onto the virtual clock too -- but only once the shot starts.
   //


### PR DESCRIPTION
[Build 42](https://www.chromatic.com/build?appId=6a7ac255b03218d7d84e6ca9&number=42) found 1 change: eight pixels on `clouds`, the StatsGl panel flipping `(1.21-25.3)` to `(1.21-24.5)` — a digit of real machine time in an otherwise deterministic capture.

The wall time got in through the one clock the harness didn't own: **the User Timing API**. `performance.mark` stamps the browser's internal monotonic clock and `measure()` computes durations from those stamps — none of it goes through `performance.now`, so virtualizing `now` never touched it. stats-gl profiles each frame's CPU cost with mark/measure pairs and prints the max onto the panel.

Marks now land on the virtual clock, measures are computed from the stored marks, and nothing is forwarded to the native calls (a real entry in the buffer would hand `getEntriesByName` the same wall time back). Anything measured inside one pumped frame is exactly 0.

Two things worth writing down:

- **The local protocol could never have seen this.** `flaky.mjs` hashes the WebGL canvas; Chromatic archives the whole DOM, stats-gl's panel canvases included. Production caught what certification structurally couldn't.
- **Verified by hashing every canvas on the page** over four cold sessions: the WebGL canvas and both 90×48 panel canvases, byte-identical each time.

The `clouds` baseline moves once (the CPU readout is a frozen `0.00` now), then never again. Only `clouds` is exposed — the five examples with drei `<Stats>` read `performance.now`, which is already virtual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
