### PR TITLE
The preview waits on the builds, not the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,18 +221,62 @@ jobs:
           CHROMATIC_SLUG: ${{ github.repository }}
 
   #
-  # Build
+  # Pages (only for pushes on main)
   #
-  # `needs: test-job`, so a red example never reaches GitHub Pages -- and never
-  # reaches a preview either, since the preview is the same build.
+  # `needs: test-job`, so a red example never reaches production.
   #
-  build-job:
+  pages-job:
     needs: test-job
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - id: configurepages
+        uses: actions/configure-pages@v5
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - uses: rharkor/caching-for-turbo@v2.5.1
+      - run: pnpm build
+        env:
+          BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
+          BASE_URL: ${{ steps.configurepages.outputs.base_url }}
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./out${{ steps.configurepages.outputs.base_path }}
+
+  #
+  # Preview (only for pull requests)
+  #
+  # No `needs`, deliberately. `test` dependsOn `build2`, so a shard builds the
+  # examples it is about to test -- and this job used to wait for all eight of
+  # them, for the warm cache that made its own `pnpm build` a cache hit. It was
+  # waiting on the wrong half. Measured on #200: the build it needs took 31s of
+  # that wait, the tests it also waited for took 3m16. On a pull request that
+  # touches many examples the same two numbers are ~3m30 and ~20m -- 170
+  # examples at ~60s of software rendering is what makes the sweep long, and
+  # building them was never the expensive part.
+  #
+  # So it builds all of them itself, at t=0. The preview lands at ~2min rather
+  # than 5m21. The turbo cache is shared and written as each shard's tasks
+  # finish, so what this actually rebuilds is whatever the shards have not
+  # reached yet: the duplicated work is a ceiling, not a bill -- and on a public
+  # repository the runner it occupies is free.
+  #
+  # What it gives up: an example whose test is red now reaches the preview.
+  # Which is what a preview is for -- `chromatic-job` publishes on `always()`
+  # for the same reason -- and merging is still gated on the tests.
+  #
+  preview-job:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     env:
       # No token, no preview: that is a fork's pull request, which cannot read
       # the repo secrets, or a checkout of this repo that never set them.
-      PREVIEW: ${{ github.event_name == 'pull_request' && secrets.VERCEL_TOKEN != '' }}
+      PREVIEW: ${{ secrets.VERCEL_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v7
       - id: configurepages
@@ -245,29 +289,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: rharkor/caching-for-turbo@v2.5.1
 
-      #
-      # Pages (only for pushes on main)
-      #
-      - run: pnpm build
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          BASE_PATH: ${{ steps.configurepages.outputs.base_path }}
-          BASE_URL: ${{ steps.configurepages.outputs.base_url }}
-      - uses: actions/upload-pages-artifact@v5
-        if: ${{ github.event_name != 'pull_request' }}
-        with:
-          path: ./out${{ steps.configurepages.outputs.base_path }}
-
-      #
-      # Preview (only for pull requests)
-      #
-      # The same `BASE_PATH` as the Pages build, and for the same reason the
-      # step above exists at all: `BASE_PATH` is a `globalEnv`, and it really
-      # does change every example's `dist` (vite's `--base`). Building the
-      # preview without it gave every `build2` a different hash -- 167 rebuilds,
-      # ~3.5min, and never a cache hit across runs either, since `main` never
-      # produces those hashes and a pull request cannot read another one's
-      # cache. With it, `pnpm test` above has already built all of them.
+      # The same `BASE_PATH` as the Pages build, and not for tidiness:
+      # `BASE_PATH` is a `globalEnv`, and it really does change every example's
+      # `dist` (vite's `--base`). Building the preview without it gave every
+      # `build2` a different hash from the one the rest of this workflow
+      # produces -- 167 rebuilds, ~3.5min, and never a cache hit across runs
+      # either, since `main` never produces those hashes and a pull request
+      # cannot read another one's cache. With it, the hashes line up, and what
+      # is actually built here is what the shards have not cached yet.
       #
       # What it costs: the preview is served from `<url>${BASE_PATH}`, not the
       # domain root, since the pages link to each other by absolute path. That
@@ -279,7 +308,7 @@ jobs:
           # The production origin, deliberately: the <head> URLs are canonical
           # links, and a preview that is "the production layout" should carry
           # them too -- besides, a different value is a different `build2`
-          # hash, and the whole point is that the shards already built this.
+          # hash, and these have to be the hashes everything else produces.
           BASE_URL: ${{ steps.configurepages.outputs.base_url }}
       - id: preview
         if: ${{ env.PREVIEW == 'true' }}
@@ -332,7 +361,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build-job
+    needs: pages-job
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -177,7 +177,7 @@ describe("ci.yml", () => {
   // writes the deployment origin into each demo's <head>), so it is part of the
   // hash for the same reason `BASE_PATH` is. #180 added it to the build steps
   // only, and for a while the shards quietly built -- and shot -- a dist nobody
-  // deploys, while build-job rebuilt all 161 examples on every run.
+  // deploys, while the deploying job rebuilt all 161 examples on every run.
   for (const name of ["BASE_PATH", "BASE_URL"] as const) {
     it(`gives each of those steps a ${name}`, () => {
       for (const step of buildingSteps()) {


### PR DESCRIPTION
`build-job` needed `test-job`, so the pull request preview landed after all eight shards had finished. It was waiting on the wrong half of them.

`test` dependsOn `build2`, so a shard builds the examples it is about to test, and the wait bought a warm turbo cache. Measured on #200:

| | |
|---|---|
| setup + install + cache restore | 43s |
| `pnpm build` (cache hit) | **31s** |
| upload + deploy to Vercel | 41s |
| **waited on the shards first** | **3m16** |

31s of build, behind 3m16 of tests. On a pull request that touches many examples the same two numbers are ~3m30 and ~20m -- 170 examples at ~60s of software rendering is what makes the sweep long, and building them was never the expensive part.

## What this does

`build-job` splits in two:

- **`pages-job`** -- pushes to main only, keeps `needs: test-job`. A red example must not reach production.
- **`preview-job`** -- pull requests only, no `needs`. Builds all of them itself, at t=0.

The preview lands at ~2min rather than 5m21, and at ~5min rather than ~22min on a cold pull request. Total CI time is unchanged; only the moment the URL appears moves.

The turbo cache is shared and written as each shard's tasks finish, so what `preview-job` rebuilds is whatever the shards have not reached yet. The duplicated build is a ceiling, not a bill -- and on a public repository the runner it occupies is free.

## What it gives up

An example whose test is red now reaches the preview. Which is what a preview is for -- `chromatic-job` has published on `always()` since the beginning for the same reason -- and merging is still gated on the tests.

The one honest cost: `preview-job` takes a tenth concurrency slot at t=0, next to the eight shards and the lint job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
