### PR TITLE
Describe eight examples chosen to break the contract

### DIFF
--- a/.claude/skills/describe-example/SKILL.md
+++ b/.claude/skills/describe-example/SKILL.md
@@ -93,3 +93,11 @@ Identifiers are data, not prose. Keeping them out of `description` is what makes
 The long-form explainer, in the example's own `README.md`, plus its glossary in `CONTEXT.md`. It does not read the source and write: it runs `teach` in sub-agents first, and only its distillation comes back. The orchestration, the mission it has to supply, and the writing contract are in [explain.md](./explain.md).
 
 Both modes live in one skill because both enforce contracts that must not drift apart — the one-liner is the compression of the same understanding the explainer spends 400 words on, and writing them from two separate readings is how they end up describing two different demos.
+
+## When this file goes away
+
+This skill is scaffolding for a finite job: every example in the gallery carrying a `description`, an `apis` list and a `README.md` explainer. **When that is done, delete it** — along with `bin/eval.mjs` and the measurement records under `bin/eval/`, keeping only `questions.json`, whose twenty hand-written answers are the expensive part and the only part worth a second run.
+
+What survives is what runs on its own and fails loudly: `apis ⊆ imports`, the description bound and non-emptiness, and the backticked-identifiers check on `README.md` and `CONTEXT.md` — all in `lint:metadata`. The `description` and `apis` contracts above are stated again, in one paragraph each, on those two fields in `schemas/pmndrs.schema.json`, which is where the author of a *new* example meets them and which outlives this file.
+
+A skill nobody runs is a document that rots while claiming to be a tool. This one has a finish line; the note is here so that reaching it is not mistaken for a reason to keep it.

--- a/bin/description-exceptions.mjs
+++ b/bin/description-exceptions.mjs
@@ -41,13 +41,19 @@
 export const DESCRIPTION_MAX_LENGTH = 120;
 
 //
-// Examples that ship `"description": ""`. Thirty-nine of the hundred and
+// Examples that ship `"description": ""`. Thirty-three of the hundred and
 // seventy; the rest run to a median of 56 characters.
 //
 // Nothing groups them. They are not the old examples, or the small ones, or
 // the ones nobody looks at -- `caustics` and `portals` are here, and
 // `aquarium` was until it became the first entry this list lost. The field was
 // simply never required to hold anything, so for these it never got anything.
+//
+// It started at forty. `aquarium` left it first, then the six the pilot of
+// #198 drew from it -- `ecctrl-fisheye`, `glass-flower`,
+// `pass-through-portals`, `react-ellipsecurve`,
+// `ssgi-spheres-with-rapier-physics` and `water-shader`, chosen for what they
+// would break rather than for being easy to write.
 //
 export const UNDESCRIBED = [
   "bloom-hdr-workflow-gltf",
@@ -59,13 +65,11 @@ export const UNDESCRIBED = [
   "csg-operations-rapier-physics",
   "dbismut-furniture",
   "diamond-ring",
-  "ecctrl-fisheye",
   "enter-portals",
   "environment-blur-and-transitions",
   "envmap-ground-projection",
   "faucets-select-highlight",
   "gatsby-stars",
-  "glass-flower",
   "ground-projected-envmaps-lamina",
   "html-input-fields",
   "inter-epoxy-resin",
@@ -77,35 +81,31 @@ export const UNDESCRIBED = [
   "motionpathcontrols",
   "nextjs-prism",
   "pairing-threejs-to-ui",
-  "pass-through-portals",
   "pmndrs-vercel",
   "portal-shapes",
   "portals",
   "rapier-physics",
-  "react-ellipsecurve",
   "shopping",
-  "ssgi-spheres-with-rapier-physics",
   "stage-presets-gltfjsx",
   "starwars",
   "t-shirt-configurator",
-  "water-shader",
 ];
 
 //
-// Examples whose description is written, and too long. Five, with the length
+// Examples whose description is written, and too long. Four, with the length
 // recorded so the entry can be checked rather than believed -- the test reads
 // the file and fails on a number that has drifted.
 //
 // None of them is a truncation away from fitting. Each spends its overflow
-// listing the stack in prose -- `bubbles` names five postprocessing effects,
-// `pixelation` and `vignette` each spell out a package -- which is the
-// identifiers-in-`description` habit that the `apis` field now exists to
-// absorb. Cutting the sentence at 120 would leave the same bad line, shorter.
-// So they are rewrites, they are `describe-example` work, and this change has
-// to land before any description is written.
+// listing the stack in prose -- `pixelation` and `vignette` each spell out a
+// package, and `bubbles` named five postprocessing effects until the pilot of
+// #198 rewrote it -- which is the identifiers-in-`description` habit that the
+// `apis` field now exists to absorb. Cutting the sentence at 120 would leave
+// the same bad line, shorter. So they are rewrites, they are
+// `describe-example` work, and this change has to land before any description
+// is written.
 //
 export const OVERLONG = {
-  bubbles: 147,
   pixelation: 127,
   "take-control": 133,
   vignette: 122,

--- a/bin/eval.mjs
+++ b/bin/eval.mjs
@@ -34,6 +34,13 @@
  * `vercel env pull` writes into the gitignored `.env.local`. That token lasts
  * twelve hours, so a 401 here usually means pulling it again rather than
  * anything being wrong.
+ *
+ * **Delete this file when the rewrite is done** -- when every example carries a
+ * description, an `apis` list and an explainer. It is scaffolding: it never runs
+ * in CI, it costs a key and twenty minutes, and its whole purpose is to say
+ * whether a finite piece of work was worth doing. Keep `bin/eval/questions.json`
+ * and drop the rest, including the recorded runs: the twenty hand-written
+ * answers are what cost something to produce and what a future run would need.
  */
 
 import fs from "node:fs";

--- a/bin/eval/baseline.md
+++ b/bin/eval/baseline.md
@@ -66,3 +66,11 @@ default because it is what the gateway's free tier serves — the hosted Anthrop
 and OpenAI models need credits on the workspace. With credits, pass
 `--model anthropic/claude-opus-5` and take a fresh baseline before comparing
 against it; do not read a run on one model against a number from another.
+
+## This file is temporary
+
+It records one run of a harness that is itself scaffolding. When every example
+carries a description, an `apis` list and an explainer, `bin/eval.mjs` and these
+records go, and `questions.json` stays. The numbers will have done their work by
+then: they exist to decide whether the rewrite is worth continuing, not to be
+kept as a score.

--- a/bin/eval/pilot-eight.md
+++ b/bin/eval/pilot-eight.md
@@ -76,3 +76,6 @@ Expect ±1, and expect it to take fifteen to twenty minutes: the gateway's free
 tier answers a handful of questions and then rate-limits, and each 429 costs a
 60-second backoff. A workspace with credits never waits. The score is only
 comparable within one model — see the last section of `baseline.md`.
+
+This file is temporary, on the same terms as `baseline.md`: it goes when
+`bin/eval.mjs` goes, and the decision it argues for outlives it in #198.

--- a/bin/eval/pilot-eight.md
+++ b/bin/eval/pilot-eight.md
@@ -1,0 +1,78 @@
+# Pilot — 19/20 (95%)
+
+The "after" number, measured on eight examples described under the contract
+(#198). The baseline it is read against is [baseline.md](./baseline.md), 15/20.
+
+| What      | Value                                                           |
+| --------- | --------------------------------------------------------------- |
+| Score     | **19/20 (95%)**, baseline **15/20 (75%)**                       |
+| Date      | 2026-08-14                                                      |
+| Model     | `openai/gpt-oss-120b`, via the Vercel AI Gateway, temperature 0 |
+| Index     | 167 examples, 19,370 bytes, generated from `pilot-eight`        |
+| Questions | `bin/eval/questions.json`, the same 20                          |
+| Command   | `node bin/build-llms.mjs && node bin/eval.mjs`                  |
+
+## The comparison is not all else equal
+
+`baseline.md` says it was taken "while every description in the gallery is
+still the one it shipped with", and that is no longer true of `aquarium`: it was
+written before this pilot, as the case the skill and the explainer were built
+on. One of the baseline's five misses is its question. So the four questions
+that flipped do not all belong to these eight lines:
+
+| Asked for                                | Baseline                    | Now                    | Whose         |
+| ---------------------------------------- | --------------------------- | ---------------------- | ------------- |
+| a glass tank you can see objects inside  | `transparent-aesop-bottles` | `aquarium`             | not the pilot |
+| a camera travelling through a doorway    | `camera-scroll`             | `pass-through-portals` | the pilot     |
+| a third-person character controller      | _no example named_          | `ecctrl-fisheye`       | the pilot     |
+| click a part, outline it, frame it       | `react-pp-outlines`         | `react-pp-outlines`    | still missed  |
+| a glass ornament, bloomed and LUT-graded | `color-grading`             | `glass-flower`         | the pilot     |
+
+**+1 to `aquarium`, +3 to the pilot.** And the `aquarium` point is the softest
+of the four: `baseline.md` records an aborted earlier pass that answered that
+question correctly on the _old_ index, so some of it is noise. The pilot's three
+are not — the baseline puts the run-to-run swing at ±1, and three is past it.
+
+The fifteen controls all held. Nothing that worked before stopped working.
+
+## The miss that stayed a miss is the result
+
+`faucets-select-highlight` was left out of the eight on purpose, while the four
+other misses were taken. It is still empty, and the model still answers
+`react-pp-outlines` — a described near neighbour — exactly as it did before.
+
+That is what separates "the index got better" from "the eval got easier". Had
+the sample covered all five misses, 20/20 would have proved nothing except that
+the questions were answerable by the examples chosen from their answers.
+
+## Two runs, because one line went back
+
+The first run scored 19/20 with `transparent-aesop-bottles` rewritten. The line
+was then reverted to its author's, and the second run — the one recorded above,
+and the one matching the commit — scored 19/20 again.
+
+The only difference: "how do I do refractive glass?" answers
+`transparent-aesop-bottles` on the author's line and `diamond-refraction` on the
+rewrite. Both are in `expected`, so it is a hit either way. The rewrite moved no
+question, which is the answer to the slot that asked for it.
+
+## What is not measured
+
+Five of the eight lines are touched by no question: `water-shader`,
+`react-ellipsecurve`, `ssgi-spheres-with-rapier-physics`, `bubbles` and
+`transparent-aesop-bottles`. Twenty questions cannot cover 170 examples, and
+adding questions aimed at the examples just described would measure nothing.
+The eval says the empty lines were the problem; it does not, and cannot, say
+these five lines are good.
+
+## Rerunning it
+
+```sh
+node bin/build-llms.mjs   # llms.txt is generated, and gitignored
+node bin/eval.mjs
+```
+
+Expect ±1, and expect it to take fifteen to twenty minutes: the gateway's free
+tier answers a handful of questions and then rate-limits, and each 429 costs a
+60-second backoff. A workspace with credits never waits. The score is only
+comparable within one model — see the last section of `baseline.md`.

--- a/examples/bubbles/pmndrs.json
+++ b/examples/bubbles/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Bubbles",
-  "description": "A metallic, mouse-reactive distorted sphere with floating instances, composited with Depth of Field, Bloom, BrightnessContrast, Noise and Vignette.",
+  "description": "A single distorting material built outside the tree and handed to every sphere, lit by a cube-map environment.",
   "tags": ["postprocessing", "bloom", "depth-of-field", "distortion"],
+  "apis": ["MeshDistortMaterial", "useCubeTexture", "DepthOfField"],
   "authors": ["Paul Henschel"],
   "source": "https://codesandbox.io/s/react-postprocessing-dof-blob-pqrpl",
   "libraries": [

--- a/examples/ecctrl-fisheye/pmndrs.json
+++ b/examples/ecctrl-fisheye/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Ecctrl Fisheye",
-  "description": "",
+  "description": "A third-person character controller on a physics body, keyboard-mapped and pointer-locked, seen through a fisheye lens.",
   "tags": [],
+  "apis": ["Fisheye", "KeyboardControls", "Gltf"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2023-10-10",
   "source": "https://codesandbox.io/s/nvk9pf",

--- a/examples/glass-flower/pmndrs.json
+++ b/examples/glass-flower/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Glass Flower",
-  "description": "",
+  "description": "Iridescent glass bloomed and graded through a cube LUT, with tone mapping left to the composer, not the renderer.",
   "tags": ["transmission"],
+  "apis": ["MeshTransmissionMaterial", "LUT", "LUTCubeLoader"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2023-04-13",
   "source": "https://codesandbox.io/s/dq6wwe",

--- a/examples/pass-through-portals/pmndrs.json
+++ b/examples/pass-through-portals/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Pass Through Portals",
-  "description": "",
+  "description": "A model that breaks out of the frame it is drawn in: a second copy outside, sliced away by local clipping planes.",
   "tags": ["portal"],
+  "apis": ["MeshPortalMaterial"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2023-06-17",
   "source": "https://codesandbox.io/s/qvk72r",

--- a/examples/react-ellipsecurve/pmndrs.json
+++ b/examples/react-ellipsecurve/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "React EllipseCurve",
-  "description": "",
+  "description": "An atom whose electrons drag tapered trails around thick world-space orbits, over-bright so bloom catches them.",
   "tags": ["trails"],
+  "apis": ["Trail", "Line", "Bloom"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2022-10-20",
   "source": "https://codesandbox.io/s/xzi6ps",

--- a/examples/ssgi-spheres-with-rapier-physics/pmndrs.json
+++ b/examples/ssgi-spheres-with-rapier-physics/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "SSGI Spheres With Rapier Physics",
-  "description": "",
+  "description": "Global illumination hand-wired into a raw effect composer, over spheres drawn together by impulses rather than gravity.",
   "tags": [],
+  "apis": ["SSGIEffect", "VelocityDepthNormalPass", "EffectPass"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2023-11-12",
   "source": "https://codesandbox.io/s/5w35n6",

--- a/examples/transparent-aesop-bottles/pmndrs.json
+++ b/examples/transparent-aesop-bottles/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Transparent Aesop Bottles",
-  "description": "PBR transmission and thickness to emulate glas.",
+  "description": "Six bottles sharing one physical transmission material, with render order pinned so the backdrop draws first.",
   "tags": ["reflections", "transmission"],
+  "apis": ["Environment"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2021-10-08",
   "source": "https://codesandbox.io/s/kv7tv",

--- a/examples/transparent-aesop-bottles/pmndrs.json
+++ b/examples/transparent-aesop-bottles/pmndrs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Transparent Aesop Bottles",
-  "description": "Six bottles sharing one physical transmission material, with render order pinned so the backdrop draws first.",
+  "description": "PBR transmission and thickness to emulate glass.",
   "tags": ["reflections", "transmission"],
   "apis": ["Environment"],
   "authors": ["Paul Henschel"],

--- a/examples/water-shader/pmndrs.json
+++ b/examples/water-shader/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Water Shader",
-  "description": "",
+  "description": "The three.js ocean add-on registered as a JSX element, with its time uniform advanced every frame.",
   "tags": ["shader", "water"],
+  "apis": ["Water", "extend"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2021-04-15",
   "source": "https://codesandbox.io/s/1b40u",

--- a/schemas/pmndrs.schema.json
+++ b/schemas/pmndrs.schema.json
@@ -23,6 +23,7 @@
       "minLength": 1
     },
     "description": {
+      "description": "One English sentence, at most 120 characters, naming the technique rather than the code. Prose only -- identifiers belong in `apis`. Say nothing the index line already says: it prints the directory name, the non-implied libraries, the tags and a size marker around this sentence, and fiber and drei are implied everywhere. A technique carried by a prop, a namespace import or a renamed default import cannot go in `apis`, and is said here instead. `bin/validate-pmndrs-metadata.mjs` enforces the bound and the non-emptiness; whether the sentence is true and well turned is a human's call.",
       "type": "string"
     },
     "tags": {
@@ -34,6 +35,7 @@
       "uniqueItems": true
     },
     "apis": {
+      "description": "The identifiers the technique is carried by -- typically two or three, ordered with the load-bearing one first. Imported identifiers only, and only ones this example's own `src/` imports, which `lint:metadata` checks. What every example imports (`Canvas`, `useFrame`, `OrbitControls`, `THREE`) discriminates nothing and stays out. An empty list is a finding, not a failure: some techniques live in a prop or a shader, and the description carries them alone.",
       "type": "array",
       "items": {
         "type": "string",


### PR DESCRIPTION
Closes #198. Last of the seven in #192's stack, and the only one that writes
prose rather than the machinery for it.

Eight examples described under the contract from #196, picked for what they
would break: a technique carried by a prop, one with no notable drei API, the
smallest source in the gallery, the largest, two that already had a line, and
two of the misses the baseline in #197 recorded. `apis` lands on all eight;
`UNDESCRIBED` goes 39 → 33 and `OVERLONG` 5 → 4, in the same commits.

**15/20 → 19/20**, of which +3 belong to these lines and +1 to `aquarium`, which
was written before the pilot. The provenance, the fifteen controls and the two
runs are in `bin/eval/pilot-eight.md` rather than in a delta quoted here.

`faucets-select-highlight` was left empty on purpose and is still missed, by the
same near neighbour as before. That is deliberate: a sample covering all five
baseline misses would have scored better and shown less.

Three things the sample broke, all of them findings rather than failures:

- `apis ⊆ imports` has two more ways to be unsatisfiable than the spec named — a
  namespace import (`new THREE.MeshPhysicalMaterial`) and a default import
  renamed at the call site (`import Controller from "ecctrl"`). Both are prose
  cases, like the prop case already was.
- "read the example whole" does not survive a vendored dependency:
  `ssgi-spheres-with-rapier-physics` is 515 kB, of which 506 kB is a checked-in
  build the example imports from.
- Rewriting a line that already passes buys nothing. `transparent-aesop-bottles`
  was rewritten and then **reverted to its author's sentence** — the rewrite
  traded `thickness: 500` for the render-order pinning, at three times the
  length, and moved no question. `bubbles` is the other half of that slot and
  stays rewritten: 147 characters is over the bound, which is not a matter of
  taste.

The decision this unblocks is in
[the issue](https://github.com/pmndrs/examples/issues/198#issuecomment-5294515275):
neither "fill the 40" nor "rewrite the 170", but the ~81 that fail a test
written down in advance — empty, over the bound, carrying an identifier or a
URL, or under 40 characters — leaving the 89 that pass untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQmbpRu6oCNrLiUQvhz5x6
