### PR TITLE
A visual change is Chromatic's to report, not this job's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,12 +167,18 @@ jobs:
       # secrets. Main has to publish too, or a pull request would have no
       # baseline to compare to.
       #
-      # No `--exit-zero-on-changes`: a visual change fails the pull request
-      # until someone accepts it in the Chromatic UI and re-runs this job. The
-      # snapshots are deterministic, so a change is never noise -- either the
-      # pull request meant it, and accepting is the review working, or it
-      # touched nothing near that example and red is the right answer. Build 42
-      # went green with exactly such a change waiting unreviewed.
+      # `--exit-zero-on-changes`: a visual change is Chromatic's to report, not
+      # this job's. The job answers "did the upload work?"; the UI Tests check
+      # Chromatic posts on the commit answers "should this have changed?", and
+      # it stays red until someone accepts the build -- no re-run of this job
+      # needed. Failing here on top of that said "broken" where the truth was
+      # "waiting for you", and it hid a real one: a `pnpm chromatic` that
+      # cannot upload looks exactly like 68 snapshots pending review.
+      #
+      # That requires the Chromatic GitHub app to be installed on the
+      # repository, which is what publishes the UI Tests check. Without it a
+      # changed build reports nothing at all, and this flag is how changes pile
+      # up unreviewed -- build 42 went green with exactly one waiting.
       #
       # `--auto-accept-changes` on main, and only there. What lands on main has
       # already been accepted on its pull request, so asking a second time
@@ -185,7 +191,7 @@ jobs:
       # times, and the nightly is what keeps asking. Chromatic answers "should
       # this have changed?", which only makes sense once the answer to "did
       # anything change by itself?" is no.
-      - run: pnpm chromatic ${{ github.ref == 'refs/heads/main' && '--auto-accept-changes' || '' }}
+      - run: pnpm chromatic ${{ github.ref == 'refs/heads/main' && '--auto-accept-changes' || '--exit-zero-on-changes' }}
         if: ${{ env.CHROMATIC == 'true' }}
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
#186 made a changed Chromatic build fail `chromatic-job`, so that a change nobody accepted could not read as green. Right rule, wrong place.

Chromatic posts its own **UI Tests** check on the commit. It is red while a build has unaccepted changes and it clears itself the moment someone accepts -- no re-run of anything. `chromatic-job` failing on top of that adds no signal and costs two:

- a pull request that *meant* its change reads as broken rather than as waiting for review (#166: 68 snapshots, all expected from three 0.165 -> 0.181);
- the one failure worth seeing here -- an upload that did not work, an expired token, an archive that never arrived -- looks exactly like 68 snapshots pending review.

So `--exit-zero-on-changes` off main. This job answers "did the upload work?"; Chromatic answers "should this have changed?". `--auto-accept-changes` on main is unchanged.

## Before merging: the GitHub app

There is no UI Tests check on this repository today -- the check-runs on #166's head are the Actions jobs and nothing else, so the Chromatic GitHub app is not installed:

```
$ gh api repos/pmndrs/examples/commits/<sha>/check-runs --jq '.check_runs[] | "\(.app.slug)\t\(.name)"'
github-actions  test-job (1)
github-actions  chromatic-job
...
```

Until it is installed (chromatic.com -> the project -> Manage -> Integrations -> GitHub), this flag removes the gate rather than moving it: a changed build reports nothing at all, which is how build 42 went green with a change waiting unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
