### PR TITLE
A visual change is a red pull request now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,15 @@ jobs:
       # secrets. Main has to publish too, or a pull request would have no
       # baseline to compare to.
       #
+      # No `--exit-zero-on-changes`: a visual change fails the pull request
+      # until someone accepts it in the Chromatic UI and re-runs this job. The
+      # snapshots are deterministic, so a change is never noise -- either the
+      # pull request meant it, and accepting is the review working, or it
+      # touched nothing near that example and red is the right answer. Build 42
+      # went green with exactly such a change waiting unreviewed.
+      #
       # `--auto-accept-changes` on main, and only there. What lands on main has
-      # already been looked at on its pull request, so asking a second time
+      # already been accepted on its pull request, so asking a second time
       # leaves a queue of unreviewed changes that turns every later build
       # yellow -- and a permanently yellow dashboard is one nobody opens.
       #
@@ -178,7 +185,7 @@ jobs:
       # times, and the nightly is what keeps asking. Chromatic answers "should
       # this have changed?", which only makes sense once the answer to "did
       # anything change by itself?" is no.
-      - run: pnpm chromatic --exit-zero-on-changes ${{ github.ref == 'refs/heads/main' && '--auto-accept-changes' || '' }}
+      - run: pnpm chromatic ${{ github.ref == 'refs/heads/main' && '--auto-accept-changes' || '' }}
         if: ${{ env.CHROMATIC == 'true' }}
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
Chromatic ran with `--exit-zero-on-changes`: a visual change surfaced as "1 Unreviewed" in the UI and the check stayed green. [Build 42](https://www.chromatic.com/build?appId=6a7ac255b03218d7d84e6ca9&number=42) went green with a drifting `clouds` panel waiting unreviewed, and nothing ever forced anyone to look.

That flag was the right call while snapshots drifted on their own. With the harness deterministic, a change is never noise: either the pull request meant it — accept it in the Chromatic UI and re-run the job — or it touched nothing near that example and red is the right answer.

`--auto-accept-changes` on main stays: what lands there was accepted on its pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
