### PR TITLE
Give an example an apis field, and take the notes away

### DIFF
--- a/.claude/skills/describe-example/SKILL.md
+++ b/.claude/skills/describe-example/SKILL.md
@@ -86,7 +86,7 @@ Identifiers are data, not prose. Keeping them out of `description` is what makes
    node -e 'const m=require("./examples/<name>/pmndrs.json");console.log(m.description.length, "|", m.description)'
    ```
 
-   `lint:metadata` reads `schemas/pmndrs.schema.json`, so if it reports `unknown field "apis"` the schema does not carry the field yet — fix the schema, not the entry. What it can never check is whether the sentence is true or well turned. That stays human, and is why step 4 exists.
+   `lint:metadata` carries `apis ⊆ imports`, so `api "X" is not imported in src/` means the entry names something this example does not import — a typo, a prop, or a local component. What it can never check is whether the sentence is true or well turned. That stays human, and is why step 4 exists.
 
 ## `--explain`
 

--- a/apps/website/app/examples/[examplename]/Info.tsx
+++ b/apps/website/app/examples/[examplename]/Info.tsx
@@ -114,12 +114,6 @@ export function Info({ example }: { example: Example }) {
           </Section>
         )}
 
-        {example.notes && (
-          <Section title="Notes">
-            <p>{example.notes}</p>
-          </Section>
-        )}
-
         {example.tags.length > 0 && (
           <Section title="Tags">
             <ul className="flex flex-wrap gap-1">
@@ -187,14 +181,6 @@ export function Info({ example }: { example: Example }) {
                           ) : (
                             asset.license
                           ))}
-                      </ItemDescription>
-                    )}
-                    {/* Notes are the only free text here, and the stock
-                        two-line clamp is measured for a row in a list, not for
-                        a panel the reader opened to read. */}
-                    {asset.notes && (
-                      <ItemDescription className="line-clamp-none text-xs">
-                        {asset.notes}
                       </ItemDescription>
                     )}
                   </ItemContent>

--- a/apps/website/lib/helper.ts
+++ b/apps/website/lib/helper.ts
@@ -23,16 +23,15 @@ export type AssetAttribution = {
   license?: string;
   licenseUrl?: string;
   modified?: boolean;
-  notes?: string;
 };
 
 export type ExampleMetadata = {
   title: string;
   description: string;
   tags: string[];
+  apis?: string[];
   authors: string[];
   publishedAt?: string;
-  notes?: string;
   source: string;
   libraries: string[];
   assets: AssetAttribution[];

--- a/bin/lib/imports.mjs
+++ b/bin/lib/imports.mjs
@@ -1,0 +1,70 @@
+/**
+ * What an example imports, read as text.
+ *
+ * This is what `apis` in `pmndrs.json` is checked against: an entry that names
+ * an identifier the example does not import is either a typo or rot -- drei
+ * renames an API, someone fixes the import, and the metadata keeps advertising
+ * the old name to every agent that reads the document.
+ *
+ * Textual on purpose. The alternative, resolving the module and asking whether
+ * the export exists, reproves what the build already enforces: rollup fails the
+ * bundle on a missing named export, and the e2e suite then renders the scene.
+ * What no build can catch is metadata drifting away from source, and that needs
+ * nothing more than the names as written.
+ */
+
+/**
+ * An import statement, from the keyword at the start of a line to the module
+ * string. `[\s\S]` rather than `.` because the member list is usually spread
+ * over lines; lazy, so each statement stops at its own `from`.
+ */
+const IMPORT_STATEMENT = /^import\s+([\s\S]*?)\s+from\s*["'][^"']*["']/gm;
+
+/** `import type { Mesh } from "three"` -- a type, never an API. */
+const TYPE_ONLY = /^type\s/;
+
+const MEMBER_LIST = /\{([\s\S]*)\}/;
+
+/**
+ * The identifiers one import clause brings in, named as the library names them:
+ * `{ useMask as mask }` is `useMask`, because that is what a reader would go
+ * looking for. A namespace binding is its local name -- `* as THREE` has no
+ * other one.
+ */
+function bindings(clause) {
+  const names = [];
+
+  // Whatever sits outside the braces, which comes first when there is both: a
+  // default binding, or a namespace.
+  for (const part of clause.replace(MEMBER_LIST, "").split(",")) {
+    const binding = part.trim();
+    const namespace = binding.match(/^\*\s+as\s+([A-Za-z_$][\w$]*)$/);
+    if (namespace) names.push(namespace[1]);
+    else if (/^[A-Za-z_$][\w$]*$/.test(binding)) names.push(binding);
+  }
+
+  const members = clause.match(MEMBER_LIST);
+  if (members) {
+    for (const member of members[1].split(",")) {
+      const imported = member
+        .trim()
+        .split(/\s+as\s+/)[0]
+        .trim();
+      if (imported && !TYPE_ONLY.test(imported)) names.push(imported);
+    }
+  }
+
+  return names;
+}
+
+/** Every identifier `source` imports. */
+export function importedIdentifiers(source) {
+  const identifiers = new Set();
+
+  for (const [, clause] of source.matchAll(IMPORT_STATEMENT)) {
+    if (TYPE_ONLY.test(clause)) continue;
+    for (const name of bindings(clause)) identifiers.add(name);
+  }
+
+  return identifiers;
+}

--- a/bin/lib/render-llms.mjs
+++ b/bin/lib/render-llms.mjs
@@ -137,6 +137,13 @@ export function renderExample(example) {
     example.publishedAt && `Published: ${example.publishedAt}`,
     example.authors.length && `Authors: ${example.authors.join(", ")}`,
     example.tags.length && `Tags: ${example.tags.join(", ")}`,
+    // The identifiers the technique is carried by, ordered by the metadata, not
+    // alphabetically -- the first one is the answer to "what makes this one
+    // different". They are here rather than on the index line because ~34
+    // characters x 167 lines is 6 kB on a file read at the start of every
+    // question, and by the time you are reading this document you already
+    // chose.
+    example.apis?.length && `APIs: ${example.apis.join(", ")}`,
     `Ported from: ${example.source}`,
     `Dependencies: ${Object.entries(example.dependencies)
       .map(([name, version]) => `${name}@${version}`)
@@ -156,7 +163,6 @@ export function renderExample(example) {
     `# ${example.title}`,
     example.description.trim(),
     facts.join("\n"),
-    example.notes?.trim(),
     example.assets.length &&
       `## Asset attribution\n\n${attribution(example.assets)}`,
     ...example.files.map((file) => {

--- a/bin/validate-pmndrs-metadata.mjs
+++ b/bin/validate-pmndrs-metadata.mjs
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { importedIdentifiers } from "./lib/imports.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const examplesDirectory = path.join(root, "examples");
 const schemaPath = path.join(root, "schemas", "pmndrs.schema.json");
@@ -44,6 +46,38 @@ function isDate(value) {
     /^\d{4}-\d{2}-\d{2}$/.test(value) &&
     !Number.isNaN(Date.parse(`${value}T00:00:00Z`))
   );
+}
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+
+/** Every identifier the example's own `src/` imports, across all of its files. */
+function importsOf(exampleDirectory) {
+  const identifiers = new Set();
+
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(absolute);
+      else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        for (const identifier of importedIdentifiers(
+          fs.readFileSync(absolute, "utf8"),
+        )) {
+          identifiers.add(identifier);
+        }
+      }
+    }
+  };
+
+  walk(path.join(exampleDirectory, "src"));
+  return identifiers;
 }
 
 const exampleNames = fs
@@ -116,6 +150,25 @@ for (const exampleName of exampleNames) {
         exampleName,
         `library "${library}" is not listed in dependencies`,
       );
+    }
+  }
+
+  // Optional until every example carries one, but never wrong: an entry the
+  // example does not import is a name a reader would go looking for and not
+  // find. The check is local and only local -- whether drei still exports it at
+  // the pinned version is the bundler's job, and it already fails on it.
+  if (metadata.apis !== undefined) {
+    if (!isStringArray(metadata.apis)) {
+      addError(exampleName, '"apis" must contain non-empty strings');
+    } else if (hasDuplicates(metadata.apis)) {
+      addError(exampleName, '"apis" contains duplicates');
+    } else {
+      const imported = importsOf(exampleDirectory);
+      for (const api of metadata.apis) {
+        if (!imported.has(api)) {
+          addError(exampleName, `api "${api}" is not imported in src/`);
+        }
+      }
     }
   }
 

--- a/examples/frosted-glass/pmndrs.json
+++ b/examples/frosted-glass/pmndrs.json
@@ -2,7 +2,6 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Frosted Glass",
   "description": "Shader mip-map blur to mimic frosted glass. ",
-  "notes": "Updated for MeshTransmissionMaterial in 2023.",
   "tags": ["frosted-glas", "shaders", "transmission"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2021-03-22",

--- a/examples/router-transitions/pmndrs.json
+++ b/examples/router-transitions/pmndrs.json
@@ -2,7 +2,6 @@
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Router Transitions",
   "description": "Shows how to implement routes and mount/unmount transition within the canvas using Wouter.",
-  "notes": "Updated for MeshTransmissionMaterial in 2023.",
   "tags": ["router", "transitions", "html", "transmission"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2021-04-19",

--- a/schemas/pmndrs.schema.json
+++ b/schemas/pmndrs.schema.json
@@ -33,6 +33,14 @@
       },
       "uniqueItems": true
     },
+    "apis": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
     "authors": {
       "type": "array",
       "items": {
@@ -44,10 +52,6 @@
     "publishedAt": {
       "type": "string",
       "format": "date"
-    },
-    "notes": {
-      "type": "string",
-      "minLength": 1
     },
     "source": {
       "type": "string",
@@ -123,10 +127,6 @@
         },
         "modified": {
           "type": "boolean"
-        },
-        "notes": {
-          "type": "string",
-          "minLength": 1
         }
       }
     }

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error -- plain JS, shared with bin/validate-pmndrs-metadata.mjs
+import { importedIdentifiers } from "../bin/lib/imports.mjs";
+
+/**
+ * The `apis` lint is `apis ⊆ imports`, so everything it can get wrong it gets
+ * wrong here: a name this misses is a valid entry rejected on `pnpm check`, and
+ * a name it invents is rot the lint was written to catch going unnoticed.
+ */
+
+const identifiers = (source: string) => [...importedIdentifiers(source)];
+
+describe("importedIdentifiers", () => {
+  it("reads a member list that is spread over lines", () => {
+    // The shape every example is written in, and the one a `grep 'from "'`
+    // misses entirely.
+    expect(
+      identifiers(`import {
+  useMask,
+  MeshTransmissionMaterial,
+} from "@react-three/drei"`),
+    ).toEqual(["useMask", "MeshTransmissionMaterial"]);
+  });
+
+  it("keeps each statement to its own module", () => {
+    expect(
+      identifiers(
+        [
+          'import { Canvas } from "@react-three/fiber"',
+          'import { useMask } from "@react-three/drei"',
+        ].join("\n"),
+      ),
+    ).toEqual(["Canvas", "useMask"]);
+  });
+
+  it("takes the name the library exports, not the local alias", () => {
+    // `apis` names what a reader would go looking for in the docs.
+    expect(
+      identifiers('import { useMask as mask } from "@react-three/drei"'),
+    ).toEqual(["useMask"]);
+  });
+
+  it("keeps a default binding alongside its member list", () => {
+    expect(identifiers('import React, { useRef } from "react"')).toEqual([
+      "React",
+      "useRef",
+    ]);
+  });
+
+  it("binds a namespace under its local name, the only one it has", () => {
+    expect(identifiers('import * as THREE from "three"')).toEqual(["THREE"]);
+  });
+
+  it("ignores types, which are not APIs", () => {
+    expect(
+      identifiers(
+        [
+          'import type { Mesh } from "three"',
+          'import { type Group, useMask } from "@react-three/drei"',
+        ].join("\n"),
+      ),
+    ).toEqual(["useMask"]);
+  });
+
+  it("has nothing to say about a side-effect import", () => {
+    expect(identifiers('import "./styles.css"')).toEqual([]);
+  });
+
+  it("does not mistake a re-export for an import", () => {
+    expect(identifiers('export { useMask } from "@react-three/drei"')).toEqual(
+      [],
+    );
+  });
+});

--- a/test/render-llms.test.ts
+++ b/test/render-llms.test.ts
@@ -106,6 +106,14 @@ describe("summaryLine", () => {
     ).toBe("caustics · One idea, spread over lines.");
   });
 
+  it("leaves the APIs to the example's own document", () => {
+    // ~34 characters x 167 lines, on the file read at the start of every
+    // question, to say what is one fetch away once the choice is made.
+    expect(
+      summaryLine(summary({ apis: ["useMask", "MeshTransmissionMaterial"] })),
+    ).toBe("caustics");
+  });
+
   it("says nothing about size for an example that is cheap to open", () => {
     // The marker has to stay rare to mean anything: its absence is the signal
     // that a reader can open two of these without weighing the budget.
@@ -156,10 +164,24 @@ describe("renderExample", () => {
   });
 
   it("omits the facts an example does not carry", () => {
-    const text = renderExample(example({ authors: [], tags: [] }));
+    const text = renderExample(example({ authors: [], tags: [], apis: [] }));
 
     expect(text).not.toContain("Authors:");
     expect(text).not.toContain("Tags:");
+    expect(text).not.toContain("APIs:");
+  });
+
+  it("names the APIs, in the order the metadata puts them", () => {
+    // Next to the tags, which are the same thing said for a human: what this
+    // example is about, in the vocabulary of its code.
+    expect(
+      renderExample(
+        example({
+          tags: ["transmission"],
+          apis: ["useMask", "MeshTransmissionMaterial"],
+        }),
+      ),
+    ).toContain("Tags: transmission\nAPIs: useMask, MeshTransmissionMaterial");
   });
 
   it("fences each file under its own path, tagged by extension", () => {

--- a/test/turbo-cache.test.ts
+++ b/test/turbo-cache.test.ts
@@ -197,6 +197,36 @@ describe("lint", () => {
     });
   });
 
+  /**
+   * `apis` is checked against the identifiers the example imports, so a source
+   * file is as much an input as the metadata that names them. Cached past a
+   * dropped import, the rule stops catching the drift it exists for.
+   */
+  it("re-runs the metadata check when an example source moves", () => {
+    const before = hashOf("//#lint:metadata", LINT);
+
+    withTouched(EXAMPLE_SOURCE, () => {
+      expect(hashOf("//#lint:metadata", LINT)).not.toBe(before);
+    });
+  });
+
+  it("re-runs the metadata check when the import reader moves", () => {
+    const before = hashOf("//#lint:metadata", LINT);
+
+    withTouched("bin/lib/imports.mjs", () => {
+      expect(hashOf("//#lint:metadata", LINT)).not.toBe(before);
+    });
+  });
+
+  it("leaves the metadata check alone for the llms renderer", () => {
+    // It shares `bin/lib/`, and nothing else.
+    const before = hashOf("//#lint:metadata", LINT);
+
+    withTouched("bin/lib/render-llms.mjs", () => {
+      expect(hashOf("//#lint:metadata", LINT)).toBe(before);
+    });
+  });
+
   it("re-runs the examples pass when an example source moves", () => {
     const before = dryRun(LINT);
 

--- a/turbo.json
+++ b/turbo.json
@@ -56,10 +56,16 @@
       "outputs": []
     },
     "//#lint:metadata": {
+      // `apis` is checked against what the example imports, so the sources are
+      // an input too: without them a dropped import replays a cached pass and
+      // the metadata keeps advertising an identifier that is no longer there --
+      // which is the one thing the rule exists to catch.
       "inputs": [
         "bin/validate-pmndrs-metadata.mjs",
+        "bin/lib/imports.mjs",
         "schemas/pmndrs.schema.json",
-        "examples/*/{package.json,pmndrs.json}"
+        "examples/*/{package.json,pmndrs.json}",
+        "examples/*/src/**/*.{js,jsx,ts,tsx,mjs,cjs}"
       ],
       "outputs": []
     },


### PR DESCRIPTION
The document an agent reads names no technique. `aquarium` is served with
an empty description and the single tag `transmission`, while what makes
it work -- `useMask` and a backside `MeshTransmissionMaterial` -- is
nowhere, and the reader pays 400 lines of TSX to rediscover it.

Identifiers are data, not prose. Three median-length API names are 34
characters, 28% of the 120 the one-line `description` gets, which is
exactly why they get their own field rather than eating the sentence.

`apis` renders in the facts block of `<name>.md`, next to the tags, and
not in `llms.txt`: ~34 characters on 167 index lines takes that file from
~19 kB to ~25 kB, on a document read at the start of every question, to
say what is one fetch away once the choice is already made.

Optional for now. It becomes required once every example carries one --
required before it is populated is a red CI on day one.

`lint:metadata` enforces `apis ⊆ imports`, as a hard error. The check is
local and only local: whether drei still exports the name at the pinned
version is the bundler's job, and rollup already fails the build on a
missing named export. What no build can catch is metadata drifting away
from the source, and that is what this catches -- drei renames an API,
someone fixes the import, `apis` still lists the old name, the lint
breaks. That property is why the example's sources are now inputs of
`//#lint:metadata`: cached past a dropped import, the rule stops catching
the one thing it exists for.

`notes` goes. Two uses, both the same string, "Updated for
MeshTransmissionMaterial in 2023." -- maintenance history that belongs in
git, rendered into the document where a reader cannot tell it from
documentation. `assets[].notes` had zero uses and went with it.

Closes #194

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>