### PR TITLE
Rename build-catalog to build-llms, and stop claiming /catalog/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ chromatic-diagnostics.json
 out/
 build
 dist
-# Written by bin/build-catalog.mjs into the website's public/, on its way to
+# Written by bin/build-llms.mjs into the website's public/, on its way to
 # out/. Here rather than in apps/website/.gitignore so that prettier, which
 # only reads the root one, skips them as well.
 apps/website/public/examples/

--- a/apps/website/lib/helper.ts
+++ b/apps/website/lib/helper.ts
@@ -88,7 +88,7 @@ export function getExamples(): Example[] {
         thumb: `${embed_url}/thumbnail.webp`,
         embed_url,
         website_url,
-        // What `bin/build-catalog.mjs` wrote for this example -- this page's URL
+        // What `bin/build-llms.mjs` wrote for this example -- this page's URL
         // with `.md` on the end. The page points at it with `rel="alternate"`
         // for readers that look, and the shape lets the rest guess.
         catalog_url: `${website_url}.md`,

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../bin/build-catalog.mjs && next dev",
+    "dev": "node ../../bin/build-llms.mjs && next dev",
     "dev2": "pnpm run dev",
-    "build": "node ../../bin/build-catalog.mjs && NODE_ENV=production next build",
+    "build": "node ../../bin/build-llms.mjs && NODE_ENV=production next build",
     "build3": "pnpm run build",
     "start": "next start",
     "lint": "eslint"

--- a/bin/build-llms.mjs
+++ b/bin/build-llms.mjs
@@ -37,7 +37,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { renderExample, renderIndex } from "./lib/render.mjs";
+import { renderExample, renderIndex } from "./lib/render-llms.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const examplesDirectory = path.join(root, "examples");

--- a/bin/lib/render-llms.mjs
+++ b/bin/lib/render-llms.mjs
@@ -3,7 +3,7 @@
  * the index, one document per example.
  *
  * This lives here rather than in whichever server hands it out, because the
- * rendered form is published too -- `/catalog/<name>.md` sits next to the JSON
+ * rendered form is published too -- `/examples/<name>.md` sits next to the JSON
  * and the example's own page points at it with `rel="alternate"`. A static host
  * cannot render on demand, so the only way an agent arriving from the open web
  * gets the same document as one arriving over MCP is for the producer to write

--- a/test/render-llms.test.ts
+++ b/test/render-llms.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-// @ts-expect-error -- plain JS, shared with bin/build-catalog.mjs
-import { renderExample, renderIndex, summaryLine } from "../bin/lib/render.mjs";
+// @ts-expect-error -- plain JS, shared with bin/build-llms.mjs
+import {
+  renderExample,
+  renderIndex,
+  summaryLine,
+} from "../bin/lib/render-llms.mjs";
 
 /**
  * What these protect is the shape of the document an agent reads. It is

--- a/test/turbo-cache.test.ts
+++ b/test/turbo-cache.test.ts
@@ -125,7 +125,7 @@ describe("build", () => {
 });
 
 /**
- * The website build also emits `/catalog/*.{json,md}` (`bin/build-catalog.mjs`),
+ * The website build also emits `/examples/*.{json,md}` (`bin/build-llms.mjs`),
  * which is what the docs MCP server and every example page's `rel="alternate"`
  * hand out. A cache hit that skips it serves a catalog describing examples that
  * have since changed -- and unlike a stale page, nobody looks at it, so nothing
@@ -135,7 +135,7 @@ describe("catalog", () => {
   it("re-runs the website build for the generator itself", () => {
     const before = hashOf("website#build3", WEBSITE_BUILD);
 
-    withTouched("bin/build-catalog.mjs", () => {
+    withTouched("bin/build-llms.mjs", () => {
       expect(hashOf("website#build3", WEBSITE_BUILD)).not.toBe(before);
     });
   });
@@ -143,7 +143,7 @@ describe("catalog", () => {
   it("re-runs the website build when the renderers move", () => {
     const before = hashOf("website#build3", WEBSITE_BUILD);
 
-    withTouched("bin/lib/render.mjs", () => {
+    withTouched("bin/lib/render-llms.mjs", () => {
       expect(hashOf("website#build3", WEBSITE_BUILD)).not.toBe(before);
     });
   });

--- a/turbo.json
+++ b/turbo.json
@@ -22,13 +22,13 @@
     "website#build3": {
       "dependsOn": ["^build2"],
       "env": ["BASE_URL"],
-      // The catalog generator and its renderers are root files, so they fall
+      // The llms generator and its renderers are root files, so they fall
       // outside the package's own inputs. What they *read* need not be listed:
       // every example's `pmndrs.json`, `package.json` and `src/` is already an
       // input of that example's `build2`, which this task depends on.
       "inputs": [
         "$TURBO_DEFAULT$",
-        "../../bin/build-catalog.mjs",
+        "../../bin/build-llms.mjs",
         "../../bin/lib/**"
       ],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],


### PR DESCRIPTION
Closes #193.

## Why

The name was contradicted by the output. `bin/lib/render.mjs` claimed in its header that `/catalog/<name>.md` sits next to the JSON, and `test/turbo-cache.test.ts` said the website build emits `/catalog/*.{json,md}` — but the script writes to `apps/website/public/examples/`. The word "catalog" no longer named anything the script emits.

"llms" names the audience instead, which is what unifies the three outputs: `llms.txt`, `/examples/<name>.md`, `/examples/<name>.json`, all served to the pmndrs docs MCP server and to `rel="alternate"` on every example page.

## What

| From | To |
| --- | --- |
| `bin/build-catalog.mjs` | `bin/build-llms.mjs` |
| `bin/lib/render.mjs` | `bin/lib/render-llms.mjs` |
| `test/render.test.ts` | `test/render-llms.test.ts` |

The eight references the issue listed, plus a ninth it missed: the `.gitignore` comment above `apps/website/public/examples/` also named `build-catalog.mjs`.

## Verification

- The generated output is **byte-identical**: the generator run on this branch and on a `main` worktree both hash `af630a0e`.
- `pnpm check` — green.
- `pnpm test:turbo` — 55/55.

Pure refactor, no behaviour change. It touches `turbo.json` inputs, so it busts the website build cache once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQmbpRu6oCNrLiUQvhz5x6

---

Position 1 of the stack: #201 → #203 → #204.
