### PR TITLE
The explainer rollout

### DIFF
--- a/bin/description-exceptions.mjs
+++ b/bin/description-exceptions.mjs
@@ -41,25 +41,27 @@
 export const DESCRIPTION_MAX_LENGTH = 120;
 
 //
-// Examples that ship `"description": ""`. Thirty-three of the hundred and
+// Examples that ship `"description": ""`. Thirty-one of the hundred and
 // seventy; the rest run to a median of 56 characters.
 //
 // Nothing groups them. They are not the old examples, or the small ones, or
-// the ones nobody looks at -- `caustics` and `portals` are here, and
-// `aquarium` was until it became the first entry this list lost. The field was
-// simply never required to hold anything, so for these it never got anything.
+// the ones nobody looks at -- `caustics` and `portals` sat here until the
+// rollout reached them, and `aquarium` until it became the first entry this
+// list lost. The field was simply never required to hold anything, so for
+// these it never got anything.
 //
 // It started at forty. `aquarium` left it first, then the six the pilot of
 // #198 drew from it -- `ecctrl-fisheye`, `glass-flower`,
 // `pass-through-portals`, `react-ellipsecurve`,
 // `ssgi-spheres-with-rapier-physics` and `water-shader`, chosen for what they
-// would break rather than for being easy to write.
+// would break rather than for being easy to write. `caustics` and `portals`
+// are the first two of the rollout proper (#216); from here the list only
+// shrinks, an example at a time, until it is empty and this file goes with it.
 //
 export const UNDESCRIBED = [
   "bloom-hdr-workflow-gltf",
   "cards",
   "cards-with-border-radius",
-  "caustics",
   "csg-bunny-usegroups",
   "csg-house",
   "csg-operations-rapier-physics",
@@ -83,7 +85,6 @@ export const UNDESCRIBED = [
   "pairing-threejs-to-ui",
   "pmndrs-vercel",
   "portal-shapes",
-  "portals",
   "rapier-physics",
   "shopping",
   "stage-presets-gltfjsx",

--- a/examples/caustics/CONTEXT.md
+++ b/examples/caustics/CONTEXT.md
@@ -1,0 +1,19 @@
+# Caustics
+
+Vocabulary local to this demo. The technique itself is in the README.
+
+## Glossary
+
+**Caustic map** — the single-channel image, rendered from the light's point of view, holding the photon density each light-space texel deposits. It is the intermediate product of the whole technique, and it is what the word "caustics" names here: not the effect on screen, but this buffer.
+
+**Catcher plane** — the auto-sized horizontal quad the map is projected onto, at the origin of the `Caustics` group's _own_ space. Not "the floor": the demo's floor is a different mesh, and tilting the group tilts the catcher with it while the floor stays put.
+
+**Differential quad** — the four neighbouring taps, a fixed world distance apart, whose refracted rays are traced together so their before-and-after areas can be compared. Its edge length is `worldRadius`, which is why that prop is a step size and not a blur radius.
+
+**Bake** — one full run of the passes, producing a map that later frames reuse unchanged. `frames` counts bakes, not frames of animation, and the counter resets on every React render.
+
+**Local-space bake** — the light direction, the light camera and the catcher plane are all computed in the group's own coordinates, with any world transform above it ignored. Moving the rig afterwards carries the caustic along and costs nothing.
+
+**Backside** — needs a subject in this demo, because both components have a prop of that name and they are unrelated: the `Caustics` one doubles the bake to cover far surfaces, the `MeshTransmissionMaterial` one doubles the transmission renders. Never say it bare.
+
+**`ior` here is not a refractive index.** It sets the refraction strength of the bake, and values below 1 — this demo uses one — spread rays instead of converging them. Real glass would be around 1.5.

--- a/examples/caustics/README.md
+++ b/examples/caustics/README.md
@@ -7,3 +7,33 @@ $ npx degit pmndrs/examples/examples/caustics
 ```
 
 ![](thumbnail.webp)
+
+## The problem
+
+A glass object lit from above should not cast a flat grey shadow. It should throw a pattern — bright filaments where the curved surface has concentrated light, and darkness around them where that light came from. Getting there by simulation means tracing photons, which no real-time renderer does, and faking it with a texture means the pattern stops belonging to the object the moment either one moves.
+
+## The technique
+
+The bright part is measured rather than simulated, and it is measured once.
+
+`Caustics` fits an orthographic camera to its children's bounds along the light direction and re-renders them into an off-screen buffer with their normals as colour. A single full-screen pass then walks that buffer: for every texel it takes four taps a fixed distance apart _in world space_, refracts each through the normal it sampled, intersects the four refracted rays with the ground plane, and writes the ratio of the entry area to the exit area. Where refraction squeezes four rays together the ratio explodes and a bright filament appears. That ratio is a photon-density estimate — no rays are marched and nothing bounces.
+
+The resulting map is projected onto a horizontal quad, auto-sized and auto-placed beneath the object, through the light camera's matrices. It is shadow mapping's projection with the sign flipped: the same trick, used to paint light in rather than take it out.
+
+`worldRadius` and `intensity` are the two dials that matter, and they pull against each other. `worldRadius` is the step of a finite difference: shrink it and neighbouring rays diverge harder relative to their spacing, so the pattern breaks into thinner, brighter threads. `intensity` then scales the whole thing back into range. This demo runs the step twelve times finer than the default and pays for it with a gain sixteen times lower.
+
+`MeshTransmissionMaterial` supplies the glass, and the coupling between the two is free. That material renders the whole scene into its own buffer and refracts it — and because that buffer is a real render of the real scene, it contains the catcher plane. The glass shows the caustic through itself with nothing wiring them together.
+
+## The pitfalls
+
+**`lightSource` is a direction, not a position.** Whatever you pass is normalised, so its length is discarded and moving the light closer changes nothing. drei's documentation calls it a camera position.
+
+**It adds light and can never remove it.** The projection blends additively. The dark ring a real caustic sits in has to come from somewhere else — here, from `AccumulativeShadows`. Without it the effect reads as a glow rather than as focused light.
+
+**The cost is memory, not frame time.** At the default `resolution` the buffers come to roughly a quarter of a gigabyte, held for the component's lifetime, for a texture written once. Two of them exist only for `backside` and are allocated whether or not it is on.
+
+**`resolution` does not buy detail.** The tap spacing reduces algebraically to `worldRadius` in world units, independent of the buffer size. Raising `resolution` costs memory and changes nothing you can see; `worldRadius` is the knob.
+
+**One receiver, and it is a plane.** The catcher is a horizontal quad in the group's own space. Caustics cannot land on a wall, on a curve, or on another object — tilt the group and the plane tilts with it.
+
+**`frames` counts bakes, not frames.** At its default the map is baked once per React render, so an unrelated re-render silently re-bakes. An animated object or a moving light needs it unbounded, which turns a one-off cost into a per-frame one.

--- a/examples/caustics/pmndrs.json
+++ b/examples/caustics/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Caustics",
-  "description": "",
+  "description": "Refraction baked from the light’s point of view into a photon-density map, projected additively onto a ground plane.",
   "tags": ["transmission"],
+  "apis": ["Caustics", "MeshTransmissionMaterial", "AccumulativeShadows"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2023-01-09",
   "source": "https://codesandbox.io/s/szj6p7",

--- a/examples/portals/CONTEXT.md
+++ b/examples/portals/CONTEXT.md
@@ -1,0 +1,19 @@
+# Portals
+
+Vocabulary local to this demo. The technique itself is in the README.
+
+## Glossary
+
+**Portal** — used in drei's sense throughout: a mesh whose material shows a separate scene through it, rendered from the same camera as its surroundings. React's and fiber's helpers of the same name are the plumbing underneath, and are never called portals here.
+
+**Frame** — the mesh the material is applied to. It contributes a silhouette and a depth and never a colour, so it is closer to a stencil than to a surface. Calling it "the plane" or "the screen" is what leads people to expect an image on it.
+
+**Portal scene** — the scene formed by a portal's children, with its own environment, background and lights. Its **outer scene** is whatever scene the frame itself sits in — for a nested portal that is the enclosing portal scene, not the canvas root.
+
+**Stencil sampling** — looking the render up by the fragment's screen position rather than by the frame's texture coordinate. This is the whole technique in three words, and the reason parallax needs no correction.
+
+**Television** — the failure mode stencil sampling avoids: a scene rendered to a texture and mapped on by UV, so the image skews with the surface as the camera moves. Render-to-texture is the machinery both share; the television is the mistake.
+
+**Full-canvas render** — the unit of a portal's per-frame cost. One whole scene drawn at canvas size times device pixel ratio, no matter how small the frame appears. **Frustum gating** is the one thing that removes it, and it cascades down nesting.
+
+**`resolution` here always means the distance-field buffer's side length.** The portal scene's render size is never called resolution, because nothing can set it.

--- a/examples/portals/README.md
+++ b/examples/portals/README.md
@@ -7,3 +7,31 @@ $ npx degit pmndrs/examples/examples/portals
 ```
 
 ![](thumbnail.webp)
+
+## The problem
+
+A second world seen through a hole in the air is not a screen showing a video of that world. A screen skews: render a scene to a texture, map it onto a surface by its texture coordinates, and the image slides with the surface as the camera moves, because it is painted _on_ the surface. A hole does the opposite — what you see through it shifts against the frame exactly as a real opening would. Faking that shift is a parallax correction, and it is the part that never quite convinces.
+
+## The technique
+
+Nothing is faked, because the image was never mapped onto the frame.
+
+`MeshPortalMaterial` turns its children into a separate scene and renders them with the _outer_ camera, into a buffer the size of the whole canvas rather than the size of the mesh. The frame's shader then looks that buffer up by the fragment's position **on screen**. The mesh contributes a silhouette and a depth, never a colour: it is a per-pixel decision about which of two full-canvas renders wins. Parallax is correct because the second world was drawn from the same viewpoint as the first, and was never projected onto anything.
+
+Once that is the mechanism, the rest of the demo is what the mechanism makes cheap. A portal's children are an ordinary scene, so they can contain lights, a model, an `Environment` of their own — and another portal. Nesting costs one more full-canvas render per level and nothing conceptually.
+
+`worldUnits` decides which space the contents are expressed in. Left off, they are relative to the frame and travel with it; switched on, they are absolute and the frame slides across them like a window over a landscape. `PivotControls` is what makes that legible: the toggle is invisible until the frame moves.
+
+`blur` softens the silhouette by fading alpha near it, read from a distance field flood-filled once at mount. It is a fraction of the frame's inner radius rather than a width, so it survives scaling the frame.
+
+## The pitfalls
+
+**`resolution` does not size the portal.** It sizes the distance-field buffer alone. The scene render is always the canvas times the device pixel ratio, and the uniform of that name is overwritten with the canvas dimensions regardless of what is passed. There is no way to render a portal small — which is the whole cost story below.
+
+**Every visible portal is another full-canvas render of a whole scene, every frame,** however small the frame looks on screen. The two nested here mean three. Frustum culling switches an unseen one off, and it cascades: culling an outer frame silences everything nested inside it.
+
+**A sky is geometry, not a setting.** `Sky` sits in the outer scene, and a portal's contents are a different scene, so the outer sky is invisible through the frame. Each world needs its own.
+
+**`blur` needs `transparent`,** or the alpha ramp is discarded and the rim stays hard. And the fade is only correct on flat, front-facing frames: the field is baked from a flat projection but read through the mesh's own coordinates, whatever the documentation says about arbitrary geometry.
+
+**Nothing can lean out of the frame.** The frame is a flat mask writing its own depth; the inner world cannot cross it. Something reaching through is a different technique — a duplicate outside, sliced with clipping planes.

--- a/examples/portals/pmndrs.json
+++ b/examples/portals/pmndrs.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../../schemas/pmndrs.schema.json",
   "title": "Portals",
-  "description": "",
+  "description": "The frame masks rather than displays — each world is sampled by screen position, so parallax is real and they nest.",
   "tags": [],
+  "apis": ["MeshPortalMaterial", "Environment"],
   "authors": ["Paul Henschel"],
   "publishedAt": "2023-06-05",
   "source": "https://codesandbox.io/s/ik11ln",


### PR DESCRIPTION
The rollout of #216: the remaining explainers, one commit per batch, on top of the #214
pilot (#215).

**This PR is a container, not a review surface.** Review happens per example, in session,
on the pass's non-obvious findings, before anything is written — #216 Decision 5. The
reviewable unit here is the **commit**, whose message carries the corrections that example
returned; `git log` on this branch is the campaign's journal. One PR rather than seventeen
because splitting a diff nobody reads as a diff buys nothing, while seventeen stacked
branches cost a rebase each every time anything below them moves.

## How each example is done

One pass of the `teach` orchestration per example, in an ephemeral workspace outside the
repo; `description`, `apis` and the explainer written from that one distillation. The
orchestrator does not read the example's source before the pass. See #214 for why, and
`.claude/skills/describe-example/explain.md` for how.

## Order

The empty descriptions first, alphabetically — the only list under a test, and the one that
closes #192. `bin/description-exceptions.mjs` shrinks by one entry per example, and the
count in its header moves with it.

## Progress

Tracked on #216. This PR merges with the rest of stack #205, at the end, after the trim.
