### PR TITLE
Put the description contract in a skill, not in a reviewer's memory

### DIFF
--- a/.claude/skills/describe-example/SKILL.md
+++ b/.claude/skills/describe-example/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: describe-example
+description: Writes one example's `description` and `apis` in `examples/<name>/pmndrs.json` from its source, and with `--explain` the long-form explainer in its `README.md`. Use when asked to describe, re-describe or explain an example in this gallery, or when a `pmndrs.json` description is empty, stale, or names the code rather than the technique.
+argument-hint: "<example-name> [--explain]"
+---
+
+# describe-example
+
+Two fields of one example's `pmndrs.json`, written by reading its source: the one-line `description` the index carries, and the `apis` list that its per-example document carries. With `--explain`, also the long-form explainer — see [explain.md](./explain.md).
+
+## Why this is a skill
+
+The gallery publishes an agent-readable surface — `llms.txt`, `/examples/<name>.md`, `/examples/<name>.json`, built by `bin/build-llms.mjs` and served both over the pmndrs docs MCP server and by `rel="alternate"` on every example page. The pipeline is sound. The content it carries is not: **40 of the 170 descriptions are empty**, and the other 130 run to a median of **56 characters** that generally name no technique.
+
+`aquarium` is the case that names the problem. It ships an empty description and the single tag `transmission`, while what actually makes the demo work is a **stencil mask** — `useMask` plus a backside `MeshTransmissionMaterial` — named nowhere. An agent asking "how do I do refractive glass" cannot tell it from the other 169, and having opened it, pays full token price to rediscover the trick by reading 200 lines of TSX.
+
+Fixing that is 170 acts of judgement. The two contracts below are what keeps those 170 acts consistent, which is why they live in this file rather than in a reviewer's memory.
+
+## Three rules that shape everything
+
+- **One example per run.** The argument is one example name. Batching is what turns review into rubber-stamping, and a rubber-stamped line is worth no more than the empty string it replaced.
+- **Nothing is written before the maintainer says yes.** Propose, then write. The only check on judgement is a human who can say no; a skill that writes first has converted that into a diff-read after the fact, which is not the same thing.
+- **The output is committed to git, and no model runs in `bin/`.** Git is the source of truth and `bin/lib/render-llms.mjs` stays dumb and deterministic. Those scripts sit on the critical path of the site build and of `turbo`'s cache: a model call there makes the build non-reproducible, offline-hostile, and cache-busting on every run. If generating this at build time starts to look attractive, that is the reason it is not.
+
+## The `description` contract
+
+One sentence, and it is the only thing most readers of `llms.txt` will ever see about this example.
+
+- **English.**
+- **≤ 120 characters.** Five descriptions exceed this today; they are rewrites, not truncations.
+- **Prose only — no identifiers.** They have their own field. Three median-length API names cost ~34 characters, 28% of the budget, which is exactly why `apis` exists.
+- **Names the _technique_, not the code.** A line that describes what the code does rots at the first refactor; a line that names which technique is employed survives.
+- **Says nothing the index line already says.** `summaryLine()` in `bin/lib/render-llms.mjs` prints the directory name, the non-implied libraries, the tags and a size marker around this sentence. "Physics simulation using cannon" spends the whole budget on `+cannon · #physics`, which the reader already has. `@react-three/fiber` and `@react-three/drei` are implied on every line and are never worth a word.
+- **No throat-clearing.** Not "This example shows…", not "A demo that…". The surrounding line has already established that this is an example.
+
+```jsonc
+// examples/aquarium/pmndrs.json
+"description": "Glass rendered as a stencil mask rather than transparency, with a backside transmission material."
+```
+
+97 characters. Note what it does not claim. `useMask` appears in six examples, one of them called `stencil-mask` — "uses a stencil mask" would discriminate nothing. The line earns its place by saying what _this_ demo does with the mask: glass, in place of transparency, with the transmission material on the backside. When a technique is shared, the line has to reach past it.
+
+A technique carried by a prop rather than an import — `gl={{ stencil: true }}`, `frameloop="demand"` — is said here, in prose, because `apis` cannot hold it. The `aquarium` line above does exactly that without naming the prop.
+
+## The `apis` contract
+
+Identifiers are data, not prose. Keeping them out of `description` is what makes the 120-character budget comfortable.
+
+```jsonc
+"apis": ["useMask", "MeshTransmissionMaterial"]
+```
+
+- **Imported identifiers only, and only from this example's own `src/`.** Not props, not local component names, not types. `apis ⊆ imports` is the whole mechanical check `lint:metadata` carries — purely local and textual, no network, no type resolution — and it is what catches silent rot: drei renames an API, someone fixes the import, `apis` still lists the old name, the lint breaks.
+- **A short selection, not a list.** An example imports 9 identifiers at the median and up to 34. The criterion is _what you would have to bring over to reproduce the effect_; everything the example happens to also import stays out. Typically two or three. No number is fixed, because how many the technique needs depends on the demo — but "no ceiling" is not "as many as you like". The limit is editorial: this skill selects, the maintainer reviews.
+- **What every example imports discriminates nothing.** `Canvas`, `useFrame`, `OrbitControls`, `* as THREE` are in most of the gallery. They are never the answer to "what makes this one different".
+- **Order it for a reader**, with the API that carries the technique first.
+- **Not every example has one.** A demo whose trick is a prop or a shader gets `[]`, and the prose carries it alone. An empty list is a finding, not a failure.
+
+`apis` is rendered in `<name>.md`, not in `llms.txt` — adding ~34 characters to every index line would take that file from ~19 kB to ~25 kB, on a document read at the start of every question. The identifiers are there the moment you open the example, which is when they matter.
+
+## Working an example
+
+1. **Read it.** `examples/<name>/pmndrs.json`, `README.md`, and every file under `src/` — the median example is 5 kB, so read it whole rather than grepping. `thumbnail.webp` is worth a look: it is what the reader is choosing from.
+
+2. **Collect the imports properly.** Grepping `from "` misses most of them, because the identifiers sit in multi-line member lists above it:
+
+   ```tsx
+   import {
+     useMask,
+     …
+   } from "@react-three/drei";
+   ```
+
+   Read the import block at the top of each source file instead.
+
+3. **Find the technique.** The question is what this demo knows that the other 169 do not. Follow it from the imports into the code and confirm it is actually load-bearing — `useMask` in `aquarium` is not decoration, the demo does not work without it. An example whose only distinguishing feature is its subject matter (a watch, a pinball table) has that as its technique, and the line should say so plainly.
+
+4. **Propose both fields together**, with the character count and one sentence on which technique you concluded and from what. Both fields describe the same finding; splitting the proposal invites approving one against a reading of the other.
+
+5. **Write, on the maintainer's ok.** Edit `examples/<name>/pmndrs.json` and nothing else. Keep the field order matching `schemas/pmndrs.schema.json` — every file in the gallery follows it today. Do not touch `title`, `tags`, `authors` or `libraries`: they are someone else's contract, and a description PR that quietly retags is one nobody can review.
+
+6. **Verify.**
+
+   ```sh
+   pnpm lint:metadata
+   node -e 'const m=require("./examples/<name>/pmndrs.json");console.log(m.description.length, "|", m.description)'
+   ```
+
+   `lint:metadata` reads `schemas/pmndrs.schema.json`, so if it reports `unknown field "apis"` the schema does not carry the field yet — fix the schema, not the entry. What it can never check is whether the sentence is true or well turned. That stays human, and is why step 4 exists.
+
+## `--explain`
+
+The long-form explainer, in the example's own `README.md`, plus its glossary in `CONTEXT.md`. It does not read the source and write: it runs `teach` in sub-agents first, and only its distillation comes back. The orchestration, the mission it has to supply, and the writing contract are in [explain.md](./explain.md).
+
+Both modes live in one skill because both enforce contracts that must not drift apart — the one-liner is the compression of the same understanding the explainer spends 400 words on, and writing them from two separate readings is how they end up describing two different demos.

--- a/.claude/skills/describe-example/explain.md
+++ b/.claude/skills/describe-example/explain.md
@@ -1,0 +1,92 @@
+# `--explain`
+
+The one-line `description` is what the index can afford. It is not what a reader wants once they have opened the example. That reader gets a second artifact:
+
+| Written to                   | Holds                                                    | Read by                                      |
+| ---------------------------- | -------------------------------------------------------- | -------------------------------------------- |
+| `examples/<name>/README.md`  | the explainer — the problem, the technique, the pitfalls | humans on GitHub, and agents via `<name>.md` |
+| `examples/<name>/CONTEXT.md` | the glossary — terms local to this demo                  | agents, before exploring                     |
+
+`README.md` already exists in all 170 examples: badges, the `degit` line, the thumbnail, and nothing else. The explainer goes under that whole block, which stays intact — the three lines are one header and splitting prose into the middle of them separates the scaffold command from the badges that link to the same thing. Additive: no new file, no new convention, and `degit` carries it into whatever the reader scaffolds.
+
+**Absence is the normal state.** This is multi-session, interactive work driven by curiosity about a particular demo, not a programme across 170. An example with an explainer is better; one without is fine.
+
+## It does not read the source and write
+
+That is the whole design. A direct read produces a confident paragraph about a demo nobody understood, and there is no way to tell one of those from the real thing by reading it. So `--explain` runs `/mattpocock-skills:teach` in sub-agents first, and writes only from what they distil.
+
+`teach` sets `disable-model-invocation`, so the Skill tool will not launch it — the sub-agent reads the skill file and follows it. The repo's `.claude/settings.json` enables `mattpocock-skills@mattpocock`, which puts it at `~/.claude/plugins/marketplaces/mattpocock/skills/productivity/teach/SKILL.md`. If the plugin layout has moved, find it: `find ~/.claude/plugins -path '*productivity/teach/SKILL.md'`.
+
+### 1. The workspace is ephemeral and outside the repo
+
+One temp directory per example — `mktemp -d`, or the session scratchpad. `teach` treats the current directory as the workspace, and a sub-agent's working directory resets between bash calls, so hand it the absolute path and say plainly that this directory is the workspace root: every path the skill names (`MISSION.md`, `./lessons/`, `./reference/`) resolves under it.
+
+Everything it grows there is scaffolding: `MISSION.md`, `learning-records/`, `lessons/*.html`, `RESOURCES.md`, `NOTES.md`, `assets/`. Half of it is one person's learning state — why _they_ wanted to learn this, what _they_ have already understood — and it has no business in a public repo of 170 shared demos. It dies with the directory. Never point the workspace at `examples/<name>/`.
+
+### 2. The skill supplies the mission
+
+`teach` is built for a human learner, and its first move is to ask why _you_ want to learn this. Headless there is nobody to ask, and a pass without a mission runs on nothing — the lessons come out abstract and the distillation comes out generic. So write `MISSION.md` into the workspace before launching the first pass, answering on the example's behalf:
+
+```md
+# Mission: <Title> — <the technique, in a few words>
+
+## Why
+
+An r3f developer has opened this example because they want the technique it
+demonstrates, in their own scene. They need it explained well enough to carry
+over: what problem it solves, how it works, and what it costs.
+
+## Success looks like
+
+- The technique can be named and explained without opening the source again.
+- The APIs that carry it are identified, and what each contributes is clear.
+- The pitfalls are known — where the approach breaks, and what it trades away.
+
+## Constraints
+
+- The source is `examples/<name>/src/`, against the versions pinned in that
+  example's `package.json`. Read the code that is there, not the API you
+  remember.
+- The explanation must not walk the code: no line numbers, no local variable
+  names, no "the file X does Y".
+
+## Out of scope
+
+- Everything the demo also happens to contain — staging, lighting, model
+  loading — that is not the technique.
+```
+
+Headless, the sub-agent is both teacher and learner: it writes the lesson and it sits the quiz. That is awkward, and it is fine, because the artifact that matters here is the reference distillation, not the score. The quiz is what forces the pass to find out whether it actually knows the thing.
+
+### 3. The first pass judges, and the cap is three
+
+Each pass ends by answering one question in its report: **is a load-bearing sub-topic still unclear enough to warrant another pass, and which one?** If yes, launch another sub-agent on the same workspace with that sub-topic as its focus — `teach` is stateful, so it reads the learning records the previous pass left and picks up from them.
+
+**Three passes total, then stop regardless.** Without a cap an obscure demo chains passes indefinitely, and the marginal pass stops paying long before the sub-agent runs out of things it would like to understand better. A sub-topic still unclear after the third pass is a caveat in the proposal, not a fourth pass.
+
+### 4. Only the distillation comes back
+
+Two things leave the workspace, rewritten as markdown:
+
+- **the reference documents** — `teach` calls them "the compressed essence", designed for quick reference — become the explainer in `README.md`
+- **the glossary** becomes `CONTEXT.md`
+
+Nothing else. Lessons, quizzes and learning records stay in the temp directory.
+
+## The writing contract
+
+**Structure is fixed, length is not** — the problem, the technique, the pitfalls. A fixed structure resists drift better than a word ceiling, and a demo that needs 200 words should not be padded to 400 nor one that needs 600 be truncated.
+
+**It names the technique and its APIs; it never walks the code.** No line numbers, no local variable names, no "the file X does Y". Same principle as the one-liner: what cannot be checked mechanically is at least made hard to write wrong.
+
+**Every identifier the prose puts in backticks must appear somewhere in the example's `src/`.** This is looser than the check on `apis`, deliberately — `apis` is a list of library APIs, so an entry that is not _imported_ has no business there, whereas prose may legitimately name the demo's own components (`Aquarium`, `Turtle`) and its props (`stencil` in `gl={{ stencil: true }}`).
+
+It is also what keeps the prose from rotting, and it is checkable by concatenation and search — no import parsing, no package resolution. `useMask` disappears in a drei migration and the rule fires on precisely the explainers that named it, and on no others; a prettier sweep never wakes it. And it reaches further than renames — in a declarative r3f scene the technique _is_ the set of components used, so an explainer saying "the spheres are instanced" names `Instances`, and the day instancing goes, the identifier goes with it.
+
+**No `CONTEXT.md` that merely restates the README.** The glossary holds terms genuinely local to this demo; the README explains the technique. If the only content would be a paraphrase, the file should not exist.
+
+## Then the bare pass
+
+Write `description` and `apis` last, from the same distillation — not from a second reading of the source. They are the compression of what the passes established, and deriving them separately is how the one-liner and the explainer end up describing two different demos.
+
+Everything in [SKILL.md](./SKILL.md) still holds: propose before writing, one example per run, and `pnpm lint:metadata` before you are done.


### PR DESCRIPTION
`llms.txt` and the per-example documents are built and served correctly.
The content they carry is what fails: 40 of the 170 descriptions are
empty, and the other 130 run to a median of 56 characters that generally
name no technique. `aquarium` ships an empty line and the single tag
`transmission`, while the thing that makes the demo work -- a stencil
mask, `useMask` plus a backside `MeshTransmissionMaterial` -- is named
nowhere.

Fixing that is 170 acts of judgement, and judgement at that scale needs
its rules written down somewhere a reviewer can point at.
`.claude/skills/describe-example/` holds them: English, 120 characters,
prose with no identifiers, naming the technique rather than the code --
because a line describing what the code does rots at the first refactor,
and one naming which technique is employed survives. Identifiers go to
`apis`, which is checkable against the example's own imports and is what
keeps the 120 characters comfortable.

Vendored here rather than installed, following the precedent the `shadcn`
skill already set: it encodes this repo's conventions, so it is reviewed
and versioned with them.

The skill proposes and waits. One example per run, written only after the
maintainer's ok, and the output committed -- git stays the source of
truth and no model runs in `bin/`, where a call would make the site build
non-reproducible, offline-hostile and cache-busting on every run.

`explain.md` carries the second mode. It deliberately does not read the
source and write: it runs `teach` in sub-agents, supplies the mission
they would otherwise interview a human for, caps the passes at three, and
keeps the workspace outside the repo -- lessons and learning records are
one person's learning state, not artefacts of a gallery of 170 shared
demos, so only the distillation and the glossary come back.

Ships no content change, so it can be reviewed as prose.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

Closes #196. Position 2 of the stack, on top of #201 — which renames `build-catalog.mjs` to `build-llms.mjs`, the name this skill's prose uses.

`pnpm check` 5/5 · `pnpm test:turbo` 55/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
