### PR TITLE
Filter by tag, and by more than one library

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -30,7 +30,11 @@ const examples = getExamples();
  */
 function bootNav(storageKey: string) {
   const params = new URLSearchParams(window.location.search);
-  const filtering = !!(params.get("q") || params.get("library"));
+  const filtering = !!(
+    params.get("q") ||
+    params.get("library") ||
+    params.get("tags")
+  );
 
   const isCollapsed = () => {
     const parts = window.location.pathname.split("/").filter(Boolean);

--- a/apps/website/components/Nav.tsx
+++ b/apps/website/components/Nav.tsx
@@ -15,15 +15,15 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useParams } from "next/navigation";
-import { createSerializer, parseAsString, useQueryStates } from "nuqs";
+import {
+  createSerializer,
+  parseAsArrayOf,
+  parseAsString,
+  useQueryStates,
+} from "nuqs";
 import { type Options, useHotkeys } from "react-hotkeys-hook";
 import { useEventListener, useIsClient } from "usehooks-ts";
-import {
-  ChevronLeftIcon,
-  ListFilterIcon,
-  SearchIcon,
-  XIcon,
-} from "lucide-react";
+import { ChevronLeftIcon, ListFilterIcon, XIcon } from "lucide-react";
 
 import { getLibraryLabel, getLibraryPopularity } from "@/const/libraries";
 import { useRovingTabIndex } from "@/hooks/use-roving-tabindex";
@@ -38,15 +38,14 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-  InputGroupText,
-} from "@/components/ui/input-group";
-import { Item, ItemFooter, ItemMedia } from "@/components/ui/item";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
+import { InputGroupAddon, InputGroupText } from "@/components/ui/input-group";
 import {
   Select,
   SelectContent,
@@ -55,6 +54,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Item, ItemFooter, ItemMedia } from "@/components/ui/item";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Sidebar,
   SidebarContent,
@@ -82,18 +84,29 @@ const SKELETON_TAGS = [
   [80, 44, 92],
 ];
 
-/* Filters are shareable: `?q=` carries the search text, `?library=` the
-   library filter. nuqs owns the round trip — the URL *is* the state, so the
-   defaults below double as the "no filter" values and `clearOnDefault` (on by
-   default) drops the empty param rather than leaving `?q=` behind.
+/* Filters are shareable: `?q=` carries the search text, `?library=` and
+   `?tags=` the picked options. nuqs owns the round trip — the URL *is* the
+   state, so the defaults below double as the "no filter" values and
+   `clearOnDefault` (on by default) drops the empty param rather than leaving
+   `?q=` behind.
 
    Its defaults also cover what the hand-rolled version had to spell out: a
    shallow `history.replaceState` instead of a router navigation per keystroke,
-   throttled to stay under Safari's History API rate limit. */
+   throttled to stay under Safari's History API rate limit.
+
+   `?library=` keeps both its name and its labels through the move to a
+   multi-select: a list parser reads a link written when it held one value as
+   the one-element list it now is, which is a compatibility layer nobody has to
+   write, deprecate or eventually delete. */
 const filterParsers = {
   q: parseAsString.withDefault(""),
-  library: parseAsString.withDefault(""),
+  library: parseAsArrayOf(parseAsString).withDefault([]),
+  tags: parseAsArrayOf(parseAsString).withDefault([]),
 };
+
+/* The floor of the rule the two option lists are cut by; see where they are
+   derived. */
+const MIN_USAGE = 2;
 
 /* Same parsers, used to hang the active filter off every card link so it
    survives the client navigation into an example. */
@@ -308,7 +321,10 @@ export default function Nav({
   const ulRef = useRef<ElementRef<"ul">>(null);
   const [listElement, setListElement] = useState<HTMLUListElement | null>(null);
   const roving = useRovingTabIndex(ulRef);
-  const searchRef = useRef<HTMLInputElement>(null);
+  const pickedRef = useRef<ElementRef<"div">>(null);
+  const pickedRoving = useRovingTabIndex(pickedRef, {
+    orientation: "horizontal",
+  });
 
   const setListRef = useCallback((node: HTMLUListElement | null) => {
     ulRef.current = node;
@@ -317,10 +333,12 @@ export default function Nav({
 
   const [openState, setOpenState] = useState<boolean | null>(null);
   const ready = useIsClient();
+  const [comboOpen, setComboOpen] = useState(false);
   const [libraryOpen, setLibraryOpen] = useState(false);
-  const [searchOpen, setSearchOpen] = useState(false);
+  const fieldRef = useRef<ElementRef<"div">>(null);
 
-  const [{ q: search, library }, setFilters] = useQueryStates(filterParsers);
+  const [{ q: search, library, tags }, setFilters] =
+    useQueryStates(filterParsers);
   const setSearch = useCallback(
     (value: string | ((current: string) => string)) =>
       setFilters((current) => ({
@@ -328,12 +346,45 @@ export default function Nav({
       })),
     [setFilters],
   );
+
+  const setTags = useCallback(
+    (next: string[]) => setFilters({ tags: next }),
+    [setFilters],
+  );
   const setLibrary = useCallback(
-    (value: string) => setFilters({ library: value }),
+    (next: string[]) => setFilters({ library: next }),
     [setFilters],
   );
 
-  const searchVisible = searchOpen || search !== "";
+  const clearFilters = useCallback(
+    () => setFilters({ q: "", library: [], tags: [] }),
+    [setFilters],
+  );
+
+  /* Bound once here rather than spelled out at the card links below, where
+     `tags` is the example's own and would quietly win. */
+  const filters = useMemo(
+    () => ({ q: search, library, tags }),
+    [library, search, tags],
+  );
+
+  /* Both vocabularies in the order they are offered, libraries first, so the
+     row underneath the field reads the same way round as the two controls
+     above it. */
+  const picked = useMemo(
+    () => [
+      ...library.map((value) => ({ kind: "library" as const, value })),
+      ...tags.map((value) => ({ kind: "tags" as const, value })),
+    ],
+    [library, tags],
+  );
+  const unpick = useCallback(
+    (kind: "library" | "tags", value: string) =>
+      setFilters((current) => ({
+        [kind]: current[kind].filter((picked) => picked !== value),
+      })),
+    [setFilters],
+  );
 
   const paintedCollapsed = useSyncExternalStore(
     subscribeToPaintedCollapsed,
@@ -359,43 +410,75 @@ export default function Nav({
 
      Plain state, not `setOpen`: following someone's filter link should not
      overwrite this visitor's stored collapse preference. */
-  const hasFilters = search !== "" || library !== "";
+  const hasFilters = search !== "" || library.length > 0 || tags.length > 0;
   const [filtersRevealed, setFiltersRevealed] = useState(hasFilters);
   if (hasFilters && !filtersRevealed) {
     setFiltersRevealed(true);
     setOpenState(true);
-    if (search) setSearchOpen(true);
   }
 
-  const libraryOptions = useMemo(() => {
-    const popularityByLabel = new Map<string, number>();
-    const usageByLabel = new Map<string, number>();
-    const libraries = new Set(examples.flatMap((example) => example.libraries));
+  /* Two vocabularies, two controls, one rule. An option earns its place by
+     partitioning the corpus: a value carried by one example alone leaves out
+     nothing worth leaving out, and a value carried by all of them leaves out
+     nothing at all. Both ends are the same defect, so both go — which is why
+     `@react-three/fiber`, on every example here, is in neither list without
+     being named in either. Read off the corpus rather than written down, it
+     cannot go stale.
 
-    libraries.forEach((exampleLibrary) => {
-      const label = getLibraryLabel(exampleLibrary);
-      popularityByLabel.set(
-        label,
-        (popularityByLabel.get(label) ?? 0) +
-          getLibraryPopularity(exampleLibrary),
-      );
-    });
+     It governs what is *offered*, never what is *accepted*: `filteredExamples`
+     honours a value that has dropped out of a list, so a link shared before it
+     dropped still narrows to what it said it would. */
+  const { tagOptions, libraryOptions, counts } = useMemo(() => {
+    const usage = new Map<string, number>();
+    const bump = (value: string) =>
+      usage.set(value, (usage.get(value) ?? 0) + 1);
 
     examples.forEach((example) => {
-      const labels = new Set(example.libraries.map(getLibraryLabel));
-      labels.forEach((label) => {
-        usageByLabel.set(label, (usageByLabel.get(label) ?? 0) + 1);
-      });
+      new Set(example.tags).forEach(bump);
+      new Set(example.libraries.map(getLibraryLabel)).forEach(bump);
     });
 
-    return Array.from(popularityByLabel)
-      .sort(
-        ([labelA, popularityA], [labelB, popularityB]) =>
-          (usageByLabel.get(labelB) ?? 0) - (usageByLabel.get(labelA) ?? 0) ||
-          popularityB - popularityA ||
-          labelA.localeCompare(labelB),
-      )
-      .map(([label]) => label);
+    /* A label can stand for several packages — the three `@react-spring/*` are
+       one "React Spring" — so its pull is theirs added up. */
+    const popularity = new Map<string, number>();
+    new Set(examples.flatMap((example) => example.libraries)).forEach(
+      (exampleLibrary) => {
+        const label = getLibraryLabel(exampleLibrary);
+        popularity.set(
+          label,
+          (popularity.get(label) ?? 0) + getLibraryPopularity(exampleLibrary),
+        );
+      },
+    );
+
+    const partitions = (value: string) => {
+      const count = usage.get(value) ?? 0;
+      return count >= MIN_USAGE && count < examples.length;
+    };
+    const by = (value: string) => usage.get(value) ?? 0;
+
+    const labels = new Set(
+      examples.flatMap((example) => example.libraries.map(getLibraryLabel)),
+    );
+    const tagNames = new Set(examples.flatMap((example) => example.tags));
+
+    return {
+      counts: usage,
+      tagOptions: Array.from(tagNames)
+        .filter(partitions)
+        .sort((a, b) => by(b) - by(a) || a.localeCompare(b)),
+      /* Libraries break their usage ties on npm popularity, which is the one
+         thing the corpus cannot say and the reason that table exists. Tags
+         have no such second opinion. */
+      libraryOptions: Array.from(labels)
+        .filter(partitions)
+        .sort(
+          (a, b) =>
+            by(b) - by(a) ||
+            (popularity.get(b) ?? 0) - (popularity.get(a) ?? 0) ||
+            a.localeCompare(b),
+        ),
+    };
   }, [examples]);
 
   const filteredExamples = useMemo(() => {
@@ -407,14 +490,13 @@ export default function Nav({
 
     return examples
       .filter((example) => {
-        if (
-          library &&
-          !example.libraries.some(
-            (exampleLibrary) => getLibraryLabel(exampleLibrary) === library,
-          )
-        ) {
+        /* Every chip narrows, within a vocabulary as much as across the two:
+           one rule, so the count under the field only ever falls as chips are
+           added. `Cannon` + `Rapier` is empty, and says so. */
+        const labels = example.libraries.map(getLibraryLabel);
+        if (!library.every((wanted) => labels.includes(wanted))) return false;
+        if (!tags.every((wanted) => example.tags.includes(wanted)))
           return false;
-        }
 
         if (terms.length === 0) return true;
 
@@ -434,27 +516,26 @@ export default function Nav({
       .sort(
         (exampleA, exampleB) => Number(exampleB.isNew) - Number(exampleA.isNew),
       );
-  }, [examples, library, search]);
+  }, [examples, library, search, tags]);
   const nearbyExamples = useNearbyExamples(listElement, filteredExamples);
 
+  /* Reached through the row that holds it rather than by a ref of its own:
+     the field is the registry's, rendered a couple of wrappers below this call
+     site, and a `ref` handed down that far arrives empty. The row is ours, and
+     the only `input` in it is this one. Same reasoning as
+     `use-roving-tabindex`, which reads the DOM for the same reason. */
   const focusSearch = useCallback(
     (select = false) => {
       setOpen(true);
-      setSearchOpen(true);
 
       requestAnimationFrame(() => {
-        searchRef.current?.focus();
-        if (select) searchRef.current?.select();
+        const field = fieldRef.current?.querySelector("input");
+        field?.focus();
+        if (select) field?.select();
       });
     },
     [setOpen],
   );
-
-  const dismissSearch = useCallback(() => {
-    setSearch("");
-    setSearchOpen(false);
-    searchRef.current?.blur();
-  }, [setSearch]);
 
   /* The rail's keyboard layer, one hotkey at a time rather than a single
      window listener with a ladder of early returns: every branch of it reads
@@ -466,7 +547,13 @@ export default function Nav({
      `enabled: !libraryOpen` is the ladder's first rung kept whole: the open
      dropdown is portalled out of the nav, so `activeElement` is nowhere near
      the trigger and the type-to-search below would eat the list's own
-     typeahead. It owns the keyboard while it is open. */
+     typeahead. It owns the keyboard while it is open.
+
+     The combobox gets no such rung, because it is open the entire time
+     someone is typing into it rather than by exception, and the same guard
+     would switch the layer off at the first keystroke. It needs none: an open
+     popup means its input has focus, and the focus test below already stands
+     the type-ahead down for any input. */
   const shortcut = {
     enabled: !libraryOpen,
     enableOnFormTags: true,
@@ -479,9 +566,13 @@ export default function Nav({
     shortcut,
   );
 
-  useHotkeys("escape", dismissSearch, {
+  /* Escape in two beats, and this is the second one. Base UI owns the first:
+     while the popup is open the key closes it and never reaches here, so the
+     one press that dismisses a list cannot also throw away what the list was
+     filtering. Closed and filtered, the same key clears. */
+  useHotkeys("escape", clearFilters, {
     ...shortcut,
-    enabled: !libraryOpen && searchVisible,
+    enabled: !comboOpen && !libraryOpen && hasFilters,
   });
 
   /* Type-to-search, which unlike the shortcuts above must not fire while
@@ -598,86 +689,135 @@ export default function Nav({
             to be set on the two children: `className` here lands on the fixed
             container, and the panel's background is painted a level deeper. */}
         <SidebarHeader className="px-4">
-          {/* Both branches read the URL, so on a filtered arrival both are
-              wrong until React knows it: the row would paint the library
-              filter unset, or paint the dropdown where the search field
-              belongs. `display: contents` so standing in front of them
-              changes nothing about how they lay out. */}
-          <Skeleton id="nav-filters-skeleton" className="h-9 rounded-full" />
+          {/* The field reads the URL, so on a filtered arrival it is wrong
+              until React knows it: the row would paint with neither the chips
+              nor the text it was linked with. One line, which is what an
+              unfilled field measures — a link carrying enough chips to wrap
+              lands taller than this, and the top of the list moves once as it
+              does. `display: contents` so standing in front of the real thing
+              changes nothing about how it lays out. */}
+          <Skeleton id="nav-filters-skeleton" className="h-9 rounded-4xl" />
           <div id="nav-filters" className="contents">
-            {searchVisible ? (
-              <InputGroup className="animate-in border-border bg-input shadow-lg duration-200 fade-in slide-in-from-top-1">
-                {/* Addons come after the control in the DOM — they focus it on
-                  click and take their visual side from `align`. */}
-                <InputGroupInput
-                  ref={searchRef}
-                  type="search"
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  onFocus={() => setSearchOpen(true)}
-                  placeholder="Search examples"
-                  aria-label="Search examples"
+            <div ref={fieldRef} className="flex items-center gap-2">
+              {/* Libraries keep a control of their own rather than joining the
+                  list below: two vocabularies in one popup is two lists to
+                  scroll past, and the shorter of them is the one nobody types.
+                  Icon and count only — the rail is 200px, and what is picked
+                  is named in the row underneath. */}
+              <Select
+                multiple
+                open={libraryOpen}
+                onOpenChange={setLibraryOpen}
+                value={library}
+                onValueChange={(next: string[]) => setLibrary(next)}
+              >
+                <SelectTrigger
+                  className="shrink-0 gap-1 border-border bg-input px-2.5 shadow-lg"
+                  aria-label="Filter examples by library"
+                >
+                  <ListFilterIcon className="text-muted-foreground" />
+                  <SelectValue>
+                    {(value: string[]) =>
+                      value.length > 0 ? (
+                        <span className="text-xs tabular-nums">
+                          {value.length}
+                        </span>
+                      ) : null
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent className="backdrop-blur-sm">
+                  <SelectGroup>
+                    {libraryOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        <span className="min-w-0 flex-1 truncate">
+                          {option}
+                        </span>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          {counts.get(option)}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {/* Picked tags are shown in the row below rather than inside the
+                  field, so the field is one line at every filter it can hold —
+                  which is what the pre-paint skeleton in front of it measures,
+                  and what keeps a pill radius honest. */}
+              <Combobox
+                multiple
+                items={tagOptions}
+                value={tags}
+                onValueChange={(next: string[]) => setTags(next)}
+                inputValue={search}
+                /* Base UI treats the typed text as the popup's own scratch
+                   space and wipes it on close. Here it is a filter in its own
+                   right and it lives in the URL, so that one write is refused
+                   and every other reason is let through. */
+                onInputValueChange={(next: string, details) => {
+                  if (details.reason === "input-clear") return details.cancel();
+                  setSearch(next);
+                }}
+                open={comboOpen}
+                onOpenChange={(next: boolean) => setComboOpen(next)}
+              >
+                <ComboboxInput
+                  showTrigger={false}
+                  placeholder="Filter examples"
+                  aria-label="Filter examples"
                   aria-controls="example-list"
                   aria-describedby="search-results"
-                  className="[&::-webkit-search-cancel-button]:hidden"
-                />
-                <InputGroupAddon>
-                  <SearchIcon />
-                </InputGroupAddon>
-                <InputGroupAddon align="inline-end">
-                  <InputGroupText className="text-xs tabular-nums">
-                    {filteredExamples.length}
-                  </InputGroupText>
-                  <InputGroupButton
-                    size="icon-xs"
-                    onClick={dismissSearch}
-                    aria-label="Close search"
-                  >
-                    <XIcon />
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
-            ) : (
-              <div className="flex items-center gap-2">
-                <Select
-                  open={libraryOpen}
-                  onOpenChange={setLibraryOpen}
-                  value={library || null}
-                  onValueChange={(value) => setLibrary(value ?? "")}
-                >
-                  <SelectTrigger
-                    className="min-w-0 flex-1 border-border bg-input shadow-lg"
-                    aria-label="Filter examples by library"
-                  >
-                    <ListFilterIcon className="text-muted-foreground" />
-                    <SelectValue placeholder="All libraries" />
-                  </SelectTrigger>
-                  <SelectContent className="backdrop-blur-sm">
-                    <SelectGroup>
-                      {/* `null` is Base UI's cleared value, so the option that
-                        drops the filter is the one that carries it and the
-                        state stays "". */}
-                      <SelectItem value={null}>All libraries</SelectItem>
-                      {libraryOptions.map((option) => (
-                        <SelectItem key={option} value={option}>
-                          {option}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  onClick={() => focusSearch()}
-                  aria-label="Search examples"
                   aria-keyshortcuts="Meta+F Control+F Meta+K Control+K"
-                  title="Search examples (⌘F)"
-                  className="bg-input shadow-lg"
+                  className="min-w-0 flex-1 border-border bg-input shadow-lg"
                 >
-                  <SearchIcon />
-                </Button>
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupText className="text-xs tabular-nums">
+                      {filteredExamples.length}
+                    </InputGroupText>
+                  </InputGroupAddon>
+                </ComboboxInput>
+                <ComboboxContent className="backdrop-blur-sm">
+                  <ComboboxEmpty>
+                    Nothing in the list says that — filtering on the text alone.
+                  </ComboboxEmpty>
+                  <ComboboxList>
+                    {(tag: string) => (
+                      <ComboboxItem key={tag} value={tag}>
+                        <span className="min-w-0 flex-1 truncate">{tag}</span>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          {counts.get(tag)}
+                        </span>
+                      </ComboboxItem>
+                    )}
+                  </ComboboxList>
+                </ComboboxContent>
+              </Combobox>
+            </div>
+            {/* Everything picked, from either control, in one row: the Select
+                is an icon and a number, so this is the only place that says
+                which libraries are on. Its own roving tabindex — a row that
+                grows with the filter would otherwise grow the site's tab
+                sequence with it. */}
+            {picked.length > 0 && (
+              <div
+                ref={pickedRef}
+                className="flex flex-wrap gap-1"
+                {...pickedRoving}
+              >
+                {picked.map(({ kind, value }) => (
+                  <Badge key={`${kind}:${value}`} className="ps-2 pe-1">
+                    {value}
+                    <button
+                      type="button"
+                      onClick={() => unpick(kind, value)}
+                      aria-label={`Remove ${value}`}
+                      className="ms-0.5 rounded-full p-0.5 opacity-50 transition-opacity hover:opacity-100"
+                    >
+                      <XIcon className="size-3" />
+                    </button>
+                  </Badge>
+                ))}
               </div>
             )}
           </div>
@@ -759,10 +899,10 @@ export default function Nav({
                                across this navigation, but the URL is the state
                                now, so a bare `/examples/<name>` would clear
                                it. */
-                            href={serializeFilters(`/examples/${name}`, {
-                              q: search,
-                              library,
-                            })}
+                            href={serializeFilters(
+                              `/examples/${name}`,
+                              filters,
+                            )}
                             aria-label={title}
                             aria-current={
                               examplename === name ? "page" : undefined
@@ -849,10 +989,7 @@ export default function Nav({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => {
-                    dismissSearch();
-                    setLibrary("");
-                  }}
+                  onClick={clearFilters}
                 >
                   Clear filters
                 </Button>

--- a/apps/website/components/ui/combobox.tsx
+++ b/apps/website/components/ui/combobox.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import * as React from "react";
+import { Combobox as ComboboxPrimitive } from "@base-ui/react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { ChevronDownIcon, XIcon, CheckIcon } from "lucide-react";
+
+const Combobox = ComboboxPrimitive.Root;
+
+function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props) {
+  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />;
+}
+
+function ComboboxTrigger({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Trigger.Props) {
+  return (
+    <ComboboxPrimitive.Trigger
+      data-slot="combobox-trigger"
+      className={cn("[&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+    </ComboboxPrimitive.Trigger>
+  );
+}
+
+function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
+  return (
+    <ComboboxPrimitive.Clear
+      data-slot="combobox-clear"
+      render={<InputGroupButton variant="ghost" size="icon-xs" />}
+      className={cn(className)}
+      {...props}
+    >
+      <XIcon className="pointer-events-none" />
+    </ComboboxPrimitive.Clear>
+  );
+}
+
+function ComboboxInput({
+  className,
+  children,
+  disabled = false,
+  showTrigger = true,
+  showClear = false,
+  ...props
+}: ComboboxPrimitive.Input.Props & {
+  showTrigger?: boolean;
+  showClear?: boolean;
+}) {
+  return (
+    <InputGroup className={cn("w-auto", className)}>
+      <ComboboxPrimitive.Input
+        render={<InputGroupInput disabled={disabled} />}
+        {...props}
+      />
+      <InputGroupAddon align="inline-end">
+        {showTrigger && (
+          <InputGroupButton
+            size="icon-xs"
+            variant="ghost"
+            render={<ComboboxTrigger />}
+            data-slot="input-group-button"
+            className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
+            disabled={disabled}
+          />
+        )}
+        {showClear && <ComboboxClear disabled={disabled} />}
+      </InputGroupAddon>
+      {children}
+    </InputGroup>
+  );
+}
+
+function ComboboxContent({
+  className,
+  side = "bottom",
+  sideOffset = 6,
+  align = "start",
+  alignOffset = 0,
+  anchor,
+  ...props
+}: ComboboxPrimitive.Popup.Props &
+  Pick<
+    ComboboxPrimitive.Positioner.Props,
+    "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
+  >) {
+  return (
+    <ComboboxPrimitive.Portal>
+      <ComboboxPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        className="isolate z-50"
+      >
+        <ComboboxPrimitive.Popup
+          data-slot="combobox-content"
+          data-chips={!!anchor}
+          className={cn(
+            "group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/5 duration-100 data-[chips=true]:min-w-(--anchor-width) data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-9 *:data-[slot=input-group]:border-none *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        />
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  );
+}
+
+function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
+  return (
+    <ComboboxPrimitive.List
+      data-slot="combobox-list"
+      className={cn(
+        "no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto overscroll-contain p-1 data-empty:p-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxItem({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Item.Props) {
+  return (
+    <ComboboxPrimitive.Item
+      data-slot="combobox-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2.5 rounded-xl py-2 pr-8 pl-3 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  );
+}
+
+function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props) {
+  return (
+    <ComboboxPrimitive.Group
+      data-slot="combobox-group"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxLabel({
+  className,
+  ...props
+}: ComboboxPrimitive.GroupLabel.Props) {
+  return (
+    <ComboboxPrimitive.GroupLabel
+      data-slot="combobox-label"
+      className={cn("px-3.5 py-2.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props) {
+  return (
+    <ComboboxPrimitive.Collection data-slot="combobox-collection" {...props} />
+  );
+}
+
+function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
+  return (
+    <ComboboxPrimitive.Empty
+      data-slot="combobox-empty"
+      className={cn(
+        "hidden w-full justify-center py-2 text-center text-sm text-muted-foreground group-data-empty/combobox-content:flex",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxSeparator({
+  className,
+  ...props
+}: ComboboxPrimitive.Separator.Props) {
+  return (
+    <ComboboxPrimitive.Separator
+      data-slot="combobox-separator"
+      className={cn("-mx-1 my-1 h-px bg-border/50", className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChips({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> &
+  ComboboxPrimitive.Chips.Props) {
+  return (
+    <ComboboxPrimitive.Chips
+      data-slot="combobox-chips"
+      className={cn(
+        "flex min-h-9 flex-wrap items-center gap-1.5 rounded-4xl border border-input bg-input/30 bg-clip-padding px-2.5 py-1.5 text-sm transition-colors focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-[3px] has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1.5 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChip({
+  className,
+  children,
+  showRemove = true,
+  ...props
+}: ComboboxPrimitive.Chip.Props & {
+  showRemove?: boolean;
+}) {
+  return (
+    <ComboboxPrimitive.Chip
+      data-slot="combobox-chip"
+      className={cn(
+        "flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 rounded-4xl bg-muted-foreground/10 px-2 text-xs font-medium whitespace-nowrap text-foreground has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showRemove && (
+        <ComboboxPrimitive.ChipRemove
+          render={<Button variant="ghost" size="icon-xs" />}
+          className="-ml-1 opacity-50 hover:opacity-100"
+          data-slot="combobox-chip-remove"
+        >
+          <XIcon className="pointer-events-none" />
+        </ComboboxPrimitive.ChipRemove>
+      )}
+    </ComboboxPrimitive.Chip>
+  );
+}
+
+function ComboboxChipsInput({
+  className,
+  ...props
+}: ComboboxPrimitive.Input.Props) {
+  return (
+    <ComboboxPrimitive.Input
+      data-slot="combobox-chip-input"
+      className={cn("min-w-16 flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+function useComboboxAnchor() {
+  return React.useRef<HTMLDivElement | null>(null);
+}
+
+export {
+  Combobox,
+  ComboboxInput,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxGroup,
+  ComboboxLabel,
+  ComboboxCollection,
+  ComboboxEmpty,
+  ComboboxSeparator,
+  ComboboxChips,
+  ComboboxChip,
+  ComboboxChipsInput,
+  ComboboxTrigger,
+  ComboboxValue,
+  useComboboxAnchor,
+};


### PR DESCRIPTION
The rail filtered by library and by free text, and the two took turns:
the header showed one or the other, never both, because there was no
room for both. Tags were printed on every card and were decorative --
they reached the free-text haystack and nothing else.

Now there are two controls on one line, and a row of what is picked
underneath.

### Two vocabularies, one rule for both

An option is offered when it partitions the corpus:

    2 <= count < examples.length

which is 56 tags and 12 libraries. `@react-three/fiber` is on all 167
examples and leaves by the top; a tag carried by one example leaves by
the bottom. Neither end is named in the code -- the rule reads the
corpus, so it cannot go stale as examples land.

It governs what is *offered*, never what is *accepted*. A value that has
dropped out of a list still filters, so a link shared before it dropped
still narrows to what it said it would.

Every pick narrows, within a vocabulary and across the two. `Cannon` +
`Rapier` is empty and says so; there is one rule to learn and the count
under the field only ever falls as filters are added.

### The URL

`?library=` keeps its name and its labels and becomes a list. A link
written when it held one value parses as the one-element list it now is,
so there is no compatibility layer to write, deprecate or delete.
`?tags=` arrives in the same shape, and `bootNav` learns it -- without
that, a `?tags=` link paints all 167 examples with no skeleton and then
snaps.

### Where the picks are shown

Not inside the field. A chips input grows to two and three lines, and
the pre-paint skeleton standing in front of it on a filtered arrival can
only be one -- and the registry's pill radius on a box three lines tall
reads as a mistake. So the field stays one line at every filter it can
hold, and everything picked sits in a row below it, from both controls
at once. That row is also the only thing that says *which* libraries are
on, the trigger being an icon and a count.

The row is a repeated group of controls, so it takes a roving tabindex
of its own: four active filters would otherwise be four more tab stops
in a site that has six.

### Keyboard

Carried over rather than dropped. Cmd-F/Cmd-K and `/` unchanged, and the
`!libraryOpen` guard stays exactly what it was, because the Select is
still open by exception.

`Escape` goes in two beats: while the popup is open Base UI closes it
and the key never reaches the rail, so the press that dismisses a list
cannot also throw away what the list was filtering. Closed and filtered,
the same key clears.

The field is reached through the row that holds it rather than by a ref:
it is the registry's component, rendered a couple of wrappers down, and
a ref handed that far arrives empty.

### Search

Still every typed word, not the whole phrase. Free text is the only way
to reach the 139 single-example tags, the authors and the descriptions,
none of which are pickable. The dropdown keeps the component's own
filter -- of 68 options exactly one is two words, which is not enough to
justify writing one.

### Checked by hand

`tsc --noEmit`, `pnpm check`, `next build` -> 171 static pages.

In the browser: picking, clearing, both counts, the intersection going
empty and the `Empty` block that catches it, a `?library=Drei` link from
before this change, `?library=Leva,Lamina` after it, the typed query
surviving the popup closing, and the roving tabindex over the picked
row. Card links carry the filter and not the card's own tags. Mobile at
375px.

Two things this browser could not drive: injected key events arrive with
an empty `key`, so the hotkey layer was exercised by dispatching events
with one -- it wants a real keyboard once -- and the popup inside the
mobile sheet.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


Closes #206. The clickable tag badges are #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
