### PR TITLE
Report the shot at the commit that has a branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,15 +202,23 @@ jobs:
       # twelve check runs on `5520f5f2`, three Chromatic statuses on the merge
       # commit `aefcbe4`, no overlap.
       #
-      # Empty on a push, where `GITHUB_SHA` is already the commit itself.
+      # It also picks the wrong baseline. That merge commit has the latest
+      # build on main for an ancestor -- the pull request's own branch does
+      # not -- so every comparison is made against main rather than against
+      # what this branch last looked like.
+      #
+      # Chromatic's own answer is to run this on `push` instead, which for
+      # this workflow would mean the whole 20-minute sweep on every branch
+      # push, pull request or not. So: the documented alternative, verbatim,
+      # falling back to the push values on main.
       #
       - run: pnpm chromatic ${{ github.ref == 'refs/heads/main' && '--auto-accept-changes' || '--exit-zero-on-changes' }}
         if: ${{ env.CHROMATIC == 'true' }}
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
-          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref }}
-          CHROMATIC_SLUG: ${{ github.event.pull_request.head.repo.full_name }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          CHROMATIC_SLUG: ${{ github.repository }}
 
   #
   # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,26 @@ jobs:
       # times, and the nightly is what keeps asking. Chromatic answers "should
       # this have changed?", which only makes sense once the answer to "did
       # anything change by itself?" is no.
+      #
+      # `CHROMATIC_SHA`, and the branch and slug that have to travel with it,
+      # because on a `pull_request` event `GITHUB_SHA` is the *merge* commit
+      # GitHub builds for the run -- a commit that exists on no branch. Left
+      # alone, Chromatic posts `UI Tests` and `UI Review` there, where the pull
+      # request shows them (GitHub knows the merge commit is its) but a
+      # required status check cannot: those are read off the head commit,
+      # which is where every Actions job already reports. Measured on #187:
+      # twelve check runs on `5520f5f2`, three Chromatic statuses on the merge
+      # commit `aefcbe4`, no overlap.
+      #
+      # Empty on a push, where `GITHUB_SHA` is already the commit itself.
+      #
       - run: pnpm chromatic ${{ github.ref == 'refs/heads/main' && '--auto-accept-changes' || '--exit-zero-on-changes' }}
         if: ${{ env.CHROMATIC == 'true' }}
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref }}
+          CHROMATIC_SLUG: ${{ github.event.pull_request.head.repo.full_name }}
 
   #
   # Build


### PR DESCRIPTION
Groundwork for adding `UI Tests` to the branch ruleset. It cannot be added today: the status never reaches the commit a required check is read from.

Chromatic posts `UI Tests` and `UI Review` on whatever commit the CLI is handed, and on a `pull_request` event that is `GITHUB_SHA` -- the merge commit GitHub builds for the run, a commit that exists on no branch. GitHub Actions, by contrast, reports its check runs on the head commit. Measured on #187, they never meet:

```
$ gh api repos/pmndrs/examples/commits/5520f5f2/check-runs --jq '.total_count'   # head
12
$ gh api repos/pmndrs/examples/commits/5520f5f2/status --jq '.statuses | length'
0

$ gh api repos/pmndrs/examples/commits/aefcbe4/status --jq '.statuses[] | "\(.context)\t\(.state)"'   # merge commit
Test suite publish  success
UI Tests            pending
UI Review           pending
```

The pull request shows all of them together -- GitHub knows the merge commit is its -- so nothing looks wrong until you make one of them required, at which point every pull request waits forever on a status that lands somewhere else.

So hand Chromatic the head commit explicitly, plus the branch and slug that have to travel with it or the build attaches to the wrong ref. All three are empty on a push, where `GITHUB_SHA` is already the commit itself.

## After this merges

1. Re-run `chromatic-job` on an open pull request and check the status lands on the head:
   ```bash
   gh api repos/pmndrs/examples/commits/$(gh pr view 187 --json headRefOid --jq .headRefOid)/status \
     --jq '.statuses[] | "\(.context)\t\(.state)"'
   ```
2. Only then add `UI Tests` to the `Basic` ruleset as a required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
