### PR TITLE
Write two explainers through the passes that had never run

### DIFF
--- a/.claude/skills/describe-example/explain.md
+++ b/.claude/skills/describe-example/explain.md
@@ -15,7 +15,15 @@ The one-line `description` is what the index can afford. It is not what a reader
 
 That is the whole design. A direct read produces a confident paragraph about a demo nobody understood, and there is no way to tell one of those from the real thing by reading it. So `--explain` runs `/mattpocock-skills:teach` in sub-agents first, and writes only from what they distil.
 
+The mechanism that makes this work is narrower than "a sub-agent reads more carefully", and worth naming because it is what would be lost if the orchestration were ever trimmed for cost: **the quiz**. A pass writes a lesson, then sits it, predicting before it checks. Both examples in the #214 pilot came back having been wrong on most of their predictions — nine of twelve in one case, and the corrections were load-bearing rather than cosmetic. Direct reading has no falsification step; nothing in it can be surprised.
+
+Which is also why **the orchestrator does not read the example's source before the passes.** Read it and the distillation arrives as confirmation of something already believed, the passes become expensive agreement, and the one check on the prose is gone. Read `pmndrs.json` and the title for the mission, and nothing else until the proposal.
+
 `teach` sets `disable-model-invocation`, so the Skill tool will not launch it — the sub-agent reads the skill file and follows it. The repo's `.claude/settings.json` enables `mattpocock-skills@mattpocock`, which puts it at `~/.claude/plugins/marketplaces/mattpocock/skills/productivity/teach/SKILL.md`. If the plugin layout has moved, find it: `find ~/.claude/plugins -path '*productivity/teach/SKILL.md'`.
+
+Name its four sibling format files to the sub-agent as well — `MISSION-FORMAT.md`, `RESOURCES-FORMAT.md`, `LEARNING-RECORD-FORMAT.md` and **`GLOSSARY-FORMAT.md`**. The last one matters here out of proportion to its size: the glossary is one of the two artifacts that leave the workspace, and `SKILL.md`'s own list of workspace files does not mention it, so a sub-agent told only to "follow the skill" can reasonably never open it.
+
+`teach` delegates to no other skill — its dependency graph is those five files and nothing else. But the sub-agent still has the full roster, and should use it as any session executing `teach` would; the pilot's passes reached for `pmndrs:docs` and reported it earned its place, by disagreeing with the installed source in one instance and with a plain fetch of the same page in another. Ask the pass to record in `NOTES.md` which skills it invoked and what each contributed, so the next one is deciding from evidence rather than from habit.
 
 ### 1. The workspace is ephemeral and outside the repo
 
@@ -62,7 +70,9 @@ Headless, the sub-agent is both teacher and learner: it writes the lesson and it
 
 Each pass ends by answering one question in its report: **is a load-bearing sub-topic still unclear enough to warrant another pass, and which one?** If yes, launch another sub-agent on the same workspace with that sub-topic as its focus — `teach` is stateful, so it reads the learning records the previous pass left and picks up from them.
 
-**Three passes total, then stop regardless.** Without a cap an obscure demo chains passes indefinitely, and the marginal pass stops paying long before the sub-agent runs out of things it would like to understand better. A sub-topic still unclear after the third pass is a caveat in the proposal, not a fourth pass.
+**"Load-bearing" is a criterion you apply, not an answer you record.** The pass proposes a candidate; whether it warrants a pass is judged here, against the writing contract below — a sub-topic is load-bearing only if the explainer would be wrong or thin without it. `teach` is built to compute a learner's zone of proximal development, so its candidate tends to be *what I would learn next*, which is a different question. Both pilot passes proposed one: extending a demo into something it is not, and a technique whose identifiers appear nowhere in that example's `src/` and which the backtick rule therefore bars the prose from naming. Neither could reach the deliverable. Both examples were finished, well, in one pass.
+
+**Three passes total, then stop regardless.** Without a cap an obscure demo chains passes indefinitely, and the marginal pass stops paying long before the sub-agent runs out of things it would like to understand better. A sub-topic still unclear after the third pass is a caveat in the proposal, not a fourth pass. One pass is the normal number, on the evidence so far; the cap is there for the demo that genuinely resists, not as a target.
 
 ### 4. Only the distillation comes back
 
@@ -78,6 +88,8 @@ Nothing else. Lessons, quizzes and learning records stay in the temp directory.
 **Structure is fixed, length is not** — the problem, the technique, the pitfalls. A fixed structure resists drift better than a word ceiling, and a demo that needs 200 words should not be padded to 400 nor one that needs 600 be truncated.
 
 **It names the technique and its APIs; it never walks the code.** No line numbers, no local variable names, no "the file X does Y". Same principle as the one-liner: what cannot be checked mechanically is at least made hard to write wrong.
+
+**Where a demo is defined by what it does _not_ do, say so unmistakably.** Some techniques are recognised by the reader as a pattern they already know, and are then read as that pattern — `gpgpu-curl-noise-dof` has no ping-pong, holds no state, and its directory name announces the opposite. A paragraph describing a mechanism the demo lacks is worse than no paragraph if it can be mistaken for a description of it, so the absence goes in the prose as an absence, not as an omission.
 
 **Every identifier the prose puts in backticks must appear somewhere in the example's `src/`.** This is looser than the check on `apis`, deliberately — `apis` is a list of library APIs, so an entry that is not _imported_ has no business there, whereas prose may legitimately name the demo's own components (`Aquarium`, `Turtle`) and its props (`stencil` in `gl={{ stencil: true }}`).
 

--- a/examples/gpgpu-curl-noise-dof/CONTEXT.md
+++ b/examples/gpgpu-curl-noise-dof/CONTEXT.md
@@ -1,0 +1,15 @@
+# GPGPU Curl Noise DOF
+
+Vocabulary local to this demo. The technique itself is in the README.
+
+## Glossary
+
+**Position field** — what this demo computes: a closed-form function from seed and time to position, evaluated fresh every frame. Read it in opposition to a particle simulation, which integrates state forward and therefore needs two buffers. The distinction decides what can be added to this demo and what cannot.
+
+**Ping-pong** — the two-target swap that gives a GPGPU simulation memory. Named here because it is the thing this demo does **not** do, and because everything the folder name leads a reader to expect is on the other side of it.
+
+**Texel address attribute** — a vertex attribute holding, instead of a position, the coordinate at which that vertex should look its position up. The indirection that lets geometry stay constant while positions change every frame.
+
+**Seed shell** — the sphere _surface_ the starting points occupy, all at one radius and none inside. Not a seed sphere: it has no interior, and that is why the output reads as a sheet.
+
+**Visible fraction** — the share of the cloud actually rasterised, gated per particle in the vertex shader. Exposed as `fov`, which it is not.

--- a/examples/gpgpu-curl-noise-dof/README.md
+++ b/examples/gpgpu-curl-noise-dof/README.md
@@ -7,3 +7,31 @@ $ npx degit pmndrs/examples/examples/gpgpu-curl-noise-dof
 ```
 
 ![](thumbnail.webp)
+
+## The problem
+
+Animating a quarter of a million particles means producing a quarter of a million positions per frame. Computing them on the CPU and uploading the result puts the whole effect behind the bus rather than behind the arithmetic, and the arithmetic is the part a GPU is good at. What is missing is somewhere for the GPU to put an array.
+
+## The technique
+
+A texture is that array, and a fragment shader is the loop that fills it.
+
+A quad covering clip space is `createPortal`ed into a scene of its own, detached from the one on screen, and rendered once per frame into the float target `useFBO` allocates. Rasterising that quad runs the fragment shader exactly once per texel, and each invocation writes one particle's position where a colour would normally go. `extend` is what lets both of those shader materials be written as JSX.
+
+The point cloud that draws the result carries no positions in its `position` attribute at all — one texel address per particle, and nothing more. Its vertex shader fetches the real position from the texture. The geometry never changes; the texture does.
+
+What the shader computes deserves naming precisely, because the name of the folder suggests otherwise: **there is no ping-pong here.** There is one target, no feedback, and the sphere of seed points is re-read every frame and never overwritten. Position is a closed-form function of seed and time, so the demo is a position _field_, not a particle simulation — nothing accumulates and nothing is remembered between frames. That is what buys the simplicity, and it is what has to be given up first.
+
+The depth of field is not a post pass either. `gl_PointSize` grows with a particle's distance from the focal plane while its opacity falls, so the circle of confusion is literally the sprite; the fragment stage then discards everything outside a unit disc to round the square off. Blurred and sharp particles cost exactly the same.
+
+## The pitfalls
+
+**`fov` is not a field of view.** It gates visibility — a particle draws only if its column fraction clears a threshold derived from it — so raising it thins the cloud. It saves rasterisation only; every particle is still simulated.
+
+**The curl noise is not divergence-free.** The curl is normalised to unit length before use, which is a non-linear rescale and destroys exactly the incompressibility that curl noise is cited for. It is a look, arrived at by ear, and transplanting it in the expectation of fluid-like flow will not produce fluid-like flow.
+
+**The cloud is a surface, not a volume.** Every seed sits at one radius, so the seed set is a two-dimensional shell and everything downstream is a warped sheet. Vary the radius to fill it.
+
+**Blur is resolution-dependent.** Sprite size is in framebuffer pixels and is never scaled by device pixel ratio, so the effect is half as strong on a 2× display; drivers also clamp point size, so extreme settings quietly stop growing.
+
+**Wanting state means restructuring.** Collisions, ageing, emission, a mouse that pushes — each needs the previous frame, which means a second target and a swap, and that change reaches everything downstream of it.

--- a/examples/gpgpu-curl-noise-dof/pmndrs.json
+++ b/examples/gpgpu-curl-noise-dof/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "GPGPU Curl Noise DOF",
-  "description": "Curl noise and depth of field.",
+  "description": "Particle positions recomputed into a float texture each frame, with sprite size standing in for depth of field.",
   "tags": ["gpu", "shader", "curl", "dof"],
+  "apis": ["useFBO", "createPortal", "extend"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2021-09-05",
   "source": "https://codesandbox.io/s/zgsyn",

--- a/examples/inverted-stencil-buffer/CONTEXT.md
+++ b/examples/inverted-stencil-buffer/CONTEXT.md
@@ -1,0 +1,15 @@
+# Inverted Stencil Buffer
+
+Vocabulary local to this demo. The technique itself is in the README.
+
+## Glossary
+
+**Mask** — always a stencil region here, never an alpha texture. The word covers two objects that behave differently: the mesh that stamps, and the material that reads. Naming them apart is worth the effort, because everything surprising about the technique comes from confusing them.
+
+**Writer** — the stamping mesh, `Mask` in drei. Invisible by construction, and occluding nothing; it is in the scene only for the pixels it covers.
+
+**Consumer** — a material that has been given `useMask`'s properties. It never touches the buffer, only reads it, which is why any number of consumers can share one id without interfering.
+
+**Invert** — a property of the consumer. drei's own documentation describes it as inverting _the mask_, which is misleading: the mask is identical either way, and two consumers of one id can invert independently of each other.
+
+**Compound mask** — several writers sharing an id. Their silhouettes union, and every consumer of that id sees the union revealed or hidden as one region. This demo uses two.

--- a/examples/inverted-stencil-buffer/README.md
+++ b/examples/inverted-stencil-buffer/README.md
@@ -7,3 +7,31 @@ $ npx degit pmndrs/examples/examples/inverted-stencil-buffer
 ```
 
 ![](thumbnail.webp)
+
+## The problem
+
+You want an object to appear only inside a shape you can move around the screen — a window — or everywhere except inside it — a hole. The routes that suggest themselves cost a second render of the scene: a portal, a render texture, a camera with clipping planes. And because the two results look like opposites, it is natural to expect two different arrangements to produce them.
+
+## The technique
+
+They are one arrangement, differing by a single comparison.
+
+`Mask` draws an ordinary mesh with its colour and depth writes turned off. It contributes no pixels and occludes nothing; all it leaves behind is an integer stamped into the stencil buffer over every pixel its silhouette covers. That buffer holds no picture — one small label per pixel, and nothing else.
+
+`useMask` supplies the other half: material properties that switch the stencil test on and keep a fragment only where the buffer holds that same integer. Its second argument flips the comparison from equal to not-equal, and that flip is the whole inversion — the same stamp, read the other way round. Nothing about the mask changes, which is why `invert` belongs to the material being masked and not to the mask: two materials sharing one id may disagree, one revealing where the other hides.
+
+Both `CircularMask`s here carry the same id, so their silhouettes union into a single region and one object is windowed by two masks at once. Putting them under `PivotControls` makes the point the technique rests on visible: drag one and the cut follows it across the screen, because a mask is a screen-space label rather than a shape in the scene. Its own position and depth matter only insofar as they change which pixels it covers.
+
+The `Frame` ring takes no part in any of this. It is an ordinary mesh parked where the invisible mask sits — which is how a stencil mask gets a visible rim.
+
+## The pitfalls
+
+**`gl={{ stencil: true }}` on the `Canvas` is load-bearing, and it is not the default.** three stopped asking for a stencil attachment in r163. Without it there is no buffer to stamp, and every mask silently does nothing — no warning, no error, an unmasked scene.
+
+**Anything that renders the scene into a render target drops the mask.** Render targets are created without a stencil buffer unless asked, so postprocessing, render textures and cube cameras all lose it.
+
+**Ids do not compose.** The stamp is unconditional and it overwrites. Two masks with different ids that overlap on screen do not layer — the region belongs to whichever drew last. Sharing one id gives a union, and that union is the only combination available; anything finer needs stencil parameters drei does not expose.
+
+**The mask reaches materials, not objects.** There is no inherited or group-level mask: masking a loaded model means walking it and assigning the properties to every material it contains.
+
+**Invisible is not absent.** The shadow pass copies no stencil state, so an object with a hole punched in it still casts a whole shadow. Raycasting and pointer events are equally blind to the cut.

--- a/examples/inverted-stencil-buffer/pmndrs.json
+++ b/examples/inverted-stencil-buffer/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Inverted Stencil Buffer",
-  "description": "How to invert a masked stencil.",
+  "description": "One mask, two readings: the inversion is a comparison on the masked material, not a property of the mask.",
   "tags": ["stencil", "portal"],
+  "apis": ["useMask", "Mask"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2022-05-20",
   "source": "https://codesandbox.io/s/7n2yru",


### PR DESCRIPTION
Closes #214. Part of #192, on top of #213.

`--explain` has always specified that it does not read the source and write: it
runs `teach` in sub-agents first, and writes only from what they distil. Nothing
had ever gone through it. `aquarium`'s explainer was written by direct reading
and kept on purpose — so the orchestration was untested at the point where it
was about to be used 170 times.

## The two examples

Chosen to be awkward rather than photogenic, one on each side of #214's split:

- **`inverted-stencil-buffer`** — the technique is already understood, and it is
  a direct sibling of `aquarium`'s stencil mask, so the output can be read
  against a hand-written explainer on the _same_ technique. This is the control.
- **`gpgpu-curl-noise-dof`** — genuinely opaque: an off-screen float target, two
  hand-written shader materials, and a noise implementation nobody reads twice.

Both cleared in **one pass**. The cap of three never engaged.

## What the passes returned that a direct reading would have gotten wrong

- **there is no ping-pong in `gpgpu-curl-noise-dof`.** One target, no feedback,
  the seed re-read and never overwritten. It is a position field, not a particle
  simulation — and the directory name says the opposite. This is the single most
  likely sentence in a directly-read explainer, and it would have been false.
- its curl noise is **normalised to unit length**, which destroys the
  divergence-free property curl noise is cited for.
- its `fov` is **not a field of view**; it gates visibility and saves no
  simulation cost.
- `Mask`'s three stencil ops are all Replace, so the stamp is unconditional and
  ids **overwrite rather than layer**.
- **inversion belongs to the masked material, not to the mask.** drei's own
  documentation describes it the other way round.

The last two come from the _control_ — the example where direct reading was
expected to be sufficient, because that is the bet `aquarium` made.

## The decision

The remaining 168 go **through the orchestration**. The reasoning, the cost and
the three reservations are in the comment on #214. The second commit here
carries the four corrections the runs found, so `explain.md` describes what
actually happens rather than what was imagined.

## Notes

- Each example's `description` and `apis` are written from the same distillation
  as its explainer, per the one-reading rule. Neither was in `UNDESCRIBED`, so
  both lines are rewrites of weak ones and the list stays at 33.
- `lint:metadata` covers the two new `CONTEXT.md` files. A planted identifier
  fails it — the guard was confirmed rather than assumed.
- `explain.md` line 12 still says an explainer is "not a programme across 170",
  which #192's plan now contradicts. Left alone deliberately: that is the scale
  question, and it belongs to its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQmbpRu6oCNrLiUQvhz5x6
