### PR TITLE
Ask a model which example llms.txt sends it to

### DIFF
--- a/bin/eval.mjs
+++ b/bin/eval.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+/**
+ * Scores `llms.txt` on the only question the file exists to answer: does an
+ * agent asking about refractive glass land on the right example?
+ *
+ * Human review answers "is this sentence true and well turned", which is a
+ * different question and a much easier one. `aquarium · #transmission` passes
+ * that review and is useless: it shares its one tag with a dozen other lines,
+ * carries no words to tell it from them, and is not a refraction demo anyway.
+ * The only way to catch that is to ask.
+ *
+ * So: for each question in `bin/eval/questions.json`, a model is handed the
+ * contents of `llms.txt` and nothing else, plus the question, and answers with
+ * the one example it would open. Hit if that name is in the question's
+ * `expected` -- the hand-written oracle, which is the expensive part of the
+ * exercise and the part no script can produce.
+ *
+ * A single answer rather than a ranked list, because that is what a reader
+ * actually does: it opens one. `expected` is therefore the set of names a
+ * maintainer would accept, not a set the answer has to cover.
+ *
+ * **Never in CI.** It calls a model, so it is non-deterministic, costs money
+ * and needs the network -- the same reasoning that keeps a model out of the
+ * `bin/` scripts the build depends on. Run it on demand, before and after a
+ * pass over the descriptions, and compare against `bin/eval/baseline.md`.
+ *
+ *     node bin/build-llms.mjs   # llms.txt is generated, and gitignored
+ *     node bin/eval.mjs
+ *     node bin/eval.mjs --model anthropic/claude-opus-5
+ *
+ * Credentials come from the Vercel AI Gateway: `AI_GATEWAY_API_KEY` if you
+ * have one, otherwise the short-lived `VERCEL_OIDC_TOKEN` that
+ * `vercel env pull` writes into the gitignored `.env.local`. That token lasts
+ * twelve hours, so a 401 here usually means pulling it again rather than
+ * anything being wrong.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const indexPath = path.join(root, "apps", "website", "public", "llms.txt");
+const questionsPath = path.join(root, "bin", "eval", "questions.json");
+const environmentPath = path.join(root, ".env.local");
+
+const ENDPOINT = "https://ai-gateway.vercel.sh/v1/chat/completions";
+
+/**
+ * The default is what `bin/eval/baseline.md` was measured against, and it is an
+ * open-weight model because the gateway's free tier refuses the hosted frontier
+ * ones outright. Override it with `--model` once the workspace has credits, and
+ * take a fresh baseline when you do: a score is only comparable within one
+ * model, so quoting a number without naming the model says nothing.
+ */
+const DEFAULT_MODEL = "openai/gpt-oss-120b";
+
+// The free tier serves a handful of requests and then closes a rolling window
+// that stays shut for minutes, so a 429 halfway through would otherwise throw
+// away the pass. Backing off is what paces the run rather than a fixed sleep:
+// a workspace with credits never sees a 429 and never waits.
+const RETRIES = 5;
+const RETRY_DELAY_MS = 60_000;
+
+const { values } = parseArgs({
+  options: { model: { type: "string", default: DEFAULT_MODEL } },
+});
+
+if (!fs.existsSync(indexPath)) {
+  console.error(
+    `No ${path.relative(root, indexPath)}. It is generated and gitignored -- run \`node bin/build-llms.mjs\` first.`,
+  );
+  process.exit(1);
+}
+
+const index = fs.readFileSync(indexPath, "utf8");
+const questions = JSON.parse(fs.readFileSync(questionsPath, "utf8"));
+
+// The directory name is everything up to the first space on an index line, and
+// it is the whole answer space: a reply that is not one of these is not an
+// example, however plausible it reads.
+const names = new Set(
+  index
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split(" ")[0]),
+);
+
+const unknown = questions.flatMap(({ expected }) =>
+  expected.filter((name) => !names.has(name)),
+);
+if (unknown.length > 0) {
+  console.error("Questions expect examples that are not in the index:");
+  for (const name of unknown) console.error(`- ${name}`);
+  process.exit(1);
+}
+
+if (
+  !process.env.AI_GATEWAY_API_KEY &&
+  !process.env.VERCEL_OIDC_TOKEN &&
+  fs.existsSync(environmentPath)
+) {
+  process.loadEnvFile(environmentPath);
+}
+
+const token = process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN;
+if (!token) {
+  console.error(
+    "No gateway credentials. Set AI_GATEWAY_API_KEY, or run `vercel env pull .env.local` for a VERCEL_OIDC_TOKEN.",
+  );
+  process.exit(1);
+}
+
+/**
+ * The whole prompt. The index is the only thing the reader is given -- no
+ * source, no per-example document, no tags of our own -- because that is
+ * exactly the position an agent is in when it decides which example to fetch.
+ */
+const system = `You are choosing which example to open from the pmndrs examples gallery.
+
+Below is the whole gallery, one line per example: the directory name, then an optional title in parentheses, a description, extra libraries after +, tags after # and an approximate size after ~. Any of those may be missing.
+
+${index}
+Answer with the directory name of the single example you would open, and nothing else.`;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function ask(question) {
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: values.model,
+        // Not determinism -- no sampler setting buys that -- but the least
+        // noise available, so a rerun reproduces the score rather than a mood.
+        temperature: 0,
+        // Room for a reasoning model to think before it names one directory.
+        max_tokens: 800,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: question },
+        ],
+      }),
+    });
+
+    if (response.ok) {
+      const body = await response.json();
+      return body.choices[0].message.content ?? "";
+    }
+
+    const retryable = response.status === 429 || response.status >= 500;
+    if (!retryable || attempt === RETRIES) {
+      throw new Error(
+        `${response.status} from the gateway: ${(await response.text()).slice(0, 200)}`,
+      );
+    }
+    console.error(
+      `  ${response.status} from the gateway, waiting ${RETRY_DELAY_MS / 1000}s`,
+    );
+    await sleep(RETRY_DELAY_MS);
+  }
+}
+
+/**
+ * Models answer with a bare name, a backticked name, or a name at the end of a
+ * sentence. All three are the same answer; anything that is not a directory
+ * name in the index is not.
+ */
+function nameOf(reply) {
+  const last = reply.trim().split("\n").filter(Boolean).at(-1) ?? "";
+  const candidate = last.trim().replace(/^[^a-z0-9]+|[^a-z0-9]+$/gi, "");
+  return names.has(candidate) ? candidate : null;
+}
+
+let hits = 0;
+
+for (const { question, expected } of questions) {
+  // The question first, so a backoff notice lands under the question waiting
+  // on it rather than ahead of it.
+  console.log(question);
+
+  const reply = await ask(question);
+  const answer = nameOf(reply);
+  const hit = answer !== null && expected.includes(answer);
+  if (hit) hits += 1;
+
+  const named =
+    answer ?? `nothing named in ${JSON.stringify(reply.trim().slice(0, 80))}`;
+  console.log(
+    `  ${hit ? "✔" : "✗"} ${named}` +
+      (hit ? "" : `  (expected ${expected.join(", ")})`),
+  );
+}
+
+const percentage = Math.round((hits / questions.length) * 100);
+console.log(
+  `\n${hits}/${questions.length} (${percentage}%) · ${values.model} · ${names.size} examples, ${Buffer.byteLength(index)} bytes of index`,
+);

--- a/bin/eval/baseline.md
+++ b/bin/eval/baseline.md
@@ -1,0 +1,68 @@
+# Baseline — 15/20 (75%)
+
+The "before" number, taken deliberately while every description in the gallery
+is still the one it shipped with. Once a rewrite lands this run is not
+repeatable, which is the whole reason it is recorded here rather than measured
+later.
+
+| What      | Value                                                           |
+| --------- | --------------------------------------------------------------- |
+| Score     | **15/20 (75%)**                                                 |
+| Date      | 2026-08-14                                                      |
+| Model     | `openai/gpt-oss-120b`, via the Vercel AI Gateway, temperature 0 |
+| Index     | 167 examples, 18,608 bytes, generated from `main` at `74eae31d` |
+| Questions | `bin/eval/questions.json`, 20 of them                           |
+| Command   | `node bin/eval.mjs`                                             |
+
+One question, one answer: the model is handed `llms.txt` and nothing else and
+names the single example it would open. A hit is that name appearing in the
+question's `expected`, so the score is `hits / 20`.
+
+## The five it got wrong
+
+| Asked for                                | Opened                                  | Expected                                |
+| ---------------------------------------- | --------------------------------------- | --------------------------------------- |
+| a glass tank you can see objects inside  | `transparent-aesop-bottles`             | `aquarium`                              |
+| a camera travelling through a doorway    | `camera-scroll`                         | `enter-portals`, `pass-through-portals` |
+| a third-person character controller      | _named no example — wrote code instead_ | `ecctrl-fisheye`                        |
+| click a part, outline it, frame it       | `react-pp-outlines`                     | `faucets-select-highlight`              |
+| a glass ornament, bloomed and LUT-graded | `color-grading`                         | `glass-flower`                          |
+
+**Every miss is an example whose `description` is empty.** `aquarium`,
+`enter-portals`, `pass-through-portals`, `ecctrl-fisheye`,
+`faucets-select-highlight` and `glass-flower` reach the index as a directory
+name plus, at best, one tag — and the reader either picks a near neighbour that
+does carry words (`transparent-aesop-bottles`, `react-pp-outlines`,
+`color-grading`) or gives up on the index entirely, as it did on the character
+controller.
+
+Nothing was wrong with the fifteen it got right either: those questions point at
+examples that already say what they are. The index is not uniformly bad, it is
+bad exactly where the prose is missing — which is the claim the rewrite is
+supposed to act on, now measured instead of asserted.
+
+Ten of the twenty questions point at an example with no description at all,
+which is the population the pilot draws from — `aquarium` among them, the case
+whose technique is carried by a prop rather than an import and so has to be said
+in prose or not at all. That is the room the pilot has to move the number. The
+other ten are the control: if they start missing, the rewrite broke something
+that already worked.
+
+## Rerunning it
+
+```sh
+node bin/build-llms.mjs   # llms.txt is generated, and gitignored
+node bin/eval.mjs
+```
+
+Expect ±1 rather than an identical transcript. `temperature: 0` is the least
+noise on offer, not determinism, and an aborted earlier pass on the same index
+and the same model answered `aquarium` correctly for the glass-tank question
+that the recorded run missed. A one-question swing is noise; the pilot has to
+beat that to have shown anything.
+
+The score is only comparable within one model. `openai/gpt-oss-120b` is the
+default because it is what the gateway's free tier serves — the hosted Anthropic
+and OpenAI models need credits on the workspace. With credits, pass
+`--model anthropic/claude-opus-5` and take a fresh baseline before comparing
+against it; do not read a run on one model against a number from another.

--- a/bin/eval/questions.json
+++ b/bin/eval/questions.json
@@ -1,0 +1,86 @@
+[
+  {
+    "question": "how do I do refractive glass?",
+    "expected": ["diamond-refraction", "transparent-aesop-bottles"]
+  },
+  {
+    "question": "I want a glass tank with objects visible inside it, without the transparency sorting falling apart. Which example shows that?",
+    "expected": ["aquarium"]
+  },
+  {
+    "question": "how do I blur whatever is behind a translucent panel, like frosted glass?",
+    "expected": ["frosted-glass"]
+  },
+  {
+    "question": "how do I cut a hole in the screen so that only what is inside it draws?",
+    "expected": ["stencil-mask", "inverted-stencil-buffer"]
+  },
+  {
+    "question": "how do I throw caustics from a glass object onto the floor under it?",
+    "expected": ["caustics"]
+  },
+  {
+    "question": "how do I let the camera travel through a doorway into the scene on the other side?",
+    "expected": ["enter-portals", "pass-through-portals"]
+  },
+  {
+    "question": "how do I render a second live scene onto a screen inside my scene?",
+    "expected": ["drei-rendertexture", "monitors"]
+  },
+  {
+    "question": "how do I add a third-person character controller with keyboard movement and a camera that follows?",
+    "expected": ["ecctrl-fisheye"]
+  },
+  {
+    "question": "clicking a part of my model should outline it and move the camera to frame it. Which example does that?",
+    "expected": ["faucets-select-highlight"]
+  },
+  {
+    "question": "how do I make my HDRI environment act as the ground the model stands on, instead of just a backdrop?",
+    "expected": ["envmap-ground-projection", "ground-projected-envmaps-lamina"]
+  },
+  {
+    "question": "how do I cast a patterned shadow from a spot light, like leaves moving over a wall?",
+    "expected": ["spotlight-shadows"]
+  },
+  {
+    "question": "my GLTF has several animation clips and I need to cross-fade between them. Which example shows that?",
+    "expected": ["gltf-animations", "gltf-animations-re-used"]
+  },
+  {
+    "question": "how do I build a product configurator where the user swaps colours and materials on a model?",
+    "expected": ["shoe-configurator", "t-shirt-configurator"]
+  },
+  {
+    "question": "my HTML labels show through the geometry in front of them. How do I occlude them?",
+    "expected": ["html-markers", "mixing-html-and-webgl-w-occlusion"]
+  },
+  {
+    "question": "how do I drive the camera along a path authored in Blender as the page scrolls?",
+    "expected": ["camera-scroll"]
+  },
+  {
+    "question": "how do I draw thousands of copies of one mesh, each with its own colour?",
+    "expected": ["instances", "instanced-vertex-colors"]
+  },
+  {
+    "question": "how do I subtract one mesh from another to get a boolean cut?",
+    "expected": [
+      "csg-house",
+      "csg-operations-rapier-physics",
+      "csg-bunny-usegroups"
+    ]
+  },
+  {
+    "question": "how do I make a car you can actually drive around, with suspension and physics?",
+    "expected": ["racing-game"]
+  },
+  {
+    "question": "how do I read the frequency spectrum of a track and drive the scene from it?",
+    "expected": ["simple-audio-analyser", "audio-analyser"]
+  },
+  {
+    "question": "I have a glass ornament model and want it bloomed and colour-graded through a LUT. Which example stages that?",
+    "expected": ["glass-flower"]
+  }
+]


### PR DESCRIPTION
Human review answers "is this sentence true and well turned". It does not
answer the only question the index line exists for: does an agent asking
about refractive glass land on the right example? `aquarium ·
#transmission` passes review and is useless -- it shares its one tag with a
dozen other lines, carries no words to tell it from them, and is not a
refraction demo anyway.

So ask. Twenty realistic questions, each with the example a maintainer
would accept, written by hand -- that oracle is the expensive part and the
part no script can produce. For each, a model is handed the contents of
`llms.txt` and nothing else, names the one example it would open, and the
score is how often that name is in `expected`.

Today's index scores 15/20. All five misses are examples whose
`description` is empty: the reader either picks a near neighbour that does
carry words, or gives up on the index and starts writing code. Ten of the
twenty questions point at that population, so the pilot has room to move
the number; the other ten are the control.

This has to be measured now. The PRs in front of it change no description,
so the baseline they leave behind is still today's -- but the moment eight
descriptions are rewritten, the "before" number is gone for good.

Never in CI. It calls a model, so it is non-deterministic, costs money and
needs the network -- the same reasoning that keeps a model out of the `bin/`
scripts the build depends on. Nothing here is wired into a turbo task, a
workflow, or a package script.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

Closes #197. Position 3 of the stack, on top of #203.

**Baseline: 15/20**, recorded in `bin/eval/baseline.md`. `openai/gpt-oss-120b` via the Vercel AI Gateway, temperature 0, one call per question. Not a Claude number: the workspace is on the gateway's free tier, which returns `403 RestrictedModelsError` for every frontier model. `--model` overrides it once the workspace has credits, and the script needs no change.

Two things the number depends on, both stated in `baseline.md`: a score is only comparable within one model, and the noise floor is ±1 rather than zero — `temperature: 0` is the least noise on offer, not determinism.

`pnpm check` 5/5 · `pnpm test:turbo` 55/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
